### PR TITLE
remove curly braces

### DIFF
--- a/modules/core/classes/GalleryUrlGenerator.class
+++ b/modules/core/classes/GalleryUrlGenerator.class
@@ -150,7 +150,7 @@ class GalleryUrlGenerator {
 	} else {
 	    if ($path = GalleryUtilities::getServerVar('REQUEST_URI')) {
 		/* Sometimes, REQUEST_URI has a host part. Remove it. */
-		if ($path{0} != '/') {
+		if ($path[0] != '/') {
 		    $components = parse_url($path);
 		    $path = $components['path'];
 		    $path .= empty($components['query']) ? '' : '?' . $components['query'];
@@ -414,7 +414,7 @@ class GalleryUrlGenerator {
     function makeUrl($path, $forceDirect=false) {
 	if (empty($path)) {
 	    $path = '/';
-	} else if ($path{0} != '/') {
+	} else if ($path[0] != '/') {
 	    $path = '/' . $path;
 	}
 


### PR DESCRIPTION
Got the following warnings in my error log with PHP 7.4:
```
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in [path]/modules/core/classes/GalleryUrlGenerator.class on line 153
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in [path]/modules/core/classes/GalleryUrlGenerator.class on line 417
```

The patch changes the curly brace syntax to the standard syntax.