### PR TITLE
Fix for SwitchDetailModeController::handleRequest warning

### DIFF
--- a/modules/exif/SwitchDetailMode.inc
+++ b/modules/exif/SwitchDetailMode.inc
@@ -31,7 +31,7 @@ class SwitchDetailModeController extends GalleryController {
     /**
      * @see GalleryController::handleRequest
      */
-    function handleRequest() {
+    function handleRequest($form) {
 	global $gallery;
 
 	$mode = GalleryUtilities::getRequestVariables('mode');


### PR DESCRIPTION
Fix PHP7 warning in exif module related to
`SwitchDetailModeController::handleRequest()` not having the `$form` arg
that the base `GalleryController` method takes.

Warning example:

> Declaration of SwitchDetailModeController::handleRequest() should be compatible with GalleryController::handleRequest($form) in .../modules/exif/SwitchDetailMode.inc on line 0

To reproduce: Go to image page, click the camera icon above the image, and toggle between "Summary" and "Details".
