### PR TITLE
Fix for GalleryLinkItem::create warning

### DIFF
--- a/modules/linkitem/classes/GalleryLinkItem.class
+++ b/modules/linkitem/classes/GalleryLinkItem.class
@@ -60,9 +60,10 @@ class GalleryLinkItem extends GalleryItem {
      *
      * @param int $parentId the id of the parent object
      * @param mixed $link the link target: either string url or int id of a GalleryAlbumItem
+     * @param boolean $canContainChildren ignored (for compatibility with base class)
      * @return GalleryStatus a status code
      */
-    function create($parentId, $link) {
+    function create($parentId=null, $link=null, $canContainChildren=false) {
 	if (!isset($parentId) || empty($link)) {
 	    return GalleryCoreApi::error(ERROR_BAD_PARAMETER);
 	}


### PR DESCRIPTION
Fix PHP7 warning in link item module related to
`GalleryLinkItem::create()` not having `$canContainChildren` arg that the
base `GalleryItem` method takes.

Warning example:

> Declaration of GalleryLinkItem::create($parentId, $link) should be compatible with GalleryItem::create($parentId = NULL, $path = NULL, $canContainChildren = false) in .../modules/linkitem/classes/GalleryLinkItem.class on line 0

Not 100% sure how to reproduce.  I get it on a certain page that has a URL like `/main.php?g2_itemId=73269`