### PR TITLE
use static call syntax fixes #18

### DIFF
--- a/modules/core/PluginCallback.inc
+++ b/modules/core/PluginCallback.inc
@@ -359,7 +359,7 @@ class PluginCallbackView extends GalleryView {
 		}
 
 		list ($ret, $states[$type][$pluginId]) =
-		    $this->getPluginState($type, $plugin, $status);
+		    PluginCallbackView::getPluginState($type, $plugin, $status);
 		if ($ret) {
 		    return array($ret, null);
 		}


### PR DESCRIPTION
Use static call syntax in PluginCallbackView, thanks @starlilyth!