### PR TITLE
removing all magic_quotes calls, which are deprecated as of PHP7

### DIFF
--- a/init.inc
+++ b/init.inc
@@ -29,8 +29,6 @@ require_once(dirname(__FILE__) . '/modules/core/classes/GalleryUtilities.class')
 function GalleryInitFirstPass($params=array()) {
     global $gallery;
 
-    ini_set('magic_quotes_runtime', 0);
-    ini_set('magic_quotes_sybase', 0);
     if (function_exists('date_default_timezone_set')) {
 	/* PHP 5.3 requires a default be set before using any date/time functions */
 	@date_default_timezone_set(date_default_timezone_get());

--- a/install/InstallStep.class
+++ b/install/InstallStep.class
@@ -89,9 +89,6 @@ class InstallStep {
     }
 
     function sanitize($string) {
-	if (get_magic_quotes_gpc()) {
-	    $string = stripslashes($string);
-	}
 	return $string;
     }
 

--- a/install/index.php
+++ b/install/index.php
@@ -37,12 +37,6 @@
 /* Show all errors. */
 @ini_set('display_errors', 1);
 
-/*
- * Disable magic_quotes runtime -- it causes problems with legitimate quotes
- * in our SQL, as well as reading/writing the config.php
- */
-@ini_set('magic_quotes_runtime', 0);
-
 $g2Base = dirname(dirname(__FILE__)) . '/';
 require_once($g2Base . 'install/GalleryStub.class');
 require_once($g2Base . 'install/InstallStep.class');
@@ -176,10 +170,6 @@ if ($currentStep->processRequest()) {
 
 function processAutoCompleteRequest() {
     $path = !empty($_GET['path']) ? $_GET['path'] : '';
-    /* Undo the damage caused by magic_quotes */
-    if (get_magic_quotes_gpc()) {
-	$path = stripslashes($path);
-    }
 
     if (is_dir($path)) {
 	$match = '';

--- a/lib/adodb/adodb-perf.inc.php
+++ b/lib/adodb/adodb-perf.inc.php
@@ -678,12 +678,6 @@ Committed_AS:   348732 kB
 	}
 	$this->conn->LogSQL($savelog);
 	
-	// magic quotes
-	
-	if (isset($_GET['sql']) && get_magic_quotes_gpc()) {
-		$_GET['sql'] = $_GET['sql'] = str_replace(array("\\'",'\"'),array("'",'"'),$_GET['sql']);
-	}
-	
 	if (!isset($_SESSION['ADODB_PERF_SQL'])) $nsql = $_SESSION['ADODB_PERF_SQL'] = 10;
 	else  $nsql = $_SESSION['ADODB_PERF_SQL'];
 	
@@ -988,12 +982,6 @@ Committed_AS:   348732 kB
 	
 	function undomq($m) 
 	{
-	if (get_magic_quotes_gpc()) {
-		// undo the damage
-		$m = str_replace('\\\\','\\',$m);
-		$m = str_replace('\"','"',$m);
-		$m = str_replace('\\\'','\'',$m);
-	}
 	return $m;
 }
 

--- a/lib/adodb/adodb.inc.php
+++ b/lib/adodb/adodb.inc.php
@@ -565,7 +565,7 @@
 	*/
 	function QMagic($s)
 	{
-		return $this->qstr($s,get_magic_quotes_gpc());
+		return $this->qstr($s,false);
 	}
 
 	function q(&$s)
@@ -1759,9 +1759,6 @@
 		if (!$rs) {
 		// no cached rs found
 			if ($this->debug) {
-				if (get_magic_quotes_runtime() && !$this->memCache) {
-					ADOConnection::outp("Please disable magic_quotes_runtime - it corrupts cache files :(");
-				}
 				if ($this->debug !== -1) ADOConnection::outp( " $md5file cache failure: $err (see sql below)");
 			}
 			

--- a/lib/pear/mime.php
+++ b/lib/pear/mime.php
@@ -313,13 +313,7 @@ class Mail_mime
         if ($filesize == 0){
             $cont =  "";
         }else{
-            if ($magic_quote_setting = get_magic_quotes_runtime()){
-                @set_magic_quotes_runtime(0);
-            }
             $cont = fread($fd, $filesize);
-            if ($magic_quote_setting){
-                @set_magic_quotes_runtime($magic_quote_setting);
-            }
         }
         fclose($fd);
         return $cont;

--- a/modules/core/classes/Gallery.class
+++ b/modules/core/classes/Gallery.class
@@ -874,7 +874,6 @@ class Gallery {
 	    header('Content-length: ' . $contentLength);
 	    header('Expires: ' . $this->getHttpDate(2147483647));
 	    header('Cache-Control: public');
-	    if (get_magic_quotes_runtime()) @set_magic_quotes_runtime(0);/* deprecated in PHP5.3 */
 	    set_time_limit(0);
 	    while (!feof($fd)) {
 		print fread($fd, 4096);

--- a/modules/core/classes/GalleryPhpVm.class
+++ b/modules/core/classes/GalleryPhpVm.class
@@ -155,15 +155,6 @@ class GalleryPhpVm {
     }
 
     /**
-     * Gets the current configuration setting of magic quotes gpc
-     *
-     * @return integer 0 for off, 1 for on
-     */
-    function get_magic_quotes_gpc() {
-	return get_magic_quotes_gpc();
-    }
-
-    /**
      * Get configuration parameter
      *
      * @param string $varname

--- a/modules/core/classes/GalleryUtilities.class
+++ b/modules/core/classes/GalleryUtilities.class
@@ -733,13 +733,6 @@ class GalleryUtilities {
 	    /* Unsanitize dangerous html entities */
 	    /* bugs.php.net/bug.php?id=22014 - TODO: remove empty check when min php is 4.3.2+ */
 	    $value = empty($value) ? $value : html_entity_decode($value);
-
-	    /* Redo the damage caused by magic_quotes */
-	    if ($adaptForMagicQuotes) {
-		if (get_magic_quotes_gpc()) {
-		    $value = addslashes($value);
-		}
-	    }
 	}
     }
 
@@ -1589,12 +1582,6 @@ class GalleryUtilities {
 	}
 	/* Urldecode value */
 	$val = trim(urldecode($val));
-	/* Add slashes if magic_quotes_gpc is on */
-	$phpVm = $gallery->getPhpVm();
-	if ($phpVm->get_magic_quotes_gpc()) {
-	    $key = addslashes($key);
-	    $val = addslashes($val);
-	}
 	if (!isset($fixedCookies[$key])) {
 	    $_COOKIE[$key] = $val;
 	    $fixedCookies[$key] = true;

--- a/modules/fotokasten/lib/nusoap.inc
+++ b/modules/fotokasten/lib/nusoap.inc
@@ -1340,7 +1340,6 @@ class soap_transport_http extends nusoap_base {
 		if($this->encoding != '' && function_exists('gzdeflate')){
 			$encoding_headers = "Accept-Encoding: $this->encoding\r\n".
 			"Connection: close\r\n";
-			@set_magic_quotes_runtime(0);
 		} else {
 			$encoding_headers = '';
 		}
@@ -1508,7 +1507,6 @@ class soap_transport_http extends nusoap_base {
 			if(function_exists('gzdeflate')){
 				$encoding_headers = "Accept-Encoding: $this->encoding\r\n".
 				"Connection: close\r\n";
-				@set_magic_quotes_runtime(0);
 			}
 		}
 		

--- a/modules/getid3/lib/getid3/getid3.inc
+++ b/modules/getid3/lib/getid3/getid3.inc
@@ -189,15 +189,6 @@ class getID3
 	    	return $this->error($errormessage);
 		}
 
-		// Disable magic_quotes_runtime, if neccesary
-		$old_magic_quotes_runtime = get_magic_quotes_runtime(); // store current setting of magic_quotes_runtime
-		if ($old_magic_quotes_runtime) {
-			@set_magic_quotes_runtime(0);                        // turn off magic_quotes_runtime
-			if (get_magic_quotes_runtime()) {
-				return $this->error('Could not disable magic_quotes_runtime - getID3() cannot work properly with this setting enabled');
-			}
-		}
-
 		// remote files not supported
 		if (preg_match('/^(ht|f)tp:\/\//', $filename)) {
 			return $this->error('Remote files are not supported in this version of getID3() - please copy the file locally first');
@@ -388,9 +379,6 @@ class getID3
 
 		// remove undesired keys
 		$this->CleanUp();
-
-		// restore magic_quotes_runtime setting
-		@set_magic_quotes_runtime($old_magic_quotes_runtime);
 
 		// return info array
 		return $this->info;

--- a/modules/getid3/lib/getid3/getid3.lib.inc
+++ b/modules/getid3/lib/getid3/getid3.lib.inc
@@ -33,9 +33,6 @@ class getid3_lib
 	}
 
 	function SafeStripSlashes($text) {
-		if (get_magic_quotes_gpc()) {
-			return stripslashes($text);
-		}
 		return $text;
 	}
 

--- a/modules/webdav/lib/HTTP/WebDAV/Server.php
+++ b/modules/webdav/lib/HTTP/WebDAV/Server.php
@@ -130,10 +130,6 @@ class HTTP_WebDAV_Server
             $this->path = trim($this->path, '/');
         }
 
-        if (ini_get('magic_quotes_gpc')) {
-            $this->path = stripslashes($this->path);
-        }
-
         // set base URL
         if (empty($this->baseUrl)) {
             $this->baseUrl = parse_url(

--- a/upgrade/UpgradeStep.class
+++ b/upgrade/UpgradeStep.class
@@ -89,9 +89,6 @@ class UpgradeStep {
     }
 
     function sanitize($string) {
-	if (get_magic_quotes_gpc()) {
-	    $string = stripslashes($string);
-	}
 	return $string;
     }
 

--- a/upgrade/index.php
+++ b/upgrade/index.php
@@ -37,12 +37,6 @@
 /* Show all errors. */
 @ini_set('display_errors', 1);
 
-/*
- * Disable magic_quotes runtime -- it causes problems with legitimate quotes
- * in our SQL, as well as reading/writing the config.php
- */
-@ini_set('magic_quotes_runtime', 0);
-
 $g2Base = dirname(dirname(__FILE__)) . '/';
 require_once($g2Base . 'upgrade/UpgradeStep.class');
 require_once($g2Base . 'upgrade/StatusTemplate.class');


### PR DESCRIPTION
As noted in #21, all the `magic_quotes` calls no longer do anything and will be removed from PHP soon, so remove them in the source. (thanks @hannob!)