### PR TITLE
PHP 8 support (closes #23)

### DIFF
--- a/init.inc
+++ b/init.inc
@@ -79,7 +79,7 @@ function GalleryInitFirstPass($params=array()) {
 
     /* Sanitize the data path */
     $dataBase = $gallery->getConfig('data.gallery.base');
-    if ($dataBase{strlen($dataBase) - 1} != $slash) {
+    if ($dataBase[strlen($dataBase) - 1] != $slash) {
 	$dataBase .= $slash;
 	$gallery->setConfig('data.gallery.base', $dataBase);
     }

--- a/install/index.php
+++ b/install/index.php
@@ -184,7 +184,7 @@ function processAutoCompleteRequest() {
 
     $dirList = array();
     if ($dir = opendir($path)) {
-	if ($path{strlen($path)-1} != DIRECTORY_SEPARATOR) {
+	if ($path[strlen($path)-1] != DIRECTORY_SEPARATOR) {
 	    $path .= DIRECTORY_SEPARATOR;
 	}
 	while (($file = readdir($dir)) !== false) {
@@ -215,7 +215,7 @@ function populateDataDirectory($dataBase) {
     /* Use non-restrictive umask to create directories with lax permissions */
     umask(0);
 
-    if ($dataBase{strlen($dataBase)-1} != DIRECTORY_SEPARATOR) {
+    if ($dataBase[strlen($dataBase)-1] != DIRECTORY_SEPARATOR) {
 	$dataBase .= DIRECTORY_SEPARATOR;
     }
 

--- a/install/steps/AuthenticateStep.class
+++ b/install/steps/AuthenticateStep.class
@@ -28,7 +28,7 @@ class AuthenticateStep extends InstallStep {
     var $_uniqueKey;
     var $_firstTime;
 
-    function AuthenticateStep() {
+    function __construct() {
 	$this->_uniqueKey = GallerySetupUtilities::generateAuthenticationKey();
 	$this->_firstTime = true;
     }

--- a/install/steps/CreateConfigFileStep.class
+++ b/install/steps/CreateConfigFileStep.class
@@ -25,7 +25,7 @@
 class CreateConfigFileStep extends InstallStep {
     var $_firstTime;
 
-    function CreateConfigFileStep() {
+    function __construct() {
 	$this->_firstTime = true;
     }
 

--- a/install/steps/DatabaseSetupStep.class
+++ b/install/steps/DatabaseSetupStep.class
@@ -609,7 +609,7 @@ class DatabaseSetupStep extends InstallStep {
 	     * all cases
 	     */
 	    $configPath = $galleryStub->getConfig('data.gallery.base');
-	    if ($configPath{strlen($configPath)-1} != DIRECTORY_SEPARATOR) {
+	    if ($configPath[strlen($configPath)-1] != DIRECTORY_SEPARATOR) {
 		$configPath .=  DIRECTORY_SEPARATOR;
 	    }
 	    $GLOBALS['gallery']->setConfig('data.gallery.base', $configPath);
@@ -676,7 +676,7 @@ class DatabaseSetupStep extends InstallStep {
 	$baseDir = $gallery->getConfig('data.gallery.base');
 	$platform =& $gallery->getPlatform();
 
-	if ($baseDir{strlen($baseDir)-1} != $platform->getDirectorySeparator()) {
+	if ($baseDir[strlen($baseDir)-1] != $platform->getDirectorySeparator()) {
 	    $baseDir .= $platform->getDirectorySeparator();
 	}
 

--- a/install/steps/SecureStep.class
+++ b/install/steps/SecureStep.class
@@ -46,9 +46,9 @@ class SecureStep extends InstallStep {
 		$templateData['configFilePath'] = realpath($configFilePath);
 		$templateData['file']['mode'] = $fileMode;
 		$templateData['file']['secure'] =
-			!((int)$fileMode{1} & 2 || (int)$fileMode{2} & 2);
+			!((int)$fileMode[1] & 2 || (int)$fileMode[2] & 2);
 		$templateData['dir']['mode'] = $dirMode;
-		$templateData['dir']['secure'] = !((int)$dirMode{1} & 2 || (int)$dirMode{2} & 2);
+		$templateData['dir']['secure'] = !((int)$dirMode[1] & 2 || (int)$dirMode[2] & 2);
 		$templateData['secure'] =
 			$templateData['file']['secure'] && $templateData['dir']['secure'];
 	    }

--- a/install/steps/SystemChecksStep.class
+++ b/install/steps/SystemChecksStep.class
@@ -33,7 +33,7 @@ class SystemChecksStep extends InstallStep {
      */
     function _getBytes($val) {
 	$val = trim($val);
-	$last = $val{strlen($val)-1};
+	$last = $val[strlen($val)-1];
 	switch ($last) {
 	case 'g':
 	case 'G':

--- a/lib/JSON/JSON.php
+++ b/lib/JSON/JSON.php
@@ -261,7 +261,7 @@ class Services_JSON
                 */
                 for ($c = 0; $c < $strlen_var; ++$c) {
 
-                    $ord_var_c = ord($var{$c});
+                    $ord_var_c = ord($var[$c]);
 
                     switch (true) {
                         case $ord_var_c == 0x08:
@@ -284,18 +284,18 @@ class Services_JSON
                         case $ord_var_c == 0x2F:
                         case $ord_var_c == 0x5C:
                             // double quote, slash, slosh
-                            $ascii .= '\\'.$var{$c};
+                            $ascii .= '\\'.$var[$c];
                             break;
 
                         case (($ord_var_c >= 0x20) && ($ord_var_c <= 0x7F)):
                             // characters U-00000000 - U-0000007F (same as ASCII)
-                            $ascii .= $var{$c};
+                            $ascii .= $var[$c];
                             break;
 
                         case (($ord_var_c & 0xE0) == 0xC0):
                             // characters U-00000080 - U-000007FF, mask 110XXXXX
                             // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                            $char = pack('C*', $ord_var_c, ord($var{$c + 1}));
+                            $char = pack('C*', $ord_var_c, ord($var[$c + 1]));
                             $c += 1;
                             $utf16 = $this->utf82utf16($char);
                             $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -305,8 +305,8 @@ class Services_JSON
                             // characters U-00000800 - U-0000FFFF, mask 1110XXXX
                             // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
                             $char = pack('C*', $ord_var_c,
-                                         ord($var{$c + 1}),
-                                         ord($var{$c + 2}));
+                                         ord($var[$c + 1]),
+                                         ord($var[$c + 2]));
                             $c += 2;
                             $utf16 = $this->utf82utf16($char);
                             $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -316,9 +316,9 @@ class Services_JSON
                             // characters U-00010000 - U-001FFFFF, mask 11110XXX
                             // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
                             $char = pack('C*', $ord_var_c,
-                                         ord($var{$c + 1}),
-                                         ord($var{$c + 2}),
-                                         ord($var{$c + 3}));
+                                         ord($var[$c + 1]),
+                                         ord($var[$c + 2]),
+                                         ord($var[$c + 3]));
                             $c += 3;
                             $utf16 = $this->utf82utf16($char);
                             $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -328,10 +328,10 @@ class Services_JSON
                             // characters U-00200000 - U-03FFFFFF, mask 111110XX
                             // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
                             $char = pack('C*', $ord_var_c,
-                                         ord($var{$c + 1}),
-                                         ord($var{$c + 2}),
-                                         ord($var{$c + 3}),
-                                         ord($var{$c + 4}));
+                                         ord($var[$c + 1]),
+                                         ord($var[$c + 2]),
+                                         ord($var[$c + 3]),
+                                         ord($var[$c + 4]));
                             $c += 4;
                             $utf16 = $this->utf82utf16($char);
                             $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -341,11 +341,11 @@ class Services_JSON
                             // characters U-04000000 - U-7FFFFFFF, mask 1111110X
                             // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
                             $char = pack('C*', $ord_var_c,
-                                         ord($var{$c + 1}),
-                                         ord($var{$c + 2}),
-                                         ord($var{$c + 3}),
-                                         ord($var{$c + 4}),
-                                         ord($var{$c + 5}));
+                                         ord($var[$c + 1]),
+                                         ord($var[$c + 2]),
+                                         ord($var[$c + 3]),
+                                         ord($var[$c + 4]),
+                                         ord($var[$c + 5]));
                             $c += 5;
                             $utf16 = $this->utf82utf16($char);
                             $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -520,7 +520,7 @@ class Services_JSON
                     for ($c = 0; $c < $strlen_chrs; ++$c) {
 
                         $substr_chrs_c_2 = substr($chrs, $c, 2);
-                        $ord_chrs_c = ord($chrs{$c});
+                        $ord_chrs_c = ord($chrs[$c]);
 
                         switch (true) {
                             case $substr_chrs_c_2 == '\b':
@@ -550,7 +550,7 @@ class Services_JSON
                             case $substr_chrs_c_2 == '\\/':
                                 if (($delim == '"' && $substr_chrs_c_2 != '\\\'') ||
                                    ($delim == "'" && $substr_chrs_c_2 != '\\"')) {
-                                    $utf8 .= $chrs{++$c};
+                                    $utf8 .= $chrs[++$c];
                                 }
                                 break;
 
@@ -563,7 +563,7 @@ class Services_JSON
                                 break;
 
                             case ($ord_chrs_c >= 0x20) && ($ord_chrs_c <= 0x7F):
-                                $utf8 .= $chrs{$c};
+                                $utf8 .= $chrs[$c];
                                 break;
 
                             case ($ord_chrs_c & 0xE0) == 0xC0:
@@ -610,7 +610,7 @@ class Services_JSON
                 } elseif (preg_match('/^\[.*\]$/s', $str) || preg_match('/^\{.*\}$/s', $str)) {
                     // array, or object notation
 
-                    if ($str{0} == '[') {
+                    if ($str[0] == '[') {
                         $stk = array(SERVICES_JSON_IN_ARR);
                         $arr = array();
                     } else {
@@ -649,7 +649,7 @@ class Services_JSON
                         $top = end($stk);
                         $substr_chrs_c_2 = substr($chrs, $c, 2);
 
-                        if (($c == $strlen_chrs) || (($chrs{$c} == ',') && ($top['what'] == SERVICES_JSON_SLICE))) {
+                        if (($c == $strlen_chrs) || (($chrs[$c] == ',') && ($top['what'] == SERVICES_JSON_SLICE))) {
                             // found a comma that is not inside a string, array, etc.,
                             // OR we've reached the end of the character list
                             $slice = substr($chrs, $top['where'], ($c - $top['where']));
@@ -691,37 +691,37 @@ class Services_JSON
 
                             }
 
-                        } elseif ((($chrs{$c} == '"') || ($chrs{$c} == "'")) && ($top['what'] != SERVICES_JSON_IN_STR)) {
+                        } elseif ((($chrs[$c] == '"') || ($chrs[$c] == "'")) && ($top['what'] != SERVICES_JSON_IN_STR)) {
                             // found a quote, and we are not inside a string
-                            array_push($stk, array('what' => SERVICES_JSON_IN_STR, 'where' => $c, 'delim' => $chrs{$c}));
+                            array_push($stk, array('what' => SERVICES_JSON_IN_STR, 'where' => $c, 'delim' => $chrs[$c]));
                             //print("Found start of string at {$c}\n");
 
-                        } elseif (($chrs{$c} == $top['delim']) &&
+                        } elseif (($chrs[$c] == $top['delim']) &&
                                  ($top['what'] == SERVICES_JSON_IN_STR) &&
-                                 (($chrs{$c - 1} != '\\') ||
-                                 ($chrs{$c - 1} == '\\' && $chrs{$c - 2} == '\\'))) {
+                                 (($chrs[$c - 1] != '\\') ||
+                                 ($chrs[$c - 1] == '\\' && $chrs[$c - 2] == '\\'))) {
                             // found a quote, we're in a string, and it's not escaped
                             array_pop($stk);
                             //print("Found end of string at {$c}: ".substr($chrs, $top['where'], (1 + 1 + $c - $top['where']))."\n");
 
-                        } elseif (($chrs{$c} == '[') &&
+                        } elseif (($chrs[$c] == '[') &&
                                  in_array($top['what'], array(SERVICES_JSON_SLICE, SERVICES_JSON_IN_ARR, SERVICES_JSON_IN_OBJ))) {
                             // found a left-bracket, and we are in an array, object, or slice
                             array_push($stk, array('what' => SERVICES_JSON_IN_ARR, 'where' => $c, 'delim' => false));
                             //print("Found start of array at {$c}\n");
 
-                        } elseif (($chrs{$c} == ']') && ($top['what'] == SERVICES_JSON_IN_ARR)) {
+                        } elseif (($chrs[$c] == ']') && ($top['what'] == SERVICES_JSON_IN_ARR)) {
                             // found a right-bracket, and we're in an array
                             array_pop($stk);
                             //print("Found end of array at {$c}: ".substr($chrs, $top['where'], (1 + $c - $top['where']))."\n");
 
-                        } elseif (($chrs{$c} == '{') &&
+                        } elseif (($chrs[$c] == '{') &&
                                  in_array($top['what'], array(SERVICES_JSON_SLICE, SERVICES_JSON_IN_ARR, SERVICES_JSON_IN_OBJ))) {
                             // found a left-brace, and we are in an array, object, or slice
                             array_push($stk, array('what' => SERVICES_JSON_IN_OBJ, 'where' => $c, 'delim' => false));
                             //print("Found start of object at {$c}\n");
 
-                        } elseif (($chrs{$c} == '}') && ($top['what'] == SERVICES_JSON_IN_OBJ)) {
+                        } elseif (($chrs[$c] == '}') && ($top['what'] == SERVICES_JSON_IN_OBJ)) {
                             // found a right-brace, and we're in an object
                             array_pop($stk);
                             //print("Found end of object at {$c}: ".substr($chrs, $top['where'], (1 + $c - $top['where']))."\n");

--- a/lib/adodb/adodb-iterator.inc.php
+++ b/lib/adodb/adodb-iterator.inc.php
@@ -69,7 +69,7 @@
 
 
 class ADODB_BASE_RS implements IteratorAggregate {
-    function getIterator() {
+    function getIterator() : Traversable {
         return new ADODB_Iterator($this);
     }
 	

--- a/lib/adodb/adodb-iterator.inc.php
+++ b/lib/adodb/adodb-iterator.inc.php
@@ -29,27 +29,27 @@
 	{
         $this->rs = $rs;
     }
-    function rewind() 
+    function rewind() : void
 	{
         $this->rs->MoveFirst();
     }
 
-	function valid() 
+	function valid() : bool
 	{
         return !$this->rs->EOF;
     }
 	
-    function key() 
+    function key() : mixed
 	{
         return $this->rs->_currentRow;
     }
 	
-    function current() 
+    function current() : mixed
 	{
         return $this->rs->fields;
     }
 	
-    function next() 
+    function next() : void
 	{
         $this->rs->MoveNext();
     }
@@ -60,7 +60,7 @@
 	}
 
 	
-	function hasMore()
+	function hasMore() : bool
 	{
 		return !$this->rs->EOF;
 	}

--- a/lib/adodb/adodb.inc.php
+++ b/lib/adodb/adodb.inc.php
@@ -842,7 +842,8 @@
 				foreach($inputarr as $arr) {
 					$sql = ''; $i = 0;
 					//Use each() instead of foreach to reduce memory usage -mikefedyk
-					while(list(, $v) = each($arr)) {
+					//while(list(, $v) = each($arr)) {
+					foreach ($arr as $unused_key => $v) {
 						$sql .= $sqlarr[$i];
 						// from Ron Baldwin <ron.baldwin#sourceprose.com>
 						// Only quote string types	

--- a/lib/adodb/drivers/adodb-ado.inc.php
+++ b/lib/adodb/drivers/adodb-ado.inc.php
@@ -37,7 +37,7 @@ class ADODB_ado extends ADOConnection {
 	var $poorAffectedRows = true; 
 	var $charPage;
 		
-	function ADODB_ado() 
+	function __construct() 
 	{ 	
 		$this->_affectedRows = new VARIANT;
 	}
@@ -325,14 +325,14 @@ class ADORecordSet_ado extends ADORecordSet {
 	var $canSeek = true;
   	var $hideErrors = true;
 		  
-	function ADORecordSet_ado($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
 		if ($mode === false) { 
 			global $ADODB_FETCH_MODE;
 			$mode = $ADODB_FETCH_MODE;
 		}
 		$this->fetchMode = $mode;
-		return $this->ADORecordSet($id,$mode);
+        parent::__construct($id,$mode);
 	}
 
 

--- a/lib/adodb/drivers/adodb-ado5.inc.php
+++ b/lib/adodb/drivers/adodb-ado5.inc.php
@@ -37,7 +37,7 @@ class ADODB_ado extends ADOConnection {
 	var $poorAffectedRows = true; 
 	var $charPage;
 		
-	function ADODB_ado() 
+	function __construct() 
 	{ 	
 		$this->_affectedRows = new VARIANT;
 	}
@@ -355,14 +355,14 @@ class ADORecordSet_ado extends ADORecordSet {
 	var $canSeek = true;
   	var $hideErrors = true;
 		  
-	function ADORecordSet_ado($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
 		if ($mode === false) { 
 			global $ADODB_FETCH_MODE;
 			$mode = $ADODB_FETCH_MODE;
 		}
 		$this->fetchMode = $mode;
-		return $this->ADORecordSet($id,$mode);
+		parent::__construct($id,$mode);
 	}
 
 

--- a/lib/adodb/drivers/adodb-ado_mssql.inc.php
+++ b/lib/adodb/drivers/adodb-ado_mssql.inc.php
@@ -39,9 +39,9 @@ class  ADODB_ado_mssql extends ADODB_ado {
 	
 	//var $_inTransaction = 1; // always open recordsets, so no transaction problems.
 	
-	function ADODB_ado_mssql()
+	function __construct()
 	{
-	        $this->ADODB_ado();
+        parent::__construct();
 	}
 	
 	function _insertid()
@@ -148,7 +148,7 @@ class  ADODB_ado_mssql extends ADODB_ado {
 	
 	function ADORecordSet_ado_mssql($id,$mode=false)
 	{
-	        return $this->ADORecordSet_ado($id,$mode);
+        parent::__construct($id,$mode);
 	}
 }
 ?>

--- a/lib/adodb/drivers/adodb-db2.inc.php
+++ b/lib/adodb/drivers/adodb-db2.inc.php
@@ -58,7 +58,7 @@ class ADODB_db2 extends ADOConnection {
         return ADOConnection::GetOne('VALUES IDENTITY_VAL_LOCAL()');
     }
 	
-	function ADODB_db2() 
+	function __construct() 
 	{ 	
 		$this->_haserrorfunctions = ADODB_PHPVER >= 0x4050;
 	}
@@ -677,7 +677,7 @@ class ADORecordSet_db2 extends ADORecordSet {
 	var $dataProvider = "db2";
 	var $useFetchArray;
 	
-	function ADORecordSet_db2($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
 		if ($mode === false) {  
 			global $ADODB_FETCH_MODE;

--- a/lib/adodb/drivers/adodb-mysql.inc.php
+++ b/lib/adodb/drivers/adodb-mysql.inc.php
@@ -40,7 +40,7 @@ class ADODB_mysql extends ADOConnection {
 	var $nameQuote = '`';		/// string to use to quote identifiers and names
 	var $compat323 = false; 		// true if compat with mysql 3.23
 	
-	function ADODB_mysql() 
+	function __construct() 
 	{			
 		if (defined('ADODB_EXTENSION')) $this->rsPrefix .= 'ext_';
 	}
@@ -604,7 +604,7 @@ class ADORecordSet_mysql extends ADORecordSet{
 	var $databaseType = "mysql";
 	var $canSeek = true;
 	
-	function ADORecordSet_mysql($queryID,$mode=false) 
+	function __construct($queryID,$mode=false) 
 	{
 		if ($mode === false) { 
 			global $ADODB_FETCH_MODE;
@@ -760,7 +760,7 @@ class ADORecordSet_mysql extends ADORecordSet{
 }
 
 class ADORecordSet_ext_mysql extends ADORecordSet_mysql {	
-	function ADORecordSet_ext_mysql($queryID,$mode=false) 
+	function __construct($queryID,$mode=false) 
 	{
 		if ($mode === false) { 
 			global $ADODB_FETCH_MODE;
@@ -776,7 +776,7 @@ class ADORecordSet_ext_mysql extends ADORecordSet_mysql {
 		$this->fetchMode = MYSQL_BOTH; break;
 		}
 		$this->adodbFetchMode = $mode;
-		$this->ADORecordSet($queryID);
+        parent::__construct($queryID);
 	}
 	
 	function MoveNext()

--- a/lib/adodb/drivers/adodb-mysqli.inc.php
+++ b/lib/adodb/drivers/adodb-mysqli.inc.php
@@ -881,7 +881,7 @@ class ADORecordSet_mysqli extends ADORecordSet{
 	{
 		if ($this->EOF) return false;
 		$this->_currentRow++;
-		$this->fields = @mysqli_fetch_array($this->_queryID,$this->fetchMode);
+		$this->fields = @mysqli_fetch_array($this->_queryID,$this->fetchMode ? $this->fetchMode : MYSQLI_BOTH);
 		
 		if (is_array($this->fields)) return true;
 		$this->EOF = true;
@@ -890,7 +890,7 @@ class ADORecordSet_mysqli extends ADORecordSet{
 	
 	function _fetch()
 	{
-		$this->fields = mysqli_fetch_array($this->_queryID,$this->fetchMode);  
+		$this->fields = mysqli_fetch_array($this->_queryID,$this->fetchMode ? $this->fetchMode : MYSQLI_BOTH);  
 	  	return is_array($this->fields);
 	}
 	

--- a/lib/adodb/drivers/adodb-mysqli.inc.php
+++ b/lib/adodb/drivers/adodb-mysqli.inc.php
@@ -52,7 +52,7 @@ class ADODB_mysqli extends ADOConnection {
 	var $optionFlags = array(array(MYSQLI_READ_DEFAULT_GROUP,0));
   var $arrayClass = 'ADORecordSet_array_mysqli';
 	
-	function ADODB_mysqli() 
+	function __construct() 
 	{			
 	 // if(!extension_loaded("mysqli"))
 	      ;//trigger_error("You must have the mysqli extension installed.", E_USER_ERROR);
@@ -765,7 +765,7 @@ class ADORecordSet_mysqli extends ADORecordSet{
 	var $databaseType = "mysqli";
 	var $canSeek = true;
 	
-	function ADORecordSet_mysqli($queryID, $mode = false) 
+	function __construct($queryID, $mode = false) 
 	{
 	  if ($mode === false) 
 	   { 
@@ -1030,9 +1030,9 @@ class ADORecordSet_mysqli extends ADORecordSet{
 }
 
 class ADORecordSet_array_mysqli extends ADORecordSet_array {
-  function ADORecordSet_array_mysqli($id=-1,$mode=false) 
+  function __construct($id=-1,$mode=false) 
   {
-    $this->ADORecordSet_array($id,$mode);
+      parent::__construct($id,$mode);
   }
   
 

--- a/lib/adodb/drivers/adodb-mysqli.inc.php
+++ b/lib/adodb/drivers/adodb-mysqli.inc.php
@@ -308,7 +308,7 @@ class ADODB_mysqli extends ADOConnection {
 	}
 
 	  
-	function &MetaIndexes ($table, $primary = FALSE)
+	function &MetaIndexes ($table, $primary = FALSE, $owner = false)
 	{
 		// save old fetch mode
 		global $ADODB_FETCH_MODE;
@@ -522,7 +522,7 @@ class ADODB_mysqli extends ADOConnection {
 	    return  $foreign_keys;
 	}
 	
- 	function &MetaColumns($table) 
+ 	function &MetaColumns($table, $normalize = true) 
 	{
 		$false = false;
 		if (!$this->metaColumnsSQL)

--- a/lib/adodb/drivers/adodb-mysqlt.inc.php
+++ b/lib/adodb/drivers/adodb-mysqlt.inc.php
@@ -25,7 +25,7 @@ class ADODB_mysqlt extends ADODB_mysql {
 	var $hasTransactions = true;
 	var $autoRollback = true; // apparently mysql does not autorollback properly 
 	
-	function ADODB_mysqlt() 
+	function __construct() 
 	{			
 	global $ADODB_EXTENSION; if ($ADODB_EXTENSION) $this->rsPrefix .= 'ext_';
 	}
@@ -89,7 +89,7 @@ class ADODB_mysqlt extends ADODB_mysql {
 class ADORecordSet_mysqlt extends ADORecordSet_mysql{	
 	var $databaseType = "mysqlt";
 	
-	function ADORecordSet_mysqlt($queryID,$mode=false) 
+	function __construct($queryID,$mode=false) 
 	{
 		if ($mode === false) { 
 			global $ADODB_FETCH_MODE;
@@ -126,7 +126,7 @@ class ADORecordSet_mysqlt extends ADORecordSet_mysql{
 
 class ADORecordSet_ext_mysqlt extends ADORecordSet_mysqlt {	
 
-	function ADORecordSet_ext_mysqlt($queryID,$mode=false) 
+	function __construct($queryID,$mode=false) 
 	{
 		if ($mode === false) { 
 			global $ADODB_FETCH_MODE;
@@ -143,7 +143,7 @@ class ADORecordSet_ext_mysqlt extends ADORecordSet_mysqlt {
 			$this->fetchMode = MYSQL_BOTH; break;
 		}
 		$this->adodbFetchMode = $mode;
-		$this->ADORecordSet($queryID);	
+        parent::__construct($queryID);
 	}
 	
 	function MoveNext()

--- a/lib/adodb/drivers/adodb-oci8.inc.php
+++ b/lib/adodb/drivers/adodb-oci8.inc.php
@@ -90,7 +90,7 @@ class ADODB_oci8 extends ADOConnection {
 	
 	// var $ansiOuter = true; // if oracle9
     
-	function ADODB_oci8() 
+	function __construct() 
 	{
 		$this->_hasOCIFetchStatement = ADODB_PHPVER >= 0x4200;
 		if (defined('ADODB_EXTENSION')) $this->rsPrefix .= 'ext_';
@@ -1255,7 +1255,7 @@ class ADORecordset_oci8 extends ADORecordSet {
 	
 	//var $_arr = false;
 		
-	function ADORecordset_oci8($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
 		if ($mode === false) { 
 			global $ADODB_FETCH_MODE;
@@ -1526,7 +1526,7 @@ class ADORecordset_oci8 extends ADORecordSet {
 }
 
 class ADORecordSet_ext_oci8 extends ADORecordSet_oci8 {	
-	function ADORecordSet_ext_oci8($queryID,$mode=false) 
+	function __construct($queryID,$mode=false) 
 	{
 		if ($mode === false) { 
 			global $ADODB_FETCH_MODE;

--- a/lib/adodb/drivers/adodb-oci805.inc.php
+++ b/lib/adodb/drivers/adodb-oci805.inc.php
@@ -21,9 +21,9 @@ class ADODB_oci805 extends ADODB_oci8 {
 	var $databaseType = "oci805";	
 	var $connectSID = true;
 	
-	function ADODB_oci805() 
+	function __construct() 
 	{
-		$this->ADODB_oci8();
+        parent::__construct();
 	}
 	
 	function &SelectLimit($sql,$nrows=-1,$offset=-1, $inputarr=false,$secs2cache=0)
@@ -51,9 +51,9 @@ class ADODB_oci805 extends ADODB_oci8 {
 
 class ADORecordset_oci805 extends ADORecordset_oci8 {	
 	var $databaseType = "oci805";
-	function ADORecordset_oci805($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		$this->ADORecordset_oci8($id,$mode);
+        parent::__construct($id,$mode);
 	}
 }
 ?>

--- a/lib/adodb/drivers/adodb-oci8po.inc.php
+++ b/lib/adodb/drivers/adodb-oci8po.inc.php
@@ -28,7 +28,7 @@ class ADODB_oci8po extends ADODB_oci8 {
 	var $metaColumnsSQL = "select lower(cname),coltype,width, SCALE, PRECISION, NULLS, DEFAULTVAL from col where tname='%s' order by colno"; //changed by smondino@users.sourceforge. net
 	var $metaTablesSQL = "select lower(table_name),table_type from cat where table_type in ('TABLE','VIEW')";
 	
-	function ADODB_oci8po()
+	function __construct()
 	{
 		$this->_hasOCIFetchStatement = ADODB_PHPVER >= 0x4200;
 		# oci8po does not support adodb extension: adodb_movenext()
@@ -78,9 +78,9 @@ class ADORecordset_oci8po extends ADORecordset_oci8 {
 
 	var $databaseType = 'oci8po';
 	
-	function ADORecordset_oci8po($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
-		$this->ADORecordset_oci8($queryID,$mode);
+        parent::_construct($queryID,$mode);
 	}
 
 	function Fields($colname)

--- a/lib/adodb/drivers/adodb-oracle.inc.php
+++ b/lib/adodb/drivers/adodb-oracle.inc.php
@@ -27,7 +27,7 @@ class ADODB_oracle extends ADOConnection {
 	var $sysTimeStamp = 'SYSDATE';
 	var $connectSID = true;
 	
-	function ADODB_oracle() 
+	function __construct() 
 	{
 	}
 
@@ -215,7 +215,7 @@ class ADORecordset_oracle extends ADORecordSet {
 	var $databaseType = "oracle";
 	var $bind = false;
 
-	function ADORecordset_oracle($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
 		
 		if ($mode === false) { 

--- a/lib/adodb/drivers/adodb-pdo.inc.php
+++ b/lib/adodb/drivers/adodb-pdo.inc.php
@@ -81,7 +81,7 @@ class ADODB_pdo extends ADOConnection {
 	var $dsnType = '';
 	var $stmt = false;
 
-        function ADODB_pdo() {
+        function __construct() {
 	}
 
 	
@@ -316,7 +316,7 @@ class ADOPDOStatement {
 	var $_stmt;
 	var $_connectionID;
 	
-	function ADOPDOStatement($stmt,$connection)
+	function __construct($stmt,$connection)
 	{
 		$this->_stmt = $stmt;
 		$this->_connectionID = $connection;
@@ -371,7 +371,7 @@ class ADORecordSet_pdo extends ADORecordSet {
 	var $databaseType = "pdo";		
 	var $dataProvider = "pdo";
 	
-	function ADORecordSet_pdo($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
 		if ($mode === false) {  
 			global $ADODB_FETCH_MODE;

--- a/lib/adodb/drivers/adodb-postgres64.inc.php
+++ b/lib/adodb/drivers/adodb-postgres64.inc.php
@@ -116,7 +116,7 @@ WHERE relkind in ('r','v') AND (c.relname='%s' or c.relname = lower('%s'))
 	// to know what the concequences are. The other values are correct (wheren't in 0.94)
 	// -- Freek Dijkstra 
 
-	function ADODB_postgres64() 
+	function __construct() 
 	{
 	// changes the metaColumnsSQL, adds columns: attnum[6]
 	}
@@ -867,7 +867,7 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 	var $_blobArr;
 	var $databaseType = "postgres64";
 	var $canSeek = true;
-	function ADORecordSet_postgres64($queryID,$mode=false) 
+	function __construct($queryID,$mode=false) 
 	{
 		if ($mode === false) { 
 			global $ADODB_FETCH_MODE;

--- a/lib/adodb/drivers/adodb-postgres7.inc.php
+++ b/lib/adodb/drivers/adodb-postgres7.inc.php
@@ -22,9 +22,9 @@ class ADODB_postgres7 extends ADODB_postgres64 {
 	var $ansiOuter = true;
 	var $charSet = true; //set to true for Postgres 7 and above - PG client supports encodings
 	
-	function ADODB_postgres7() 
+	function __construct() 
 	{
-		$this->ADODB_postgres64();
+        parent::__construct();
 		if (ADODB_ASSOC_CASE !== 2) {
 			$this->rsPrefix .= 'assoc_';
 		}
@@ -167,9 +167,9 @@ class ADORecordSet_postgres7 extends ADORecordSet_postgres64{
 	var $databaseType = "postgres7";
 	
 	
-	function ADORecordSet_postgres7($queryID,$mode=false) 
+	function __construct($queryID,$mode=false) 
 	{
-		$this->ADORecordSet_postgres64($queryID,$mode);
+        parent::__construct($queryID,$mode);
 	}
 	
 	 	// 10% speedup to move MoveNext to child class
@@ -198,9 +198,9 @@ class ADORecordSet_assoc_postgres7 extends ADORecordSet_postgres64{
 	var $databaseType = "postgres7";
 	
 	
-	function ADORecordSet_assoc_postgres7($queryID,$mode=false) 
+	function __construct($queryID,$mode=false) 
 	{
-		$this->ADORecordSet_postgres64($queryID,$mode);
+        parent::__construct($queryID,$mode);
 	}
 	
 	function _fetch()

--- a/lib/bbcode/stringparser.class.php
+++ b/lib/bbcode/stringparser.class.php
@@ -459,7 +459,7 @@ class StringParser {
 		// if yes, how should this be achieved? Another member of
 		// StringParser_Node?
 		$this->_setStatus (0);
-		$res = $this->_appendText ($this->_text{$topelem->occurredAt});
+		$res = $this->_appendText ($this->_text[$topelem->occurredAt]);
 		if (!$res) {
 			return false;
 		}
@@ -568,7 +568,7 @@ class StringParser {
 				return false;
 			}
 			if (!$res) {
-				$res = $this->_appendText ($this->_text{$this->_cpos});
+				$res = $this->_appendText ($this->_text[$this->_cpos]);
 				if (!$res) {
 					return false;
 				}
@@ -611,7 +611,7 @@ class StringParser {
 			
 			if ($needle === false) {
 				// not found => see if character is allowed
-				if (!in_array ($this->_text{$this->_cpos}, $this->_charactersAllowed)) {
+				if (!in_array ($this->_text[$this->_cpos], $this->_charactersAllowed)) {
 					if ($strict) {
 						return false;
 					}
@@ -619,7 +619,7 @@ class StringParser {
 					continue;
 				}
 				// lot's of FIXMES
-				$res = $this->_appendText ($this->_text{$this->_cpos});
+				$res = $this->_appendText ($this->_text[$this->_cpos]);
 				if (!$res) {
 					return false;
 				}

--- a/lib/bbcode/stringparser.class.php
+++ b/lib/bbcode/stringparser.class.php
@@ -199,7 +199,7 @@ class StringParser {
 	 *
 	 * @access public
 	 */
-	function StringParser () {
+	function __construct () {
 	}
 	
 	/**
@@ -910,7 +910,7 @@ class StringParser_Node {
 	 *                        occurred at. If not determinable, it is -1.
 	 * @global __STRINGPARSER_NODE_ID
 	 */
-	function StringParser_Node ($occurredAt = -1) {
+	function __construct ($occurredAt = -1) {
 		$this->_id = $GLOBALS['__STRINGPARSER_NODE_ID']++;
 		$this->occurredAt = $occurredAt;
 	}
@@ -1486,8 +1486,8 @@ class StringParser_Node_Text extends StringParser_Node {
 	 *                        occurred at. If not determinable, it is -1.
 	 * @see StringParser_Node_Text::content
 	 */
-	function StringParser_Node_Text ($content, $occurredAt = -1) {
-		parent::StringParser_Node ($occurredAt);
+	function __construct ($content, $occurredAt = -1) {
+		parent::__construct ($occurredAt);
 		$this->content = $content;
 	}
 	

--- a/lib/bbcode/stringparser_bbcode.class.php
+++ b/lib/bbcode/stringparser_bbcode.class.php
@@ -1053,12 +1053,12 @@ class StringParser_BBCode extends StringParser {
 			$ol = strlen ($output);
 			switch ($node->getFlag ('newlinemode.begin', 'integer', BBCODE_NEWLINE_PARSE)) {
 			case BBCODE_NEWLINE_IGNORE:
-				if ($ol && $output{0} == "\n") {
+				if ($ol && $output[0] == "\n") {
 					$before = "\n";
 				}
 				// don't break!
 			case BBCODE_NEWLINE_DROP:
-				if ($ol && $output{0} == "\n") {
+				if ($ol && $output[0] == "\n") {
 					$output = substr ($output, 1);
 					$ol--;
 				}
@@ -1066,12 +1066,12 @@ class StringParser_BBCode extends StringParser {
 			}
 			switch ($node->getFlag ('newlinemode.end', 'integer', BBCODE_NEWLINE_PARSE)) {
 			case BBCODE_NEWLINE_IGNORE:
-				if ($ol && $output{$ol-1} == "\n") {
+				if ($ol && $output[$ol-1] == "\n") {
 					$after = "\n";
 				}
 				// don't break!
 			case BBCODE_NEWLINE_DROP:
-				if ($ol && $output{$ol-1} == "\n") {
+				if ($ol && $output[$ol-1] == "\n") {
 					$output = substr ($output, 0, -1);
 					$ol--;
 				}
@@ -1449,10 +1449,10 @@ class StringParser_BBCode_Node_Paragraph extends StringParser_Node {
 			$f_begin = $this->_children[0]->getFlag ('newlinemode.begin', 'integer', BBCODE_NEWLINE_PARSE);
 			$f_end = $this->_children[0]->getFlag ('newlinemode.end', 'integer', BBCODE_NEWLINE_PARSE);
 			$content = $this->_children[0]->content;
-			if ($f_begin != BBCODE_NEWLINE_PARSE && $content{0} == "\n") {
+			if ($f_begin != BBCODE_NEWLINE_PARSE && $content[0] == "\n") {
 				$content = substr ($content, 1);
 			}
-			if ($f_end != BBCODE_NEWLINE_PARSE && $content{strlen($content)-1} == "\n") {
+			if ($f_end != BBCODE_NEWLINE_PARSE && $content[strlen($content)-1] == "\n") {
 				$content = substr ($content, 0, -1);
 			}
 			if (!strlen ($content)) {

--- a/lib/pear/HTMLSax3.php
+++ b/lib/pear/HTMLSax3.php
@@ -161,7 +161,7 @@ class XML_HTMLSax3_StateParser {
     * @var XML_HTMLSax3 instance of user front end class
     * @access protected
     */
-    function XML_HTMLSax3_StateParser (& $htmlsax) {
+    function __construct (& $htmlsax) {
         $this->htmlsax = & $htmlsax;
         $this->State[XML_HTMLSAX3_STATE_START] = new XML_HTMLSax3_StartingState();
 
@@ -332,8 +332,8 @@ class XML_HTMLSax3_StateParser_Lt430 extends XML_HTMLSax3_StateParser {
     * @var XML_HTMLSax3 instance of user front end class
     * @access protected
     */
-    function XML_HTMLSax3_StateParser_Lt430(& $htmlsax) {
-        parent::XML_HTMLSax3_StateParser($htmlsax);
+    function __construct(& $htmlsax) {
+        parent::__construct($htmlsax);
         $this->parser_options['XML_OPTION_TRIM_DATA_NODES'] = 0;
         $this->parser_options['XML_OPTION_CASE_FOLDING'] = 0;
         $this->parser_options['XML_OPTION_LINEFEED_BREAK'] = 0;
@@ -396,8 +396,8 @@ class XML_HTMLSax3_StateParser_Gtet430 extends XML_HTMLSax3_StateParser {
     * @var XML_HTMLSax3 instance of user front end class
     * @access protected
     */
-    function XML_HTMLSax3_StateParser_Gtet430(& $htmlsax) {
-        parent::XML_HTMLSax3_StateParser($htmlsax);
+    function __construct(& $htmlsax) {
+        parent::__construct($htmlsax);
         $this->parser_options['XML_OPTION_TRIM_DATA_NODES'] = 0;
         $this->parser_options['XML_OPTION_CASE_FOLDING'] = 0;
         $this->parser_options['XML_OPTION_LINEFEED_BREAK'] = 0;
@@ -486,7 +486,7 @@ class XML_HTMLSax3 {
     * </pre>
     * @access public
     */
-    function XML_HTMLSax3() {
+    function __construct() {
         if (version_compare(phpversion(), '4.3', 'ge')) {
             $this->state_parser = new XML_HTMLSax3_StateParser_Gtet430($this);
         } else {
@@ -1038,7 +1038,7 @@ class XML_HTMLSax3_Trim {
     * @param string original handler method
     * @access protected
     */
-    function XML_HTMLSax3_Trim(&$orig_obj, $orig_method) {
+    function __construct(&$orig_obj, $orig_method) {
         $this->orig_obj =& $orig_obj;
         $this->orig_method = $orig_method;
     }
@@ -1086,7 +1086,7 @@ class XML_HTMLSax3_CaseFolding {
     * @param string original close handler method
     * @access protected
     */
-    function XML_HTMLSax3_CaseFolding(&$orig_obj, $orig_open_method, $orig_close_method) {
+    function __construct(&$orig_obj, $orig_open_method, $orig_close_method) {
         $this->orig_obj =& $orig_obj;
         $this->orig_open_method = $orig_open_method;
         $this->orig_close_method = $orig_close_method;
@@ -1136,7 +1136,7 @@ class XML_HTMLSax3_Linefeed {
     * @param string original handler method
     * @access protected
     */
-    function XML_HTMLSax3_LineFeed(&$orig_obj, $orig_method) {
+    function __construct(&$orig_obj, $orig_method) {
         $this->orig_obj =& $orig_obj;
         $this->orig_method = $orig_method;
     }
@@ -1178,7 +1178,7 @@ class XML_HTMLSax3_Tab {
     * @param string original handler method
     * @access protected
     */
-    function XML_HTMLSax3_Tab(&$orig_obj, $orig_method) {
+    function __construct(&$orig_obj, $orig_method) {
         $this->orig_obj =& $orig_obj;
         $this->orig_method = $orig_method;
     }
@@ -1221,7 +1221,7 @@ class XML_HTMLSax3_Entities_Parsed {
     * @param string original handler method
     * @access protected
     */
-    function XML_HTMLSax3_Entities_Parsed(&$orig_obj, $orig_method) {
+    function __construct(&$orig_obj, $orig_method) {
         $this->orig_obj =& $orig_obj;
         $this->orig_method = $orig_method;
     }
@@ -1273,7 +1273,7 @@ class XML_HTMLSax3_Entities_Unparsed {
     * @param string original handler method
     * @access protected
     */
-    function XML_HTMLSax3_Entities_Unparsed(&$orig_obj, $orig_method) {
+    function __construct(&$orig_obj, $orig_method) {
         $this->orig_obj =& $orig_obj;
         $this->orig_method = $orig_method;
     }
@@ -1316,7 +1316,7 @@ class XML_HTMLSax3_Escape_Stripper {
     * @param string original handler method
     * @access protected
     */
-    function XML_HTMLSax3_Escape_Stripper(&$orig_obj, $orig_method) {
+    function __construct(&$orig_obj, $orig_method) {
         $this->orig_obj =& $orig_obj;
         $this->orig_method = $orig_method;
     }

--- a/lib/pear/HTMLSax3.php
+++ b/lib/pear/HTMLSax3.php
@@ -199,7 +199,7 @@ class XML_HTMLSax3_StateParser {
     */
     function scanCharacter() {
         if ($this->position < $this->length) {
-            return $this->rawtext{$this->position++};
+            return $this->rawtext[$this->position++];
         }
     }
 
@@ -352,7 +352,7 @@ class XML_HTMLSax3_StateParser_Lt430 extends XML_HTMLSax3_StateParser {
     */
     function scanUntilCharacters($string) {
         $startpos = $this->position;
-        while ($this->position < $this->length && strpos($string, $this->rawtext{$this->position}) === FALSE) {
+        while ($this->position < $this->length && strpos($string, $this->rawtext[$this->position]) === FALSE) {
             $this->position++;
         }
         return substr($this->rawtext, $startpos, $this->position - $startpos);
@@ -365,7 +365,7 @@ class XML_HTMLSax3_StateParser_Lt430 extends XML_HTMLSax3_StateParser {
     */
     function ignoreWhitespace() {
         while ($this->position < $this->length && 
-            strpos(" \n\r\t", $this->rawtext{$this->position}) !== FALSE) {
+            strpos(" \n\r\t", $this->rawtext[$this->position]) !== FALSE) {
             $this->position++;
         }
     }

--- a/lib/pear/Safe.php
+++ b/lib/pear/Safe.php
@@ -292,7 +292,7 @@ class HTML_Safe
         foreach ($this->blackProtocols as $proto) {
             $preg = "/[\s\x01-\x1F]*";
             for ($i=0; $i<strlen($proto); $i++) {
-                $preg .= $proto{$i} . "[\s\x01-\x1F]*";
+                $preg .= $proto[$i] . "[\s\x01-\x1F]*";
             }
             $preg .= ":/i";
             $this->_protoRegexps[] = $preg;

--- a/lib/pear/Safe.php
+++ b/lib/pear/Safe.php
@@ -286,7 +286,7 @@ class HTML_Safe
      *
      * @access public
      */
-    function HTML_Safe() 
+    function __construct() 
     {
         //making regular expressions based on Proto & CSS arrays
         foreach ($this->blackProtocols as $proto) {

--- a/lib/pear/mime.php
+++ b/lib/pear/mime.php
@@ -114,7 +114,7 @@ class Mail_mime
      *
      * @access public
      */
-    function Mail_mime($crlf = "\r\n")
+    function __construct($crlf = "\r\n")
     {
         $this->_setEOL($crlf);
         $this->_build_params = array(

--- a/lib/pear/mimePart.php
+++ b/lib/pear/mimePart.php
@@ -139,7 +139,7 @@ class Mail_mimePart {
      *                  charset      - Character set to use
      * @access public
      */
-    function Mail_mimePart($body = '', $params = array())
+    function __construct($body = '', $params = array())
     {
         if (!defined('MAIL_MIMEPART_CRLF')) {
             define('MAIL_MIMEPART_CRLF', defined('MAIL_MIME_CRLF') ? MAIL_MIME_CRLF : "\r\n", TRUE);

--- a/lib/phpass/PasswordHash.inc
+++ b/lib/phpass/PasswordHash.inc
@@ -30,7 +30,7 @@ class PasswordHash {
 	var $portable_hashes;
 	var $random_state;
 
-	function PasswordHash($iteration_count_log2, $portable_hashes)
+	function __construct($iteration_count_log2, $portable_hashes)
 	{
 		$this->itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 

--- a/lib/smarty/Config_File.class.php
+++ b/lib/smarty/Config_File.class.php
@@ -69,7 +69,7 @@ class Config_File {
      *
      * @param string $config_path (optional) path to the config files
      */
-    function Config_File($config_path = NULL)
+    function __construct($config_path = NULL)
     {
         if (isset($config_path))
             $this->set_path($config_path);

--- a/lib/smarty/Smarty.class.php
+++ b/lib/smarty/Smarty.class.php
@@ -565,7 +565,7 @@ class Smarty
     /**
      * The class constructor.
      */
-    function Smarty()
+    function __construct()
     {
       $this->assign('SCRIPT_NAME', isset($_SERVER['SCRIPT_NAME']) ? $_SERVER['SCRIPT_NAME']
                     : @$GLOBALS['HTTP_SERVER_VARS']['SCRIPT_NAME']);

--- a/lib/smarty/Smarty_Compiler.class.php
+++ b/lib/smarty/Smarty_Compiler.class.php
@@ -1538,7 +1538,7 @@ class Smarty_Compiler extends Smarty {
         preg_match_all('~(?:' . $this->_obj_call_regexp . '|' . $this->_qstr_regexp . ' | (?>[^"\'=\s]+)
                          )+ |
                          [=]
-                        ~x', $tag_args, $match);
+                        ~x', is_null($tag_args) ? '' : $tag_args, $match);
         $tokens       = $match[0];
 
         $attrs = array();

--- a/lib/smarty/Smarty_Compiler.class.php
+++ b/lib/smarty/Smarty_Compiler.class.php
@@ -78,7 +78,7 @@ class Smarty_Compiler extends Smarty {
     /**
      * The class constructor.
      */
-    function Smarty_Compiler()
+    function __construct()
     {
         // matches double quoted strings:
         // "foobar"
@@ -564,7 +564,9 @@ class Smarty_Compiler extends Smarty {
 
             case 'php':
                 /* handle folded tags replaced by {php} */
-                list(, $block) = each($this->_folded_blocks);
+                $block = current($this->_folded_blocks);
+                /* advance array pointer */
+                next($this->_folded_blocks);
                 $this->_current_line_no += substr_count($block[0], "\n");
                 /* the number of matched elements in the regexp in _compile_file()
                    determins the type of folded tag that was found */

--- a/lib/smarty_plugins/modifier.entitytruncate.php
+++ b/lib/smarty_plugins/modifier.entitytruncate.php
@@ -58,7 +58,7 @@ function smarty_modifier_entitytruncate($string, $length, $etc='...', $breakWord
 	list ($tmp, $piece) = GalleryUtilities::entitySubstr($piece, 0, $length - $etcLength);
 
 	$pieceLength = strlen($piece);
-	if (!$breakWords && $string{$pieceLength-1} != ' ' && $string{$pieceLength} != ' ') {
+	if (!$breakWords && $string[$pieceLength-1] != ' ' && $string[$pieceLength] != ' ') {
 	    /* We split a word, and we're not allowed to.  Try to back up to the last space */
 	    $splitIndex = strrpos($piece, ' ');
 	    if ($splitIndex > 0) {

--- a/lib/smarty_plugins/modifier.markup.php
+++ b/lib/smarty_plugins/modifier.markup.php
@@ -92,7 +92,7 @@ class GalleryHtmlMarkupParser {
 class GalleryBbcodeMarkupParser {
     var $_bbcode;
 
-    function GalleryBbcodeMarkupParser() {
+    function __construct() {
 	if (!class_exists('StringParser_BBCode')) {
 	    GalleryCoreApi::requireOnce('lib/bbcode/stringparser_bbcode.class.php');
 	}

--- a/lib/support/SupportStatusTemplate.class
+++ b/lib/support/SupportStatusTemplate.class
@@ -29,7 +29,7 @@ class SupportStatusTemplate {
      * Create a SupportStatusTemplate.
      * @param string $title the status title
      */
-    function SupportStatusTemplate($title) {
+    function __construct($title) {
     	$this->_title = $title;
     }
 

--- a/lib/support/chmod.php
+++ b/lib/support/chmod.php
@@ -314,7 +314,7 @@ class PermissionBits {
      */
     static function fromString($bitsAsString) {
     	$bitsAsString = (string)$bitsAsString;
-    	if (strlen($bitsAsString) && $bitsAsString{0} != '0') {
+    	if (strlen($bitsAsString) && $bitsAsString[0] != '0') {
     	    $bitsAsString = '0' . $bitsAsString;
     	}
     	return new PermissionBits(octdec($bitsAsString));

--- a/lib/support/chmod.php
+++ b/lib/support/chmod.php
@@ -302,7 +302,7 @@ class PermissionBits {
      * Constructor
      * @param int $bits permission bits in decimal integer representation, eg. octdec(0755)
      */
-    function PermissionBits($bits) {
+    function __construct($bits) {
     	$this->_bits = decoct($bits);
     }
 

--- a/lib/support/phpinfo.php
+++ b/lib/support/phpinfo.php
@@ -9,7 +9,7 @@ preg_match('#<body>(.*)</body>#ims', $phpinfo, $matches);
 $phpinfo = $matches[1];
 $phpinfo = preg_replace_callback(
     '#(<td class="v">)(.*?)(</td>)#ims',
-    create_function('$matches', 'return $matches[1] . wordwrap($matches[2], 10, "<wbr>", true) . $matches[3];'),
+    function($matches) {return $matches[1] . wordwrap($matches[2], 10, "<wbr>", true) . $matches[3];},
     $phpinfo);
 
 ?>

--- a/modules/albumselect/Callbacks.inc
+++ b/modules/albumselect/Callbacks.inc
@@ -305,7 +305,7 @@ class AlbumSelectCallbacks {
  */
 class AlbumSelectTreeSorter {
     var $_titles;
-    function AlbumSelectTreeSorter(&$titles) {
+    function __construct(&$titles) {
 	$this->_titles =& $titles;
     }
     function sort($a, $b) {

--- a/modules/albumselect/module.inc
+++ b/modules/albumselect/module.inc
@@ -28,7 +28,7 @@
  */
 class AlbumSelectModule extends GalleryModule {
 
-    function AlbumSelectModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('albumselect');
 	$this->setName($gallery->i18n('Album Select'));

--- a/modules/archiveupload/ArchiveUploadSiteAdmin.inc
+++ b/modules/archiveupload/ArchiveUploadSiteAdmin.inc
@@ -53,7 +53,7 @@ class ArchiveUploadSiteAdminController extends GalleryController {
 		    $platform =& $gallery->getPlatform();
 		    $slash = $platform->getDirectorySeparator();
 		    $retryPath = $form['unzipPath'];
-		    if ($retryPath{strlen($retryPath)-1} != $slash) {
+		    if ($retryPath[strlen($retryPath)-1] != $slash) {
 			$retryPath .= $slash;
 		    }
 		    $retryPath .= 'unzip';

--- a/modules/archiveupload/classes/ArchiveUploadHelper.class
+++ b/modules/archiveupload/classes/ArchiveUploadHelper.class
@@ -93,7 +93,7 @@ class ArchiveUploadHelper {
 		if (empty($path)) {
 		    continue;
 		}
-		if ($path{strlen($path)-1} != $slash) {
+		if ($path[strlen($path)-1] != $slash) {
 		    $path .= $slash;
 		}
 		$paths[] = $path . 'unzip.exe';
@@ -106,7 +106,7 @@ class ArchiveUploadHelper {
 		if (empty($path)) {
 		    continue;
 		}
-		if ($path{strlen($path)-1} != $slash) {
+		if ($path[strlen($path)-1] != $slash) {
 		    $path .= $slash;
 		}
 		$paths[] = $path . 'unzip';

--- a/modules/archiveupload/module.inc
+++ b/modules/archiveupload/module.inc
@@ -28,7 +28,7 @@
  */
 class ArchiveUploadModule extends GalleryModule {
 
-    function ArchiveUploadModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('archiveupload');

--- a/modules/captcha/module.inc
+++ b/modules/captcha/module.inc
@@ -28,7 +28,7 @@
  */
 class CaptchaModule extends GalleryModule {
 
-    function CaptchaModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('captcha');
 	$this->setName($gallery->i18n('Captcha'));

--- a/modules/cart/classes/CartHelper.class
+++ b/modules/cart/classes/CartHelper.class
@@ -34,7 +34,7 @@ class CartHelper {
      * @return array GalleryStatus a status code
      *               array (itemId => count, itemId => count, ..)
      */
-    function fetchCartItemCounts() {
+    static function fetchCartItemCounts() {
 	global $gallery;
 	$session =& $gallery->getSession();
 
@@ -54,7 +54,7 @@ class CartHelper {
      * @param array $ids int item ids
      * @return GalleryStatus a status code
      */
-    function addItemsToCart($ids) {
+    static function addItemsToCart($ids) {
 	list ($ret, $cartItemIds) = CartHelper::fetchCartItemCounts();
 	if ($ret) {
 	    return $ret;
@@ -95,7 +95,7 @@ class CartHelper {
      * @param array $cartItemIds (itemId => count, itemId => count, ..)
      * @return GalleryStatus a status code
      */
-    function setCartItemCounts($cartItemIds) {
+    static function setCartItemCounts($cartItemIds) {
 	global $gallery;
 	$session =& $gallery->getSession();
 
@@ -115,7 +115,7 @@ class CartHelper {
      * @return array GalleryStatus a status code
      *               array of items
      */
-    function loadCartItems() {
+    static function loadCartItems() {
 	list ($ret, $cartItemIds) = CartHelper::fetchCartItemCounts();
 	if ($ret) {
 	    return array($ret, null);

--- a/modules/cart/module.inc
+++ b/modules/cart/module.inc
@@ -27,7 +27,7 @@
  */
 class CartModule extends GalleryModule {
 
-    function CartModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('cart');

--- a/modules/colorpack/module.inc
+++ b/modules/colorpack/module.inc
@@ -27,7 +27,7 @@
  */
 class ColorPackModule extends GalleryModule {
 
-    function ColorPackModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('colorpack');
 	$this->setName($gallery->i18n('Color Packs'));

--- a/modules/comment/CommentSiteAdmin.inc
+++ b/modules/comment/CommentSiteAdmin.inc
@@ -32,7 +32,7 @@ GalleryCoreApi::requireOnce('modules/comment/classes/GalleryCommentHelper.class'
 class CommentSiteAdminController extends GalleryController {
     var $_akismet;
 
-    function CommentSiteAdminController() {
+    function __construct() {
 	$this->_akismet = new AkismetApi();
     }
 

--- a/modules/comment/classes/GalleryComment.class
+++ b/modules/comment/classes/GalleryComment.class
@@ -159,7 +159,7 @@ class GalleryComment extends GalleryChildEntity {
     /**
      * @see GalleryEntity::create
      */
-    function create($parentId) {
+    function create($parentId=false) {
 	$ret = parent::create($parentId);
 	if ($ret) {
 	    return $ret;

--- a/modules/comment/classes/GalleryCommentHelper.class
+++ b/modules/comment/classes/GalleryCommentHelper.class
@@ -169,7 +169,8 @@ class GalleryCommentHelper /* implements GalleryEventListener */ {
 	 AND
 	   [GalleryAccessSubscriberMap::itemId] = [GalleryItemAttributesMap::itemId]';
 	if ($publishStatus !== null) {
-	    $statusMarkers = GalleryUtilities::makeMarkers(count($publishStatus));
+        $numPublishStatuses = is_array($publishStatus) ? count($publishStatus) : 1;
+	    $statusMarkers = GalleryUtilities::makeMarkers($numPublishStatuses);
 	    $queryBase .= '
 	 AND
 	   [GalleryComment::publishStatus] IN (' . $statusMarkers . ')';

--- a/modules/comment/classes/GalleryCommentHelper.class
+++ b/modules/comment/classes/GalleryCommentHelper.class
@@ -42,7 +42,7 @@ class GalleryCommentHelper /* implements GalleryEventListener */ {
      * @return array GalleryStatus a status code,
      *               array (entityId => GalleryComment, ...)
      */
-    function fetchComments($itemId, $count=null, $orderDirection=ORDER_ASCENDING,
+    static function fetchComments($itemId, $count=null, $orderDirection=ORDER_ASCENDING,
 			   $publishStatus=COMMENT_PUBLISH_STATUS_PUBLISHED) {
 	global $gallery;
 
@@ -120,7 +120,7 @@ class GalleryCommentHelper /* implements GalleryEventListener */ {
      *               array (entityId => GalleryComment, ...)
      *               int total number of comments available
      */
-    function fetchAllComments($itemId, $count=null, $offset=null, $orderDirection=ORDER_ASCENDING,
+    static function fetchAllComments($itemId, $count=null, $offset=null, $orderDirection=ORDER_ASCENDING,
 			      $publishStatus=COMMENT_PUBLISH_STATUS_PUBLISHED) {
 	global $gallery;
 
@@ -248,7 +248,7 @@ class GalleryCommentHelper /* implements GalleryEventListener */ {
      * @return array GalleryStatus a status code
      *               int a count
      */
-    function fetchCommentCounts($itemIds) {
+    static function fetchCommentCounts($itemIds) {
 	global $gallery;
 
 	$markers = GalleryUtilities::makeMarkers(sizeof($itemIds));
@@ -290,7 +290,7 @@ class GalleryCommentHelper /* implements GalleryEventListener */ {
      * @return array GalleryStatus a status code,
      *               int latest comment time
      */
-    function getLatestCommentTime($hostAddress) {
+    static function getLatestCommentTime($hostAddress) {
 	global $gallery;
 
 	$data = array($hostAddress);
@@ -329,7 +329,7 @@ class GalleryCommentHelper /* implements GalleryEventListener */ {
      * @return array GalleryStatus a status code
      *               array values used for the AddComment page (itemId, host, validation plugins)
      */
-    function getAddComment(&$item, &$form) {
+    static function getAddComment(&$item, &$form) {
 	/* Make sure we have permission to add a comment */
 	list ($ret, $permissions) = GalleryCoreApi::getPermissions($item->getId());
 	if ($ret) {
@@ -395,7 +395,7 @@ class GalleryCommentHelper /* implements GalleryEventListener */ {
      * @return array GalleryStatus a status code
      *               boolean true to use validation plugins
      */
-    function useValidationPlugins() {
+    static function useValidationPlugins() {
 	list ($ret, $level) =
 	    GalleryCoreApi::getPluginParameter('module', 'comment', 'validation.level');
 	if ($ret) {
@@ -424,7 +424,7 @@ class GalleryCommentHelper /* implements GalleryEventListener */ {
       *
       * @see GalleryEventListener::handleEvent
       */
-    function handleEvent($event) {
+    static function handleEvent($event) {
 	global $gallery;
 
 	switch ($event->getEventName()) {

--- a/modules/comment/module.inc
+++ b/modules/comment/module.inc
@@ -34,7 +34,7 @@ define('COMMENT_PUBLISH_STATUS_SPAM', 2);
  */
 class CommentModule extends GalleryModule {
 
-    function CommentModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('comment');

--- a/modules/core/AdminCore.inc
+++ b/modules/core/AdminCore.inc
@@ -64,10 +64,10 @@ class AdminCoreController extends GalleryController {
 		    $urlComponents = parse_url($urlGenerator->getCurrentUrlDir(false));
 		    $paths['embedded'] = $urlComponents['path'];
 		    foreach ($paths as $key => $value) {
-			if ($value{strlen($value)-1} != '/') {
+			if ($value[strlen($value)-1] != '/') {
 			    $value .= '/';
 			}
-			if ($value{0} != '/') {
+			if ($value[0] != '/') {
 			    $value = '/' . $value;
 			}
 			$paths[$key] = $value;
@@ -86,7 +86,7 @@ class AdminCoreController extends GalleryController {
 		/* It should either be empty or a substring of the request-host */
 		if (!empty($form['cookie']['domain'])) {
 		    $cookieDomain = $form['cookie']['domain'];
-		    if ($cookieDomain{0} != '.') {
+		    if ($cookieDomain[0] != '.') {
 			$cookieDomain = '.' . $cookieDomain;
 		    }
 		    $urlComponents = parse_url($urlGenerator->getCurrentUrlDir());

--- a/modules/core/ItemAdmin.inc
+++ b/modules/core/ItemAdmin.inc
@@ -168,7 +168,7 @@ class ItemAdminView extends GalleryView {
 	$ItemAdmin['subViewChoices'] = $subViewChoices;
 	$ItemAdmin['viewL10Domain'] = $subView->getL10Domain();
 	$ItemAdmin['isSiteAdmin'] = $isSiteAdmin;
-	$ItemAdmin['unsetCallback'] = create_function('$a,$k', 'unset($a[$k]);return $a;');
+	$ItemAdmin['unsetCallback'] = function($a, $k) { unset($a[$k]); return $a; };
 
 	if (!isset($ItemAdmin['enctype'])) {
 	    $ItemAdmin['enctype'] = 'application/x-www-form-urlencoded';

--- a/modules/core/ShowItem.inc
+++ b/modules/core/ShowItem.inc
@@ -101,7 +101,7 @@ class ShowItemView extends GalleryView {
     /**
      * @see GalleryView::getItem
      */
-    function getItem($getOriginalSpecified=false) {
+    static function getItem($getOriginalSpecified=false) {
 	static $originalSpecified;
 	list ($ret, $item, $wasSpecified) = parent::getItem();
 	if ($ret) {

--- a/modules/core/SimpleCallback.inc
+++ b/modules/core/SimpleCallback.inc
@@ -120,7 +120,7 @@ class SimpleCallbackView extends GalleryView {
 	$dirList = $fileList = array();
 	if ($dir = $platform->opendir($path)) {
 	    $slash = $platform->getDirectorySeparator();
-	    if ($path{strlen($path)-1} != $slash) {
+	    if ($path[strlen($path)-1] != $slash) {
 		$path .= $slash;
 	    }
 	    while (($file = $platform->readdir($dir)) !== false) {

--- a/modules/core/classes/FlockLockSystem.class
+++ b/modules/core/classes/FlockLockSystem.class
@@ -106,7 +106,7 @@ class FlockLockSystem extends GalleryLockSystem {
 		    }
 		    return array(GalleryCoreApi::error(ERROR_LOCK_TIMEOUT, __FILE__, __LINE__,
 			array_reduce($notLocked,
-			    create_function('$v,$w', 'return empty($v) ? $w[1] : "$v $w[1]";'))),
+			    function($v,$w) {return empty($v) ? $w[1] : "$v $w[1]";})),
 			null);
 		}
 

--- a/modules/core/classes/GalleryCoreApi.class
+++ b/modules/core/classes/GalleryCoreApi.class
@@ -141,7 +141,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code,
      *               object an instance
      */
-    function newFactoryInstanceByHint($classType, $hints) {
+    static function newFactoryInstanceByHint($classType, $hints) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryFactoryHelper_simple.class');
 	return GalleryFactoryHelper_simple::newInstanceByHint($classType, $hints);
@@ -155,7 +155,7 @@ class GalleryCoreApi {
      * @return GalleryStatus a status code
      *         object the instance
      */
-    function newFactoryInstance($classType, $className=null) {
+    static function newFactoryInstance($classType, $className=null) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryFactoryHelper_simple.class');
 	return GalleryFactoryHelper_simple::newInstance($classType, $className);
@@ -169,7 +169,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code,
      *               object an instance
      */
-    function newFactoryInstanceById($classType, $id) {
+    static function newFactoryInstanceById($classType, $id) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryFactoryHelper_simple.class');
 	return GalleryFactoryHelper_simple::newInstanceById($classType, $id);

--- a/modules/core/classes/GalleryCoreApi.class
+++ b/modules/core/classes/GalleryCoreApi.class
@@ -87,7 +87,7 @@ class GalleryCoreApi {
      * - convert the contents of GALLERY_PERMISSION_SESSION_KEY to array indices instead of array
      *   of values.
      */
-    function getApiVersion() {
+    static function getApiVersion() {
 	return array(7, 54);
     }
 
@@ -104,7 +104,7 @@ class GalleryCoreApi {
      *              implementation (eg. array('image/jpeg', 'image/gif'))
      * @param int $orderWeight the priority of this implementation (lower number == higher priority)
      */
-    function registerFactoryImplementation($classType, $className, $implId, $implPath,
+    static function registerFactoryImplementation($classType, $className, $implId, $implPath,
 					   $implModuleId, $hints, $orderWeight=5) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryFactoryHelper_medium.class');
@@ -125,7 +125,7 @@ class GalleryCoreApi {
      *              implementation (eg. array('image/jpeg', 'image/gif'))
      * @return GalleryStatus
      */
-    function registerFactoryImplementationForRequest($classType, $className, $implId, $implPath,
+    static function registerFactoryImplementationForRequest($classType, $className, $implId, $implPath,
 					      $implModuleId, $hints) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryFactoryHelper_medium.class');
@@ -235,7 +235,7 @@ class GalleryCoreApi {
      * @param string $moduleId an id (eg. 'netpbm')
      * @return GalleryStatus a status code
      */
-    function unregisterFactoryImplementationsByModuleId($moduleId) {
+    static function unregisterFactoryImplementationsByModuleId($moduleId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryFactoryHelper_medium.class');
 	return GalleryFactoryHelper_medium::unregisterImplementationsByModuleId($moduleId);
@@ -248,7 +248,7 @@ class GalleryCoreApi {
      * @param string $implId an implementation id (eg. 'NetPBM')
      * @return GalleryStatus a status code
      */
-    function unregisterFactoryImplementation($classType, $implId) {
+    static function unregisterFactoryImplementation($classType, $implId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryFactoryHelper_medium.class');
 	return GalleryFactoryHelper_medium::unregisterImplementation($classType, $implId);
@@ -279,7 +279,7 @@ class GalleryCoreApi {
      * @param GalleryPlugin $plugin
      * @return boolean true if the plugin is compatible
      */
-    function isPluginCompatibleWithApis($plugin) {
+    static function isPluginCompatibleWithApis($plugin) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPluginHelper_simple.class');
 	return GalleryPluginHelper_simple::isPluginCompatibleWithApis($plugin);
@@ -311,7 +311,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array (parameterName => parameterValue)
      */
-    function fetchAllPluginParameters($pluginType, $pluginId, $itemId=0) {
+    static function fetchAllPluginParameters($pluginType, $pluginId, $itemId=0) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPluginHelper_simple.class');
 	return GalleryPluginHelper_simple::fetchAllParameters($pluginType, $pluginId, $itemId);
@@ -323,7 +323,7 @@ class GalleryCoreApi {
      * @param int $itemId the id of the GalleryItem
      * @return GalleryStatus a status code
      */
-    function removePluginParametersForItemId($itemId) {
+    static function removePluginParametersForItemId($itemId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPluginHelper_medium.class');
 	return GalleryPluginHelper_medium::removeParametersForItemId($itemId);
@@ -338,7 +338,7 @@ class GalleryCoreApi {
      * @param mixed $parameterValue the value to be matched
      * @return GalleryStatus a status code
      */
-    function removePluginParameterByValue($pluginType, $pluginId, $parameterName, $parameterValue) {
+    static function removePluginParameterByValue($pluginType, $pluginId, $parameterName, $parameterValue) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPluginHelper_medium.class');
 	return GalleryPluginHelper_medium::removeParameterByValue($pluginType, $pluginId,
@@ -390,7 +390,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array redirect info for error page (empty for success)
      */
-    function activatePlugin($pluginType, $pluginId) {
+    static function activatePlugin($pluginType, $pluginId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPluginHelper_medium.class');
 	return GalleryPluginHelper_medium::activate($pluginType, $pluginId);
@@ -404,7 +404,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array redirect info for error page (empty for success)
      */
-    function deactivatePlugin($pluginType, $pluginId) {
+    static function deactivatePlugin($pluginType, $pluginId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPluginHelper_medium.class');
 	return GalleryPluginHelper_medium::deactivate($pluginType, $pluginId);
@@ -417,7 +417,7 @@ class GalleryCoreApi {
      * @param string $pluginId
      * @return GalleryStatus a status code
      */
-    function removePlugin($pluginType, $pluginId) {
+    static function removePlugin($pluginType, $pluginId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPluginHelper_medium.class');
 	return GalleryPluginHelper_medium::removePlugin($pluginType, $pluginId);
@@ -430,7 +430,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               string plugin ids
      */
-    function getAllPluginIds($pluginType) {
+    static function getAllPluginIds($pluginType) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPluginHelper_medium.class');
 	return GalleryPluginHelper_medium::getAllPluginIds($pluginType);
@@ -445,7 +445,7 @@ class GalleryCoreApi {
      * @param int $itemId the id of item (or null for a global setting)
      * @return GalleryStatus a status code
      */
-    function removePluginParameter($pluginType, $pluginId, $parameterName, $itemId=0) {
+    static function removePluginParameter($pluginType, $pluginId, $parameterName, $itemId=0) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPluginHelper_medium.class');
 	return GalleryPluginHelper_medium::removeParameter($pluginType, $pluginId,
@@ -459,7 +459,7 @@ class GalleryCoreApi {
      * @param string $pluginId
      * @return GalleryStatus a status code
      */
-    function removeAllPluginParameters($pluginType, $pluginId) {
+    static function removeAllPluginParameters($pluginType, $pluginId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPluginHelper_medium.class');
 	return GalleryPluginHelper_medium::removeAllParameters($pluginType, $pluginId);
@@ -494,7 +494,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array int access list ids
      */
-    function fetchAccessListIds($permission, $userId, $sessionPermissions=true) {
+    static function fetchAccessListIds($permission, $userId, $sessionPermissions=true) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_simple.class');
 	return GalleryPermissionHelper_simple::fetchAccessListIds(
@@ -506,7 +506,7 @@ class GalleryCoreApi {
      *
      * @return GalleryStatus a status code
      */
-    function maybeCompactAccessLists() {
+    static function maybeCompactAccessLists() {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_advanced.class');
 	return GalleryPermissionHelper_advanced::maybeCompactAccessLists();
@@ -518,7 +518,7 @@ class GalleryCoreApi {
      *
      * @return GalleryStatus a status code
      */
-    function compactAccessLists() {
+    static function compactAccessLists() {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_advanced.class');
 	return GalleryPermissionHelper_advanced::compactAccessLists();
@@ -531,7 +531,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code,
      *               int accessListId the associated item's list
      */
-    function fetchAccessListId($itemId) {
+    static function fetchAccessListId($itemId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_advanced.class');
 	return GalleryPermissionHelper_advanced::fetchAccessListId($itemId);
@@ -545,7 +545,7 @@ class GalleryCoreApi {
      * @return GalleryStatus success if the user has permission,
      *                              ERROR_PERMISSION_DENIED if not.
      */
-    function assertHasItemPermission($itemId, $permission) {
+    static function assertHasItemPermission($itemId, $permission) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryUserHelper_simple.class');
 	return GalleryUserHelper_simple::assertHasItemPermission($itemId, $permission);
     }
@@ -560,7 +560,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               boolean true if yes
      */
-    function hasItemPermission($itemId, $permission, $userId=null, $sessionPermissions=true) {
+    static function hasItemPermission($itemId, $permission, $userId=null, $sessionPermissions=true) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryUserHelper_simple.class');
 	return GalleryUserHelper_simple::hasItemPermission(
 	    $itemId, $permission, $userId, $sessionPermissions);
@@ -577,7 +577,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array (username, username, ...)
      */
-    function fetchUsernames($count=null, $offset=null, $substring=null) {
+    static function fetchUsernames($count=null, $offset=null, $substring=null) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryUserHelper_medium.class');
 	return GalleryUserHelper_medium::fetchUsernames($count, $offset, $substring);
     }
@@ -589,7 +589,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               int number of users
      */
-    function fetchUserCount($substring=null, $groupId=null) {
+    static function fetchUserCount($substring=null, $groupId=null) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryUserHelper_medium.class');
 	return GalleryUserHelper_medium::fetchUserCount($substring, $groupId);
     }
@@ -601,7 +601,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               GalleryUser a user
      */
-    function fetchUserByUserName($userName=null) {
+    static function fetchUserByUserName($userName=null) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryUserHelper_medium.class');
 	return GalleryUserHelper_medium::fetchUserByUserName($userName);
     }
@@ -612,7 +612,7 @@ class GalleryCoreApi {
      * @return GalleryStatus success if the user is an administrator
      *                              ERROR_PERMISSION_DENIED if not.
      */
-    function assertUserIsSiteAdministrator() {
+    static function assertUserIsSiteAdministrator() {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryUserHelper_medium.class');
 	return GalleryUserHelper_medium::assertSiteAdministrator();
     }
@@ -624,7 +624,7 @@ class GalleryCoreApi {
      * @param int $userId
      * @return array GalleryStatus a status code
      */
-    function deleteUserItems($userId) {
+    static function deleteUserItems($userId) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryUserHelper_medium.class');
 	return GalleryUserHelper_medium::deleteUserItems($userId);
     }
@@ -639,7 +639,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array (groupname, groupname, ...)
      */
-    function fetchGroupNames($count=null, $offset=null, $substring=null) {
+    static function fetchGroupNames($count=null, $offset=null, $substring=null) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryGroupHelper_simple.class');
 	return GalleryGroupHelper_simple::fetchGroupNames($count, $offset, $substring);
     }
@@ -651,7 +651,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               int group count
      */
-    function fetchGroupCount($substring=null) {
+    static function fetchGroupCount($substring=null) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryGroupHelper_simple.class');
 	return GalleryGroupHelper_simple::fetchGroupCount($substring);
     }
@@ -663,7 +663,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               GalleryGroup a group
      */
-    function fetchGroupByGroupName($groupName=null) {
+    static function fetchGroupByGroupName($groupName=null) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryGroupHelper_simple.class');
 	return GalleryGroupHelper_simple::fetchGroupByGroupName($groupName);
     }
@@ -675,7 +675,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               integer bits
      */
-    function convertPermissionIdsToBits($permissionIds) {
+    static function convertPermissionIdsToBits($permissionIds) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_simple.class');
 	return GalleryPermissionHelper_simple::convertIdsToBits($permissionIds);
@@ -689,7 +689,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array (bits, bits, bits)
      */
-    function convertPermissionBitsToIds($permissionBits, $compress=false) {
+    static function convertPermissionBitsToIds($permissionBits, $compress=false) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_simple.class');
 	return GalleryPermissionHelper_simple::convertBitsToIds($permissionBits, $compress);
@@ -704,7 +704,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array (id => array(array(permission.id => 1, ...), ...)
      */
-    function fetchPermissionsForItems($itemIds, $userId=null, $sessionPermissions=true) {
+    static function fetchPermissionsForItems($itemIds, $userId=null, $sessionPermissions=true) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_simple.class');
 	return GalleryPermissionHelper_simple::fetchPermissionsForItems(
@@ -720,7 +720,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array (perm1, perm2)
      */
-    function getPermissions($itemId, $userId=null, $sessionPermissions=true) {
+    static function getPermissions($itemId, $userId=null, $sessionPermissions=true) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_simple.class');
 	return GalleryPermissionHelper_simple::getPermissions(
@@ -738,7 +738,7 @@ class GalleryCoreApi {
      * @deprecated Use fetchPermissionsForItems instead.
      * @return GalleryStatus a status code
      */
-    function studyPermissions($itemIds, $userId=null, $sessionPermissions=true) {
+    static function studyPermissions($itemIds, $userId=null, $sessionPermissions=true) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_simple.class');
 	return GalleryPermissionHelper_simple::studyPermissions(
@@ -754,7 +754,7 @@ class GalleryCoreApi {
      * @param boolean $applyToChildren (optional) whether or not this call applies to child items
      * @return GalleryStatus a status code
      */
-    function addUserPermission($itemId, $userId, $permission, $applyToChildren=false) {
+    static function addUserPermission($itemId, $userId, $permission, $applyToChildren=false) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_advanced.class');
 	return GalleryPermissionHelper_advanced::addUserPermission($itemId, $userId,
@@ -767,7 +767,7 @@ class GalleryCoreApi {
      * @param int $entityId The permission identifier (e.g. a user, group, or entity id) which 
      *			    grants one or more permissions to one or more items
      */
-    function addPermissionToSession($entityId) {
+    static function addPermissionToSession($entityId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_simple.class');
 	return GalleryPermissionHelper_simple::addPermissionToSession($entityId);
@@ -782,7 +782,7 @@ class GalleryCoreApi {
      * @param boolean $applyToChildren (optional) whether or not this call applies to child items
      * @return GalleryStatus a status code
      */
-    function addGroupPermission($itemId, $groupId, $permission, $applyToChildren=false) {
+    static function addGroupPermission($itemId, $groupId, $permission, $applyToChildren=false) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_advanced.class');
 	return GalleryPermissionHelper_advanced::addGroupPermission($itemId, $groupId,
@@ -800,7 +800,7 @@ class GalleryCoreApi {
      * @param boolean $applyToChildren (optional) whether or not this call applies to child items
      * @return GalleryStatus a status code
      */
-    function addEntityPermission($itemId, $entityId, $permission, $applyToChildren=false) {
+    static function addEntityPermission($itemId, $entityId, $permission, $applyToChildren=false) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_advanced.class');
 	return GalleryPermissionHelper_advanced::addEntityPermission($itemId, $entityId,
@@ -816,7 +816,7 @@ class GalleryCoreApi {
      * @param boolean $applyToChildren (optional) whether or not this call applies to child items
      * @return GalleryStatus a status code
      */
-    function removeUserPermission($itemId, $userId, $permission, $applyToChildren=false) {
+    static function removeUserPermission($itemId, $userId, $permission, $applyToChildren=false) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_advanced.class');
 	return GalleryPermissionHelper_advanced::removeUserPermission(
@@ -832,7 +832,7 @@ class GalleryCoreApi {
      * @param boolean $applyToChildren (optional) whether or not this call applies to child items
      * @return GalleryStatus a status code
      */
-    function removeGroupPermission($itemId, $groupId, $permission, $applyToChildren=false) {
+    static function removeGroupPermission($itemId, $groupId, $permission, $applyToChildren=false) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_advanced.class');
 	return GalleryPermissionHelper_advanced::removeGroupPermission(
@@ -848,7 +848,7 @@ class GalleryCoreApi {
      * @param boolean $applyToChildren (optional) whether or not this call applies to child items
      * @return GalleryStatus a status code
      */
-    function removeEntityPermission($itemId, $entityId, $permission, $applyToChildren=false) {
+    static function removeEntityPermission($itemId, $entityId, $permission, $applyToChildren=false) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_advanced.class');
 	return GalleryPermissionHelper_advanced::removeEntityPermission(
@@ -861,7 +861,7 @@ class GalleryCoreApi {
      * @param int $itemId
      * @return GalleryStatus a status code
      */
-    function removeItemPermissions($itemId) {
+    static function removeItemPermissions($itemId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_advanced.class');
 	return GalleryPermissionHelper_advanced::removeItemPermissions($itemId);
@@ -876,7 +876,7 @@ class GalleryCoreApi {
      *               array array('userId' or 'groupId' or 'entityId' => ...,
      *                           'permission' => ...)
      */
-    function fetchAllPermissionsForItem($itemId, $compress=false) {
+    static function fetchAllPermissionsForItem($itemId, $compress=false) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_advanced.class');
 	return GalleryPermissionHelper_advanced::fetchAllPermissionsForItem($itemId, $compress);
@@ -889,7 +889,7 @@ class GalleryCoreApi {
      * @param int $fromId the id of the source item
      * @return GalleryStatus a status code
      */
-    function copyPermissions($itemId, $fromId) {
+    static function copyPermissions($itemId, $fromId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_advanced.class');
 	return GalleryPermissionHelper_advanced::copyPermissions($itemId, $fromId);
@@ -905,7 +905,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               boolean true if yes
      */
-    function hasPermission($itemId, $entityIds, $permissions) {
+    static function hasPermission($itemId, $entityIds, $permissions) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_advanced.class');
 	return GalleryPermissionHelper_advanced::hasPermission($itemId, $entityIds, $permissions);
@@ -921,7 +921,7 @@ class GalleryCoreApi {
      * @param array $composites (optional) ids of other permissions that compose this one
      * @return GalleryStatus a status code
      */
-    function registerPermission($module, $permissionId, $description,
+    static function registerPermission($module, $permissionId, $description,
 				$flags=0, $composites=array()) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_advanced.class');
@@ -937,7 +937,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array (id => description, id => description, ...)
      */
-    function getPermissionIds($flags=0) {
+    static function getPermissionIds($flags=0) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_advanced.class');
 	return GalleryPermissionHelper_advanced::getPermissionIds($flags);
@@ -951,7 +951,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array(array('id' => ..., 'description' => ...), ...)
      */
-    function getSubPermissions($permissionId) {
+    static function getSubPermissions($permissionId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_advanced.class');
 	return GalleryPermissionHelper_advanced::getSubPermissions($permissionId);
@@ -962,7 +962,7 @@ class GalleryCoreApi {
      *
      * @return GalleryStatus a status code
      */
-    function unregisterModulePermissions($moduleId) {
+    static function unregisterModulePermissions($moduleId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryPermissionHelper_advanced.class');
 	return GalleryPermissionHelper_advanced::unregisterModulePermissions($moduleId);
@@ -978,7 +978,7 @@ class GalleryCoreApi {
      *               GalleryDerivative the up-to-date derivative
      *               boolean true if it had to be rebuilt, false if not
      */
-    function rebuildDerivativeCacheIfNotCurrent($derivativeId, $fixBroken=false) {
+    static function rebuildDerivativeCacheIfNotCurrent($derivativeId, $fixBroken=false) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_simple.class');
 	return GalleryDerivativeHelper_simple::rebuildCacheIfNotCurrent($derivativeId, $fixBroken);
@@ -991,7 +991,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               GalleryDerivative the rebuilt derivative
      */
-    function rebuildDerivativeCache($derivativeId) {
+    static function rebuildDerivativeCache($derivativeId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class');
 	return GalleryDerivativeHelper_advanced::rebuildCache($derivativeId);
@@ -1003,7 +1003,7 @@ class GalleryCoreApi {
      * @param array $ids source ids
      * @return GalleryStatus a status code
      */
-    function expireDerivativeTreeBySourceIds($ids) {
+    static function expireDerivativeTreeBySourceIds($ids) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class');
 	return GalleryDerivativeHelper_advanced::expireDerivativeTreeBySourceIds($ids);
@@ -1016,7 +1016,7 @@ class GalleryCoreApi {
      * @param array $ids source ids
      * @return GalleryStatus a status code
      */
-    function invalidateDerivativeDimensionsBySourceIds($ids) {
+    static function invalidateDerivativeDimensionsBySourceIds($ids) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class');
 	return GalleryDerivativeHelper_advanced::invalidateDerivativeDimensionsBySourceIds($ids);
@@ -1034,7 +1034,7 @@ class GalleryCoreApi {
      *               GalleryEntity (either a GalleryDataItem or a GalleryDerivative) the
      *               preferred source
      */
-    function fetchPreferredSource($item) {
+    static function fetchPreferredSource($item) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class');
 	return GalleryDerivativeHelper_advanced::fetchPreferredSource($item);
@@ -1047,7 +1047,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array(GalleryItem id => GalleryDerivativeImage, ...)
      */
-    function fetchThumbnailsByItemIds($ids) {
+    static function fetchThumbnailsByItemIds($ids) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_simple.class');
 	return GalleryDerivativeHelper_simple::fetchThumbnailsByItemIds($ids);
@@ -1060,7 +1060,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array(GalleryItem id => GalleryDerivativeImage, ...)
      */
-    function fetchPreferredsByItemIds($ids) {
+    static function fetchPreferredsByItemIds($ids) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_medium.class');
 	return GalleryDerivativeHelper_medium::fetchPreferredsByItemIds($ids);
@@ -1074,7 +1074,7 @@ class GalleryCoreApi {
      *               array(GalleryItem id => array(GalleryDerivativeImage, ...)
      *                     ...)
      */
-    function fetchResizesByItemIds($ids) {
+    static function fetchResizesByItemIds($ids) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_medium.class');
 	return GalleryDerivativeHelper_medium::fetchResizesByItemIds($ids);
@@ -1097,7 +1097,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               the merged operation set
      */
-    function mergeDerivativeOperations($operationSet1, $operationSet2, $highPriority=false) {
+    static function mergeDerivativeOperations($operationSet1, $operationSet2, $highPriority=false) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class');
 	return GalleryDerivativeHelper_advanced::mergeOperations($operationSet1, $operationSet2,
@@ -1109,7 +1109,7 @@ class GalleryCoreApi {
      *
      * @return string the new operation set
      */
-    function removeDerivativeOperation($operation, $operationSet) {
+    static function removeDerivativeOperation($operation, $operationSet) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class');
 	return GalleryDerivativeHelper_advanced::removeOperation($operation, $operationSet);
@@ -1123,7 +1123,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array(GalleryItem id => GalleryDerivativeImage, ...)
      */
-    function fetchDerivativesBySourceIds($ids, $types=array()) {
+    static function fetchDerivativesBySourceIds($ids, $types=array()) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class');
 	return GalleryDerivativeHelper_advanced::fetchDerivativesBySourceIds($ids, $types);
@@ -1136,7 +1136,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array(GalleryItem id => GalleryDerivativeImage, ...)
      */
-    function fetchDerivativesByItemIds($ids) {
+    static function fetchDerivativesByItemIds($ids) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class');
 	return GalleryDerivativeHelper_advanced::fetchDerivativesByItemIds($ids);
@@ -1155,7 +1155,7 @@ class GalleryCoreApi {
      * @param boolean $reverse (optional) true if we should apply the transform in reverse
      * @return GalleryStatus a status code
      */
-    function adjustDependentDerivatives($id, $operation, $reverse=false) {
+    static function adjustDependentDerivatives($id, $operation, $reverse=false) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class');
 	return GalleryDerivativeHelper_advanced::adjustDependentDerivatives($id, $operation,
@@ -1173,7 +1173,7 @@ class GalleryCoreApi {
      * @param int $serialNumber (optional) avoid concurrent edits
      * @return GalleryStatus a status code
      */
-    function applyToolkitOperation($operation, $args, $preserveOriginal,
+    static function applyToolkitOperation($operation, $args, $preserveOriginal,
 				   &$item, $preferred=null, $serialNumber=null) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class');
@@ -1188,7 +1188,7 @@ class GalleryCoreApi {
      * @param string $newSourceId the new source id
      * @return GalleryStatus a status code
      */
-    function remapSourceIds($originalSourceId, $newSourceId) {
+    static function remapSourceIds($originalSourceId, $newSourceId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class');
 	return GalleryDerivativeHelper_advanced::remapSourceIds($originalSourceId, $newSourceId);
@@ -1202,7 +1202,7 @@ class GalleryCoreApi {
      * @param int $targetId the target id
      * @return GalleryStatus a status code
      */
-    function copyDerivativePreferences($sourceId, $targetId) {
+    static function copyDerivativePreferences($sourceId, $targetId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class');
 	return GalleryDerivativeHelper_advanced::copyPreferences($sourceId, $targetId);
@@ -1215,7 +1215,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array (derivativeType => ..., derivativeOperations => ...)
      */
-    function fetchDerivativePreferencesForItem($targetId) {
+    static function fetchDerivativePreferencesForItem($targetId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class');
 	return GalleryDerivativeHelper_advanced::fetchPreferencesForItem($targetId);
@@ -1230,7 +1230,7 @@ class GalleryCoreApi {
      * @param string $derivativeOperations (eg. 'thumbnail|200')
      * @return GalleryStatus a status code
      */
-    function addDerivativePreference($order, $itemId, $derivativeType, $derivativeOperations) {
+    static function addDerivativePreference($order, $itemId, $derivativeType, $derivativeOperations) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class');
 	return GalleryDerivativeHelper_advanced::addPreference($order, $itemId, $derivativeType,
@@ -1244,7 +1244,7 @@ class GalleryCoreApi {
      * @param int $derivativeType
      * @return GalleryStatus a status code
      */
-    function removeDerivativePreferenceForItemType($itemId, $derivativeType) {
+    static function removeDerivativePreferenceForItemType($itemId, $derivativeType) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class');
 	return GalleryDerivativeHelper_advanced::removePreferenceForItemType($itemId,
@@ -1257,7 +1257,7 @@ class GalleryCoreApi {
      * @param int $itemId
      * @return GalleryStatus a status code
      */
-    function removeDerivativePreferencesForItem($itemId) {
+    static function removeDerivativePreferencesForItem($itemId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class');
 	return GalleryDerivativeHelper_advanced::removePreferencesForItem($itemId);
@@ -1273,7 +1273,7 @@ class GalleryCoreApi {
      *               (probably a GalleryPhotoItem or GalleryMovieItem)
      * @return GalleryStatus a status code
      */
-    function estimateDerivativeDimensions(&$derivative, $source) {
+    static function estimateDerivativeDimensions(&$derivative, $source) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryToolkitHelper_medium.class');
 	return GalleryToolkitHelper_medium::estimateDerivativeDimensions($derivative, $source);
@@ -1285,7 +1285,7 @@ class GalleryCoreApi {
      * @param int $entityId
      * @return GalleryStatus a status code
      */
-    function updateModificationTimestamp($entityId) {
+    static function updateModificationTimestamp($entityId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryEntityHelper_medium.class');
 	return GalleryEntityHelper_medium::updateModificationTimestamp($entityId);
@@ -1297,7 +1297,7 @@ class GalleryCoreApi {
      * @param int $step the amount to increment
      * @return GalleryStatus a status code
      */
-    function incrementItemViewCount($itemId, $step=1) {
+    static function incrementItemViewCount($itemId, $step=1) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemAttributesHelper_simple.class');
 	return GalleryItemAttributesHelper_simple::incrementViewCount($itemId, $step);
@@ -1309,7 +1309,7 @@ class GalleryCoreApi {
      * @param array $parentSequence the sequence of parent ids
      * @return GalleryStatus a status code
      */
-    function createItemAttributes($itemId, $parentSequence) {
+    static function createItemAttributes($itemId, $parentSequence) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemAttributesHelper_advanced.class');
 	return GalleryItemAttributesHelper_advanced::createItemAttributes($itemId, $parentSequence);
@@ -1320,7 +1320,7 @@ class GalleryCoreApi {
      * @param int $itemId
      * @return GalleryStatus a status code
      */
-    function removeItemAttributes($itemId) {
+    static function removeItemAttributes($itemId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemAttributesHelper_advanced.class');
 	return GalleryItemAttributesHelper_advanced::removeItemAttributes($itemId);
@@ -1332,7 +1332,7 @@ class GalleryCoreApi {
      * @param int $count the new count
      * @return GalleryStatus a status code
      */
-    function setItemViewCount($itemId, $count) {
+    static function setItemViewCount($itemId, $count) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemAttributesHelper_advanced.class');
 	return GalleryItemAttributesHelper_advanced::setViewCount($itemId, $count);
@@ -1344,7 +1344,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               int view count
      */
-    function fetchItemViewCount($itemId) {
+    static function fetchItemViewCount($itemId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemAttributesHelper_simple.class');
 	return GalleryItemAttributesHelper_simple::fetchViewCount($itemId);
@@ -1356,7 +1356,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array (itemId => viewCount, ..)
      */
-    function fetchItemViewCounts($itemIds) {
+    static function fetchItemViewCounts($itemIds) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemAttributesHelper_simple.class');
 	return GalleryItemAttributesHelper_simple::fetchViewCounts($itemIds);
@@ -1368,7 +1368,7 @@ class GalleryCoreApi {
      * @param int $orderWeight the new order weight
      * @return GalleryStatus a status code
      */
-    function setItemOrderWeight($itemId, $orderWeight) {
+    static function setItemOrderWeight($itemId, $orderWeight) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemAttributesHelper_advanced.class');
 	return GalleryItemAttributesHelper_advanced::setOrderWeight($itemId, $orderWeight);
@@ -1380,7 +1380,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               int the order weight
      */
-    function fetchItemOrderWeight($itemId) {
+    static function fetchItemOrderWeight($itemId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemAttributesHelper_medium.class');
 	return GalleryItemAttributesHelper_medium::fetchOrderWeight($itemId);
@@ -1393,7 +1393,7 @@ class GalleryCoreApi {
      *               array(itemId1 => orderWeight1,
      *                     itemId2 => orderWeight2, ...)
      */
-    function fetchItemOrderWeights($itemIds) {
+    static function fetchItemOrderWeights($itemIds) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemAttributesHelper_medium.class');
 	return GalleryItemAttributesHelper_medium::fetchOrderWeights($itemIds);
@@ -1408,7 +1408,7 @@ class GalleryCoreApi {
      * @param int $spacing the order spacing
      * @return GalleryStatus a status code
      */
-    function rebalanceChildOrderWeights($parentItemId, $spacing=1000) {
+    static function rebalanceChildOrderWeights($parentItemId, $spacing=1000) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemAttributesHelper_advanced.class');
 	return GalleryItemAttributesHelper_advanced::rebalanceChildOrderWeights($parentItemId,
@@ -1421,7 +1421,7 @@ class GalleryCoreApi {
      * @param int $direction the direction (HIGHER_WEIGHT, LOWER_WEIGHT)
      * @return int a weight
      */
-    function fetchExtremeChildWeight($itemId, $direction) {
+    static function fetchExtremeChildWeight($itemId, $direction) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemAttributesHelper_advanced.class');
 	return GalleryItemAttributesHelper_advanced::fetchExtremeChildWeight($itemId, $direction);
@@ -1434,7 +1434,7 @@ class GalleryCoreApi {
      * @param int $direction the direction (HIGHER_WEIGHT, LOWER_WEIGHT)
      * @return int a weight
      */
-    function fetchNextItemWeight($itemId, $direction) {
+    static function fetchNextItemWeight($itemId, $direction) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemAttributesHelper_advanced.class');
 	return GalleryItemAttributesHelper_advanced::fetchNextWeight($itemId, $direction);
@@ -1447,7 +1447,7 @@ class GalleryCoreApi {
      * @param array $parentSequence the parent sequence (ids)
      * @return GalleryStatus a status code
      */
-    function setParentSequence($itemId, $parentSequence) {
+    static function setParentSequence($itemId, $parentSequence) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemAttributesHelper_advanced.class');
 	return GalleryItemAttributesHelper_advanced::setParentSequence($itemId, $parentSequence);
@@ -1460,7 +1460,7 @@ class GalleryCoreApi {
      * @param array $newParentSequence the parent sequence (ids)
      * @return GalleryStatus a status code
      */
-    function updateParentSequence($oldParentSequence, $newParentSequence) {
+    static function updateParentSequence($oldParentSequence, $newParentSequence) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemAttributesHelper_advanced.class');
 	return GalleryItemAttributesHelper_advanced::updateParentSequence($oldParentSequence,
@@ -1474,7 +1474,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array the parent id sequence from root album down; given itemId not included
      */
-    function fetchParentSequence($itemId, $filterBreadcrumb=false) {
+    static function fetchParentSequence($itemId, $filterBreadcrumb=false) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemAttributesHelper_simple.class');
 	return GalleryItemAttributesHelper_simple::fetchParentSequence($itemId, $filterBreadcrumb);
@@ -1488,7 +1488,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               string a theme plugi
      */
-    function fetchThemeId($item) {
+    static function fetchThemeId($item) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryItemHelper_simple.class');
 	return GalleryItemHelper_simple::fetchThemeId($item);
     }
@@ -1501,7 +1501,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array (itemId => count, itemId => count, ...)
      */
-    function fetchChildCounts($itemIds, $userId=null) {
+    static function fetchChildCounts($itemIds, $userId=null) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryItemHelper_simple.class');
 	return GalleryItemHelper_simple::fetchChildCounts($itemIds, $userId);
     }
@@ -1514,7 +1514,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array(id => ##, id => ##)
      */
-    function fetchDescendentCounts($itemIds, $userId=null) {
+    static function fetchDescendentCounts($itemIds, $userId=null) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryItemHelper_simple.class');
 	return GalleryItemHelper_simple::fetchDescendentCounts($itemIds, $userId);
     }
@@ -1530,7 +1530,7 @@ class GalleryCoreApi {
      *                     id => array('GalleryAlbumItem' => ##,
      *                                 'GalleryDataItem' => ##))
      */
-    function fetchItemizedDescendentCounts($itemIds) {
+    static function fetchItemizedDescendentCounts($itemIds) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemHelper_advanced.class');
 	return GalleryItemHelper_advanced::fetchItemizedDescendentCounts($itemIds);
@@ -1545,7 +1545,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               int a count
      */
-    function fetchItemIdCount($itemType, $permission='core.view', $userId=null) {
+    static function fetchItemIdCount($itemType, $permission='core.view', $userId=null) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryItemHelper_simple.class');
 	return GalleryItemHelper_simple::fetchItemIdCount($itemType, $permission, $userId);
     }
@@ -1560,7 +1560,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array a list of ids
      */
-    function fetchChildItemIdsWithPermission($itemId, $permissionId) {
+    static function fetchChildItemIdsWithPermission($itemId, $permissionId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryChildEntityHelper_simple.class');
 	return GalleryChildEntityHelper_simple::fetchChildItemIdsWithPermission($itemId,
@@ -1579,7 +1579,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array a list of ids
      */
-    function fetchLinkableChildItemIdsWithPermission($itemId, $permissionId) {
+    static function fetchLinkableChildItemIdsWithPermission($itemId, $permissionId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryChildEntityHelper_simple.class');
 	return GalleryChildEntityHelper_simple::fetchLinkableChildItemIdsWithPermission($itemId,
@@ -1595,7 +1595,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array(id, id, id, ...)
      */
-    function fetchAllItemIds($itemType, $permission='core.view') {
+    static function fetchAllItemIds($itemType, $permission='core.view') {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryItemHelper_medium.class');
 	return GalleryItemHelper_medium::fetchAllItemIds($itemType, $permission);
     }
@@ -1608,7 +1608,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array(id, id, id, ...)
      */
-    function fetchAllItemIdsByOwnerId($ownerId) {
+    static function fetchAllItemIdsByOwnerId($ownerId) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryItemHelper_medium.class');
 	return GalleryItemHelper_medium::fetchAllItemIdsByOwnerId($ownerId);
     }
@@ -1622,7 +1622,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               GalleryItem an item
      */
-    function newItemByMimeType($mimeType) {
+    static function newItemByMimeType($mimeType) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryItemHelper_medium.class');
 	return GalleryItemHelper_medium::newItemByMimeType($mimeType);
     }
@@ -1639,7 +1639,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               GalleryAlbumItem a new album
      */
-    function createAlbum($parentAlbumId, $name, $title, $summary, $description, $keywords) {
+    static function createAlbum($parentAlbumId, $name, $title, $summary, $description, $keywords) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemHelper_advanced.class');
 	return GalleryItemHelper_advanced::createAlbum($parentAlbumId, $name, $title, $summary,
@@ -1661,7 +1661,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               GalleryDataItem a new item
      */
-    function addItemToAlbum($fileName, $itemName, $title, $summary,
+    static function addItemToAlbum($fileName, $itemName, $title, $summary,
 			    $description, $mimeType, $albumId, $symlink=false) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryItemHelper_medium.class');
 	return GalleryItemHelper_medium::addItemToAlbum(
@@ -1676,7 +1676,7 @@ class GalleryCoreApi {
      * @param boolean $isNew (optional) if true, skip check for existing derivatives
      * @return GalleryStatus a status code
      */
-    function addExistingItemToAlbum($item, $albumId, $isNew=false) {
+    static function addExistingItemToAlbum($item, $albumId, $isNew=false) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryItemHelper_medium.class');
 	return GalleryItemHelper_medium::addExistingItemToAlbum($item, $albumId, $isNew);
     }
@@ -1689,7 +1689,7 @@ class GalleryCoreApi {
      * @param boolean $isNew (optional) if true, skip check for existing derivatives
      * @return GalleryStatus a status code
      */
-    function applyDerivativePreferences($item, $albumId, $isNew=false) {
+    static function applyDerivativePreferences($item, $albumId, $isNew=false) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryItemHelper_medium.class');
 	return GalleryItemHelper_medium::applyDerivativePreferences($item, $albumId, $isNew);
     }
@@ -1701,7 +1701,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               int a timestamp or null if nothing was found
      */
-    function fetchOriginationTimestamp($item) {
+    static function fetchOriginationTimestamp($item) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryItemHelper_medium.class');
 	return GalleryItemHelper_medium::fetchOriginationTimestamp($item);
     }
@@ -1715,7 +1715,7 @@ class GalleryCoreApi {
      * @return GalleryStatus a status code
      *                boolean true if successful
      */
-    function setThumbnailFromItem($itemId, $fromItemId) {
+    static function setThumbnailFromItem($itemId, $fromItemId) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryItemHelper_medium.class');
 	return GalleryItemHelper_medium::setThumbnailFromItem($itemId, $fromItemId);
     }
@@ -1728,7 +1728,7 @@ class GalleryCoreApi {
      * @return GalleryStatus a status code
      *                boolean true if successful
      */
-    function guaranteeAlbumHasThumbnail($itemId) {
+    static function guaranteeAlbumHasThumbnail($itemId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemHelper_advanced.class');
 	return GalleryItemHelper_advanced::guaranteeAlbumHasThumbnail($itemId);
@@ -1744,7 +1744,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array (albumId => array(albumId => array, ..), ..)
      */
-    function fetchAlbumTree($itemId=null, $depth=null, $userId=null) {
+    static function fetchAlbumTree($itemId=null, $depth=null, $userId=null) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemHelper_simple.class');
 	return GalleryItemHelper_simple::fetchAlbumTree($itemId, $depth, $userId);
@@ -1757,7 +1757,7 @@ class GalleryCoreApi {
      * @param int $newUserId the user id of the new owner
      * @return GalleryStatus a status code
      */
-    function remapOwnerId($oldUserId, $newUserId) {
+    static function remapOwnerId($oldUserId, $newUserId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemHelper_advanced.class');
 	return GalleryItemHelper_advanced::remapOwnerId($oldUserId, $newUserId);
@@ -1770,7 +1770,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               boolean true if yes
      */
-    function isUserInSiteAdminGroup($userId=null) {
+    static function isUserInSiteAdminGroup($userId=null) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryUserGroupHelper_simple.class');
 	return GalleryUserGroupHelper_simple::isUserInSiteAdminGroup($userId);
@@ -1784,7 +1784,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               boolean true if yes
      */
-    function isUserInGroup($userId, $groupId) {
+    static function isUserInGroup($userId, $groupId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryUserGroupHelper_simple.class');
 	return GalleryUserGroupHelper_simple::isUserInGroup($userId, $groupId);
@@ -1797,7 +1797,7 @@ class GalleryCoreApi {
      * @param int $groupId
      * @return GalleryStatus a status code
      */
-    function addUserToGroup($userId, $groupId) {
+    static function addUserToGroup($userId, $groupId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryUserGroupHelper_medium.class');
 	return GalleryUserGroupHelper_medium::addUserToGroup($userId, $groupId);
@@ -1810,7 +1810,7 @@ class GalleryCoreApi {
      * @param int $groupId
      * @return GalleryStatus a status code
      */
-    function removeUserFromGroup($userId, $groupId) {
+    static function removeUserFromGroup($userId, $groupId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryUserGroupHelper_medium.class');
 	return GalleryUserGroupHelper_medium::removeUserFromGroup($userId, $groupId);
@@ -1822,7 +1822,7 @@ class GalleryCoreApi {
      * @param int $userId
      * @return GalleryStatus a status code
      */
-    function removeUserFromAllGroups($userId) {
+    static function removeUserFromAllGroups($userId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryUserGroupHelper_medium.class');
 	return GalleryUserGroupHelper_medium::removeUserFromAllGroups($userId);
@@ -1834,7 +1834,7 @@ class GalleryCoreApi {
      * @param int $groupId
      * @return GalleryStatus a status code
      */
-    function removeAllUsersFromGroup($groupId) {
+    static function removeAllUsersFromGroup($groupId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryUserGroupHelper_medium.class');
 	return GalleryUserGroupHelper_medium::removeAllUsersFromGroup($groupId);
@@ -1853,7 +1853,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array user id => user name
      */
-    function fetchUsersForGroup($groupId, $count=null, $offset=null, $substring=null) {
+    static function fetchUsersForGroup($groupId, $count=null, $offset=null, $substring=null) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryUserGroupHelper_medium.class');
 	return GalleryUserGroupHelper_medium::fetchUsersForGroup($groupId, $count,
@@ -1870,7 +1870,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array group id => group name
      */
-    function fetchGroupsForUser($userId, $count=null, $offset=null) {
+    static function fetchGroupsForUser($userId, $count=null, $offset=null) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryUserGroupHelper_simple.class');
 	return GalleryUserGroupHelper_simple::fetchGroupsForUser($userId, $count, $offset);
@@ -1883,7 +1883,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               string code of preferred locale
      */
-    function fetchLanguageCodeForUser($userId) {
+    static function fetchLanguageCodeForUser($userId) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryUserHelper_medium.class');
 	return GalleryUserHelper_medium::fetchLanguageCodeForUser($userId);
     }
@@ -1895,7 +1895,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               int the item id
      */
-    function fetchItemIdByPath($path) {
+    static function fetchItemIdByPath($path) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryFileSystemEntityHelper_simple.class');
 	return GalleryFileSystemEntityHelper_simple::fetchItemIdByPath($path);
@@ -1910,7 +1910,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               boolean true if there's a collision
      */
-    function checkPathCollision($pathComponent, $parentId, $selfId=null) {
+    static function checkPathCollision($pathComponent, $parentId, $selfId=null) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryFileSystemEntityHelper_medium.class');
 	return GalleryFileSystemEntityHelper_medium::checkPathCollision($pathComponent,
@@ -1929,7 +1929,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               string the legal path component
      */
-    function getLegalPathComponent($pathComponent, $parentId, $selfId=null, $forDirectory=false) {
+    static function getLegalPathComponent($pathComponent, $parentId, $selfId=null, $forDirectory=false) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryFileSystemEntityHelper_medium.class');
 	return GalleryFileSystemEntityHelper_medium::getLegalPathComponent(
@@ -1945,7 +1945,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               int an id
      */
-    function fetchChildIdByPathComponent($parentId, $pathComponent) {
+    static function fetchChildIdByPathComponent($parentId, $pathComponent) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryFileSystemEntityHelper_simple.class');
 	return GalleryFileSystemEntityHelper_simple::fetchChildIdByPathComponent($parentId,
@@ -1968,7 +1968,7 @@ class GalleryCoreApi {
      * @param int $priority priority of this implementation vs other toolkits
      * @return GalleryStatus a status code
      */
-    function registerToolkitOperation($toolkitId, $mimeTypes, $operationName,
+    static function registerToolkitOperation($toolkitId, $mimeTypes, $operationName,
 				      $parameterTypesArray, $description,
 				      $outputMimeType='', $priority=5) {
 	GalleryCoreApi::requireOnce(
@@ -1986,7 +1986,7 @@ class GalleryCoreApi {
      * @param array $mimeTypes the applicable mime types to remove; empty for all mime types
      * @return GalleryStatus a status code
      */
-    function unregisterToolkitOperation($toolkitId, $operationName, $mimeTypes=array()) {
+    static function unregisterToolkitOperation($toolkitId, $operationName, $mimeTypes=array()) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryToolkitHelper_medium.class');
 	return GalleryToolkitHelper_medium::unregisterOperation($toolkitId, $operationName,
@@ -1999,7 +1999,7 @@ class GalleryCoreApi {
      * @param string $moduleId
      * @return GalleryStatus a status code
      */
-    function unregisterToolkitsByModuleId($moduleId) {
+    static function unregisterToolkitsByModuleId($moduleId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryToolkitHelper_medium.class');
 	return GalleryToolkitHelper_medium::unregisterToolkitsByModuleId($moduleId);
@@ -2019,7 +2019,7 @@ class GalleryCoreApi {
      * @param string $description a translatable description of this property
      * @return GalleryStatus a status code
      */
-    function registerToolkitProperty($toolkitId, $mimeTypes, $propertyName, $type, $description) {
+    static function registerToolkitProperty($toolkitId, $mimeTypes, $propertyName, $type, $description) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryToolkitHelper_medium.class');
 	return GalleryToolkitHelper_medium::registerProperty($toolkitId, $mimeTypes,
@@ -2033,7 +2033,7 @@ class GalleryCoreApi {
      * @param string $toolkitId
      * @return GalleryStatus a status code
      */
-    function unregisterToolkit($toolkitId) {
+    static function unregisterToolkit($toolkitId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryToolkitHelper_medium.class');
 	return GalleryToolkitHelper_medium::unregisterToolkit($toolkitId);
@@ -2051,7 +2051,7 @@ class GalleryCoreApi {
      *                                        'description' => ...),
      *                                  ...)
      */
-    function getToolkitOperations($mimeType) {
+    static function getToolkitOperations($mimeType) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryToolkitHelper_medium.class');
 	return GalleryToolkitHelper_medium::getOperations($mimeType);
@@ -2064,7 +2064,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array(mime type => array(toolkit ids, sorted by priority))
      */
-    function getToolkitOperationMimeTypes($operationName) {
+    static function getToolkitOperationMimeTypes($operationName) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryToolkitHelper_medium.class');
 	return GalleryToolkitHelper_medium::getOperationMimeTypes($operationName);
@@ -2080,7 +2080,7 @@ class GalleryCoreApi {
      *               )
      *
      */
-    function getToolkitProperties($mimeType) {
+    static function getToolkitProperties($mimeType) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryToolkitHelper_medium.class');
 	return GalleryToolkitHelper_medium::getProperties($mimeType);
@@ -2095,7 +2095,7 @@ class GalleryCoreApi {
      *               GalleryToolkit a toolkit
      *               string a result mime type
      */
-    function getToolkitByOperation($mimeType, $operationName) {
+    static function getToolkitByOperation($mimeType, $operationName) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryToolkitHelper_simple.class');
 	return GalleryToolkitHelper_simple::getToolkitByOperation($mimeType, $operationName);
@@ -2112,7 +2112,7 @@ class GalleryCoreApi {
      *         boolean true if supported, false if not
      *         string the output mime type
      */
-    function isSupportedOperationSequence($mimeType, $operations) {
+    static function isSupportedOperationSequence($mimeType, $operations) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryToolkitHelper_medium.class');
 	return GalleryToolkitHelper_medium::isSupportedOperationSequence($mimeType, $operations);
@@ -2129,7 +2129,7 @@ class GalleryCoreApi {
      *               string a sequence of operations, null if not supported
      *               string the output mime type, null if not supported
      */
-    function makeSupportedViewableOperationSequence($mimeType, $operations,
+    static function makeSupportedViewableOperationSequence($mimeType, $operations,
 						    $prependConversion=true) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryToolkitHelper_medium.class');
@@ -2145,7 +2145,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               GalleryToolkit a toolkit
      */
-    function getToolkitByProperty($mimeType, $propertyName) {
+    static function getToolkitByProperty($mimeType, $propertyName) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryToolkitHelper_simple.class');
 	return GalleryToolkitHelper_simple::getToolkitByProperty($mimeType, $propertyName);
@@ -2159,7 +2159,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array of toolkitIds
      */
-    function getToolkitsByProperty($mimeType, $propertyName) {
+    static function getToolkitsByProperty($mimeType, $propertyName) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryToolkitHelper_simple.class');
 	return GalleryToolkitHelper_simple::getToolkitsByProperty($mimeType, $propertyName);
@@ -2171,7 +2171,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               int priority
      */
-    function getMaximumManagedToolkitPriority() {
+    static function getMaximumManagedToolkitPriority() {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryToolkitHelper_simple.class');
 	return GalleryToolkitHelper_simple::getMaximumManagedPriority();
@@ -2184,7 +2184,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               int priority
      */
-    function getToolkitPriorityById($toolkitId) {
+    static function getToolkitPriorityById($toolkitId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryToolkitHelper_simple.class');
 	return GalleryToolkitHelper_simple::getToolkitPriorityById($toolkitId);
@@ -2221,7 +2221,7 @@ class GalleryCoreApi {
      * @param boolean $disableForUnitTests (optional) if true, disable event listener during tests
      * @deprecated Use GalleryCoreApi::registerFactoryImplementation('GalleryEventListener', ...
      */
-    function registerEventListener($eventName, &$eventListener, $disableForUnitTests=false) {
+    static function registerEventListener($eventName, &$eventListener, $disableForUnitTests=false) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryEventHelper_simple.class');
 	return GalleryEventHelper_simple::registerEventListener(
 	    $eventName, $eventListener, $disableForUnitTests);
@@ -2233,7 +2233,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array data returned from listeners, if any
      */
-    function postEvent($event) {
+    static function postEvent($event) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryEventHelper_simple.class');
 	return GalleryEventHelper_simple::postEvent($event);
     }
@@ -2247,7 +2247,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               int the lock id
      */
-    function acquireReadLock($ids, $timeout=10) {
+    static function acquireReadLock($ids, $timeout=10) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryLockHelper_simple.class');
 	return GalleryLockHelper_simple::acquireReadLock($ids, $timeout);
     }
@@ -2262,7 +2262,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               int the lock id
      */
-    function acquireReadLockParents($id, $timeout=10) {
+    static function acquireReadLockParents($id, $timeout=10) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryLockHelper_simple.class');
 	return GalleryLockHelper_simple::acquireReadLockParents($id, $timeout);
     }
@@ -2273,7 +2273,7 @@ class GalleryCoreApi {
      * @param int $id an entity id
      * @return boolean true if the entity is read locked
      */
-    function isReadLocked($id) {
+    static function isReadLocked($id) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryLockHelper_simple.class');
 	return GalleryLockHelper_simple::isReadLocked($id);
     }
@@ -2286,7 +2286,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               int the lock id
      */
-    function acquireWriteLock($ids, $timeout=10) {
+    static function acquireWriteLock($ids, $timeout=10) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryLockHelper_simple.class');
 	return GalleryLockHelper_simple::acquireWriteLock($ids, $timeout);
     }
@@ -2297,7 +2297,7 @@ class GalleryCoreApi {
      * @param int $id an entity id
      * @return boolean true if the entity is write locked
      */
-    function isWriteLocked($id) {
+    static function isWriteLocked($id) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryLockHelper_simple.class');
 	return GalleryLockHelper_simple::isWriteLocked($id);
     }
@@ -2308,7 +2308,7 @@ class GalleryCoreApi {
      * @param mixed $lockIds array of lock ids, or a single lock id
      * @return GalleryStatus a status code
      */
-    function releaseLocks($lockIds) {
+    static function releaseLocks($lockIds) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryLockHelper_simple.class');
 	return GalleryLockHelper_simple::releaseLocks($lockIds);
     }
@@ -2318,7 +2318,7 @@ class GalleryCoreApi {
      *
      * @return GalleryStatus a status code
      */
-    function releaseAllLocks() {
+    static function releaseAllLocks() {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryLockHelper_simple.class');
 	return GalleryLockHelper_simple::releaseAllLocks();
     }
@@ -2329,7 +2329,7 @@ class GalleryCoreApi {
      * @param int $freshUntil the new "fresh until" timestamp
      * @return GalleryStatus a status code
      */
-    function refreshLocks($freshUntil) {
+    static function refreshLocks($freshUntil) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryLockHelper_simple.class');
 	return GalleryLockHelper_simple::refreshLocks($freshUntil);
     }
@@ -2339,7 +2339,7 @@ class GalleryCoreApi {
      *
      * @return object array of lock ids
      */
-    function getLockIds() {
+    static function getLockIds() {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryLockHelper_simple.class');
 	return GalleryLockHelper_simple::getLockIds();
     }
@@ -2371,7 +2371,7 @@ class GalleryCoreApi {
      * @return GalleryStatus a status code
      * @deprecated $requiredEntityType will no longer be optional after the next major API change
      */
-    function deleteEntityById($id, $requiredEntityType=null) {
+    static function deleteEntityById($id, $requiredEntityType=null) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryEntityHelper_medium.class');
 	return GalleryEntityHelper_medium::deleteEntityById($id, $requiredEntityType);
@@ -2384,7 +2384,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array entity ids
      */
-    function fetchEntitiesLinkedTo($targetId) {
+    static function fetchEntitiesLinkedTo($targetId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryEntityHelper_medium.class');
 	return GalleryEntityHelper_medium::fetchEntitiesLinkedTo($targetId);
@@ -2398,7 +2398,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               GalleryEntity
      */
-    function loadEntityByExternalId($externalId, $entityType) {
+    static function loadEntityByExternalId($externalId, $entityType) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryEntityHelper_simple.class');
 	return GalleryEntityHelper_simple::loadEntityByExternalId($externalId, $entityType);
@@ -2410,7 +2410,7 @@ class GalleryCoreApi {
      * @param array $handlerIds of factory impl ids
      * @return GalleryStatus a status code
      */
-    function removeOnLoadHandlers($handlerIds) {
+    static function removeOnLoadHandlers($handlerIds) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryEntityHelper_medium.class');
 	return GalleryEntityHelper_medium::removeOnLoadHandlers($handlerIds);
@@ -2426,7 +2426,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array integer ids
      */
-    function fetchDescendentItemIds($item, $offset=null, $count=null, $permission='core.view') {
+    static function fetchDescendentItemIds($item, $offset=null, $count=null, $permission='core.view') {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryChildEntityHelper_simple.class');
 	return GalleryChildEntityHelper_simple::fetchDescendentItemIds($item, $offset,
@@ -2444,7 +2444,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array integer ids
      */
-    function fetchChildItemIds($item, $offset=null, $count=null, $userId=null) {
+    static function fetchChildItemIds($item, $offset=null, $count=null, $userId=null) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryChildEntityHelper_simple.class');
 	return GalleryChildEntityHelper_simple::fetchChildItemIds($item, $offset, $count, $userId);
@@ -2460,7 +2460,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array integer ids
      */
-    function fetchDescendentAlbumItemIds($item, $offset=null, $count=null,
+    static function fetchDescendentAlbumItemIds($item, $offset=null, $count=null,
 					 $permission='core.view') {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryChildEntityHelper_simple.class');
@@ -2478,7 +2478,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array integer ids
      */
-    function fetchChildAlbumItemIds($item, $offset=null, $count=null, $userId=null) {
+    static function fetchChildAlbumItemIds($item, $offset=null, $count=null, $userId=null) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryChildEntityHelper_simple.class');
 	return GalleryChildEntityHelper_simple::fetchChildAlbumItemIds($item, $offset,
@@ -2495,7 +2495,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array integer ids
      */
-    function fetchChildDataItemIds($item, $offset=null, $count=null, $userId=null) {
+    static function fetchChildDataItemIds($item, $offset=null, $count=null, $userId=null) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryChildEntityHelper_simple.class');
 	return GalleryChildEntityHelper_simple::fetchChildDataItemIds($item, $offset,
@@ -2511,7 +2511,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array integer ids
      */
-    function fetchChildItemIdsIgnorePermissions($item, $offset=null, $count=null) {
+    static function fetchChildItemIdsIgnorePermissions($item, $offset=null, $count=null) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryChildEntityHelper_simple.class');
 	return GalleryChildEntityHelper_simple::fetchChildItemIdsIgnorePermissions($item, $offset,
@@ -2528,7 +2528,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array of GalleryItem, from top level to parent item
      */
-    function fetchParents($item, $permission=null, $filterBreadcrumb=false) {
+    static function fetchParents($item, $permission=null, $filterBreadcrumb=false) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryChildEntityHelper_simple.class');
 	return GalleryChildEntityHelper_simple::fetchParents($item, $permission, $filterBreadcrumb);
@@ -2551,7 +2551,7 @@ class GalleryCoreApi {
      *               string query
      *               array data items for query (not including any ? marks in baseQuery)
      */
-    function buildItemQuery($baseTable, $baseIdColumn, $baseQuery, $orderBy, $orderDirection,
+    static function buildItemQuery($baseTable, $baseIdColumn, $baseQuery, $orderBy, $orderDirection,
 			    $class, $requiredPermission, $linkableOnly, $userId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryChildEntityHelper_simple.class');
@@ -2567,7 +2567,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               string a mime type (application/unknown if no known mapping)
      */
-    function convertExtensionToMime($extension) {
+    static function convertExtensionToMime($extension) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryMimeTypeHelper_simple.class');
 	return GalleryMimeTypeHelper_simple::convertExtensionToMime($extension);
@@ -2580,7 +2580,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array of file extensions (empty array if no known mapping)
      */
-    function convertMimeToExtensions($mimeType) {
+    static function convertMimeToExtensions($mimeType) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryMimeTypeHelper_simple.class');
 	return GalleryMimeTypeHelper_simple::convertMimeToExtensions($mimeType);
@@ -2595,7 +2595,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               string a mime type (application/unknown if no known extension)
      */
-    function getMimeType($filename, $requestMimeType=null) {
+    static function getMimeType($filename, $requestMimeType=null) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryMimeTypeHelper_simple.class');
 	return GalleryMimeTypeHelper_simple::getMimeType($filename, $requestMimeType);
@@ -2608,7 +2608,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               boolean
      */
-    function isViewableMimeType($mimeType) {
+    static function isViewableMimeType($mimeType) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryMimeTypeHelper_simple.class');
 	return GalleryMimeTypeHelper_simple::isViewableMimeType($mimeType);
@@ -2621,7 +2621,7 @@ class GalleryCoreApi {
      * @param array $mimeMatch (keys/values to delete)
      * @return GalleryStatus a status code
      */
-    function removeMimeType($mimeMatch) {
+    static function removeMimeType($mimeMatch) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryMimeTypeHelper_advanced.class');
 	return GalleryMimeTypeHelper_advanced::removeMimeType($mimeMatch);
@@ -2638,7 +2638,7 @@ class GalleryCoreApi {
      * @param bool $viewable whether or not it's browser viewable
      * @return GalleryStatus a status code
      */
-    function addMimeType($extension, $mimeType, $viewable) {
+    static function addMimeType($extension, $mimeType, $viewable) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryMimeTypeHelper_advanced.class');
 	return GalleryMimeTypeHelper_advanced::addMimeType($extension, $mimeType, $viewable);
@@ -2655,7 +2655,7 @@ class GalleryCoreApi {
      * @return array(boolean success, http response, headers, url)
      *  the url is the final url retrieved after redirects
      */
-    function fetchWebFile($url, $outputFile, $extraHeaders=array(), $postDataArray=array()) {
+    static function fetchWebFile($url, $outputFile, $extraHeaders=array(), $postDataArray=array()) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/WebHelper_simple.class');
 	return WebHelper_simple::fetchWebFile($url, $outputFile, $extraHeaders, $postDataArray);
     }
@@ -2669,7 +2669,7 @@ class GalleryCoreApi {
      * @return array(boolean success, string body, http response, headers, url)
      *	the url is the final url retrieved after redirects
      */
-    function fetchWebPage($url, $extraHeaders=array()) {
+    static function fetchWebPage($url, $extraHeaders=array()) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/WebHelper_simple.class');
 	return WebHelper_simple::fetchWebPage($url, $extraHeaders);
     }
@@ -2682,7 +2682,7 @@ class GalleryCoreApi {
      * @param array $extraHeaders (optional) extra headers to pass to the server
      * @return array(body, http response, headers)
      */
-    function postToWebPage($url, $postDataArray, $extraHeaders=array()) {
+    static function postToWebPage($url, $postDataArray, $extraHeaders=array()) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/WebHelper_simple.class');
 	return WebHelper_simple::postToWebPage($url, $postDataArray, $extraHeaders);
     }
@@ -2695,7 +2695,7 @@ class GalleryCoreApi {
      * @param string $requestBody (optional) the request body to pass to the server
      * @return array($responseStatus, $responseHeaders, $responseBody)
      */
-    function requestWebPage($url, $requestMethod='GET', $requestHeaders=array(), $requestBody='') {
+    static function requestWebPage($url, $requestMethod='GET', $requestHeaders=array(), $requestBody='') {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/WebHelper_simple.class');
 	return WebHelper_simple::requestWebPage(
 	    $url, $requestMethod, $requestHeaders, $requestBody);
@@ -2721,7 +2721,7 @@ class GalleryCoreApi {
      * @param string $targetEncoding target encoding (eg. 'ISO-8859-1'), defaults to system charset
      * @return string the result
      */
-    function convertFromUtf8($inputString, $targetEncoding=null) {
+    static function convertFromUtf8($inputString, $targetEncoding=null) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryCharsetHelper_simple.class');
 	return GalleryCharsetHelper_simple::convertFromUtf8($inputString, $targetEncoding);
@@ -2761,7 +2761,7 @@ class GalleryCoreApi {
      * This function should only be used in special circumstances, for example when a list of all
      * plugins needs to be made.  Currently it returns gallery2/ and gallery2/plugins/.
      */
-     function getPluginBaseDirs() {
+     static function getPluginBaseDirs() {
 	 return array('base' => dirname(dirname(dirname(dirname(__FILE__)))) . '/');
      }
 
@@ -2780,7 +2780,7 @@ class GalleryCoreApi {
      * @param bool $clearCache (optional) force index to be reread from the filesystem
      * @return string plugin base directory
      */
-    function getPluginBaseDir($pluginType, $pluginId, $clearCache=false) {
+    static function getPluginBaseDir($pluginType, $pluginId, $clearCache=false) {
 	return dirname(dirname(dirname(dirname(__FILE__)))) . '/';
     }
 
@@ -2802,7 +2802,7 @@ class GalleryCoreApi {
      * @param bool $clearCache (optional) force index to be reread from the filesystem
      * @return boolean
      */
-    function isPluginInDefaultLocation($pluginType, $pluginId, $clearCache=false) {
+    static function isPluginInDefaultLocation($pluginType, $pluginId, $clearCache=false) {
 	return true;
     }
 
@@ -2839,7 +2839,7 @@ class GalleryCoreApi {
      * @param string $headers (optional) additional headers (\r\n separated)
      * @return GalleryStatus a status code
      */
-    function sendTemplatedEmail($file, $data, $from, $to, $subject, $headers='') {
+    static function sendTemplatedEmail($file, $data, $from, $to, $subject, $headers='') {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/MailHelper_simple.class');
 	return MailHelper_simple::sendTemplatedEmail($file, $data, $from, $to, $subject, $headers);
     }
@@ -2924,7 +2924,7 @@ class GalleryCoreApi {
      * @param array $data an associative array of data about the entries to match
      * @return GalleryStatus a status code
      */
-    function removeMapEntry($mapName, $data) {
+    static function removeMapEntry($mapName, $data) {
 	global $gallery;
 
 	if (sizeof($data) == 0) {
@@ -2948,7 +2948,7 @@ class GalleryCoreApi {
      *                non transactional database connection for this operation.  Default is false.
      * @return GalleryStatus a status code
      */
-    function addMapEntry($mapName, $data, $useNonTransactionalConnection=false) {
+    static function addMapEntry($mapName, $data, $useNonTransactionalConnection=false) {
 	global $gallery;
 
 	$storage =& $gallery->getStorage();
@@ -2968,7 +2968,7 @@ class GalleryCoreApi {
      *             TRUNCATE statement).
      * @return GalleryStatus a status code
      */
-    function removeAllMapEntries($mapName, $useNonTransactionalConnection=false) {
+    static function removeAllMapEntries($mapName, $useNonTransactionalConnection=false) {
 	global $gallery;
 
 	$storage =& $gallery->getStorage();
@@ -2987,7 +2987,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code,
      *               array member name => member type
      */
-    function describeMap($mapName, $tryAllModules=false) {
+    static function describeMap($mapName, $tryAllModules=false) {
 	global $gallery;
 
 	$storage =& $gallery->getStorage();
@@ -3007,7 +3007,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               entity associative array
      */
-    function describeEntity($entityName, $tryAllModules=false) {
+    static function describeEntity($entityName, $tryAllModules=false) {
 	global $gallery;
 	$storage =& $gallery->getStorage();
 	list ($ret, $entityInfo) = $storage->describeEntity($entityName, $tryAllModules);
@@ -3023,7 +3023,7 @@ class GalleryCoreApi {
      *
      * @param int $entityId
      */
-    function deleteFastDownloadFileById($entityId) {
+    static function deleteFastDownloadFileById($entityId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryEntityHelper_medium.class');
 	return GalleryEntityHelper_medium::deleteFastDownloadFileById($entityId);
@@ -3038,7 +3038,7 @@ class GalleryCoreApi {
      * @param bool $runEvenInUnitTest (optional) force this to run, even in the unit test framework
      * @return GalleryStatus a status code
      */
-    function createFastDownloadFile($entity, $runEvenInUnitTest=false) {
+    static function createFastDownloadFile($entity, $runEvenInUnitTest=false) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryEntityHelper_medium.class');
 	return GalleryEntityHelper_medium::createFastDownloadFile($entity, $runEvenInUnitTest);
@@ -3049,7 +3049,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               int album id
      */
-    function getDefaultAlbumId() {
+    static function getDefaultAlbumId() {
 	global $gallery;
 
 	$defaultId = $gallery->getConfig('defaultAlbumId');
@@ -3070,7 +3070,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               int user id
      */
-    function getAnonymousUserId() {
+    static function getAnonymousUserId() {
 	global $gallery;
 	$id = $gallery->getConfig('anonymousUserId');
 	if (empty($id)) {
@@ -3090,7 +3090,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               boolean true if anonymous
      */
-    function isAnonymousUser($userId=null) {
+    static function isAnonymousUser($userId=null) {
 	if (empty($userId)) {
 	    global $gallery;
 	    $userId = $gallery->getActiveUserId();
@@ -3109,7 +3109,7 @@ class GalleryCoreApi {
      * @param string $sortOrder
      * @return GalleryStatus a status code
      */
-    function deleteSortOrder($sortOrder) {
+    static function deleteSortOrder($sortOrder) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemHelper_advanced.class');
 	return GalleryItemHelper_advanced::deleteSortOrder($sortOrder);
@@ -3121,7 +3121,7 @@ class GalleryCoreApi {
      * @param string $rendererClassName
      * @return GalleryStatus a status code
      */
-    function deleteRenderer($rendererClassName) {
+    static function deleteRenderer($rendererClassName) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryItemHelper_advanced.class');
 	return GalleryItemHelper_advanced::deleteRenderer($rendererClassName);
@@ -3136,7 +3136,7 @@ class GalleryCoreApi {
      * @param array $form
      * @return GalleryStatus a status code
      */
-    function loadThemeSettingsForm($themeId, $itemId, &$template, &$form) {
+    static function loadThemeSettingsForm($themeId, $itemId, &$template, &$form) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryThemeHelper_medium.class');
 	return GalleryThemeHelper_medium::loadThemeSettingsForm(
 		$themeId, $itemId, $template, $form);
@@ -3149,7 +3149,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array block configurations
      */
-    function loadAvailableBlocks($getInactive=false) {
+    static function loadAvailableBlocks($getInactive=false) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryThemeHelper_medium.class');
 	return GalleryThemeHelper_medium::loadAvailableBlocks($getInactive);
     }
@@ -3164,7 +3164,7 @@ class GalleryCoreApi {
      *               array error messages
      *               string localized status message
      */
-    function handleThemeSettingsRequest($themeId, $itemId, $form) {
+    static function handleThemeSettingsRequest($themeId, $itemId, $form) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryThemeHelper_medium.class');
 	return GalleryThemeHelper_medium::handleThemeSettingsRequest($themeId, $itemId, $form);
     }
@@ -3177,7 +3177,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               bool true if the account is disabled
      */
-    function isDisabledUsername($userName) {
+    static function isDisabledUsername($userName) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryUserHelper_medium.class');
 	return GalleryUserHelper_medium::isDisabledUsername($userName);
     }
@@ -3192,7 +3192,7 @@ class GalleryCoreApi {
      *                                array('read' => boolean true if it's ok to show,
      *                                      'write' => boolean true if it's ok to set))
      */
-    function getExternalAccessMemberList($entityName) {
+    static function getExternalAccessMemberList($entityName) {
 	GalleryCoreApi::requireOnce(
 		'modules/core/classes/helpers/GalleryEntityHelper_medium.class');
 	return GalleryEntityHelper_medium::getExternalAccessMemberList($entityName);
@@ -3205,7 +3205,7 @@ class GalleryCoreApi {
      * @param string $pluginId the id of the plugin
      * @return GalleryStatus a status code
      */
-    function installTranslationsForPlugin($pluginType, $pluginId) {
+    static function installTranslationsForPlugin($pluginType, $pluginId) {
 	GalleryCoreApi::requireOnce(
 		'modules/core/classes/helpers/GalleryTranslatorHelper_medium.class');
 	return GalleryTranslatorHelper_medium::installTranslationsForPlugin($pluginType, $pluginId);
@@ -3218,7 +3218,7 @@ class GalleryCoreApi {
      * @param string $pluginId the id of the plugin
      * @return GalleryStatus a status code
      */
-    function removeTranslationsForPlugin($pluginType, $pluginId) {
+    static function removeTranslationsForPlugin($pluginType, $pluginId) {
 	GalleryCoreApi::requireOnce(
 		'modules/core/classes/helpers/GalleryTranslatorHelper_medium.class');
 	return GalleryTranslatorHelper_medium::removeTranslationsForPlugin($pluginType, $pluginId);
@@ -3230,7 +3230,7 @@ class GalleryCoreApi {
      * @param string $locale (optional) Defaults to translator's current locale
      * @return GalleryStatus a status code
      */
-    function installTranslationsForLocale($locale=null) {
+    static function installTranslationsForLocale($locale=null) {
 	GalleryCoreApi::requireOnce(
 		'modules/core/classes/helpers/GalleryTranslatorHelper_medium.class');
 	return GalleryTranslatorHelper_medium::installTranslationsForLocale($locale);
@@ -3241,7 +3241,7 @@ class GalleryCoreApi {
      * @return array['language code']['country code'] =
      *              array('description', 'right-to-left'?)
      */
-    function getSupportedLanguages() {
+    static function getSupportedLanguages() {
     	GalleryCoreApi::requireOnce(
 		'modules/core/classes/helpers/GalleryTranslatorHelper_medium.class');
 	return GalleryTranslatorHelper_medium::getSupportedLanguages();
@@ -3255,7 +3255,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *		     string language description
      */
-    function getLanguageDescription($languageCode) {
+    static function getLanguageDescription($languageCode) {
     	GalleryCoreApi::requireOnce(
 		'modules/core/classes/helpers/GalleryTranslatorHelper_medium.class');
 	return GalleryTranslatorHelper_medium::getLanguageDescription($languageCode);
@@ -3282,7 +3282,7 @@ class GalleryCoreApi {
      * are still up to date. The result is cached in memory.
      * @return boolean false if the compiled templates should be used without any checking
      */
-    function shouldDoCompileCheck() {
+    static function shouldDoCompileCheck() {
 	GalleryCoreApi::requireOnce('modules/core/classes/GalleryTemplate.class');
 	return GalleryTemplate::shouldDoCompileCheck();
     }
@@ -3293,7 +3293,7 @@ class GalleryCoreApi {
      * 			  custom maintenance mode page.
      * @return GalleryStatus a status code
      */
-    function setMaintenanceMode($mode) {
+    static function setMaintenanceMode($mode) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/MaintenanceHelper_simple.class');
 	return MaintenanceHelper_simple::setMaintenanceMode($mode);
     }
@@ -3306,7 +3306,7 @@ class GalleryCoreApi {
      * @param string $detail the event details
      * @return GalleryStatus a status code
      */
-    function addEventLogEntry($type, $summary, $details) {
+    static function addEventLogEntry($type, $summary, $details) {
 	GalleryCoreApi::requireOnce(
 		'modules/core/classes/helpers/GalleryEventLogHelper_medium.class');
 	return GalleryEventLogHelper_medium::addEventLogEntry($type, $summary, $details);

--- a/modules/core/classes/GalleryCoreApi.class
+++ b/modules/core/classes/GalleryCoreApi.class
@@ -182,7 +182,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array (id => className, ...)
      */
-    function getAllFactoryImplementationIds($classType) {
+    static function getAllFactoryImplementationIds($classType) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryFactoryHelper_simple.class');
 	return GalleryFactoryHelper_simple::getAllImplementationIds($classType);
@@ -194,7 +194,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array (id => className, ...)
      */
-    function getAllFactoryImplementationIdsWithHint($classType, $hint) {
+    static function getAllFactoryImplementationIdsWithHint($classType, $hint) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryFactoryHelper_medium.class');
 	return GalleryFactoryHelper_medium::getAllImplementationIdsWithHint($classType, $hint);
@@ -208,7 +208,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus
      *               array Hints for the specified implementation id and class type
      */
-    function getFactoryDefinitionHints($classType, $implId) {
+    static function getFactoryDefinitionHints($classType, $implId) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryFactoryHelper_medium.class');
 	return GalleryFactoryHelper_medium::getFactoryDefinitionHints($classType, $implId);
@@ -222,7 +222,7 @@ class GalleryCoreApi {
      * @param mixed $hints array of hints to try (in order) or single string hint (eg. 'image/jpeg')
      * @return GalleryStatus
      */
-    function updateFactoryDefinitionHints($classType, $implId, $hints) {
+    static function updateFactoryDefinitionHints($classType, $implId, $hints) {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryFactoryHelper_medium.class');
 	return
@@ -2198,7 +2198,7 @@ class GalleryCoreApi {
      * @return array GalleryStatus a status code
      *               array (toolkitId=>priority, ..)
      */
-    function getRedundantToolkitPriorities() {
+    static function getRedundantToolkitPriorities() {
 	GalleryCoreApi::requireOnce(
 	    'modules/core/classes/helpers/GalleryToolkitHelper_medium.class');
 	return GalleryToolkitHelper_medium::getRedundantPriorities();
@@ -2209,7 +2209,7 @@ class GalleryCoreApi {
      * @param string $eventName the name of the event, e.g. GalleryEntity::save
      * @return GalleryEvent an event with the given name
      */
-    function newEvent($eventName) {
+    static function newEvent($eventName) {
 	GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryEventHelper_simple.class');
 	return GalleryEventHelper_simple::newEvent($eventName);
     }

--- a/modules/core/classes/GalleryDataCache.class
+++ b/modules/core/classes/GalleryDataCache.class
@@ -59,7 +59,7 @@ class GalleryDataCache {
      * Is in-memory caching enabled?
      * @return boolean true if it's enabled
      */
-    function isMemoryCachingEnabled() {
+    static function isMemoryCachingEnabled() {
 	$cache =& GalleryDataCache::_getCache();
 	return $cache['memoryCacheEnabled'];
     }
@@ -68,7 +68,7 @@ class GalleryDataCache {
      * Turn in-memory caching on or off
      * @param boolean $bool
      */
-    function setMemoryCachingEnabled($bool) {
+    static function setMemoryCachingEnabled($bool) {
 	$cache =& GalleryDataCache::_getCache();
 	$cache['memoryCacheEnabled'] = $bool;
     }
@@ -118,7 +118,7 @@ class GalleryDataCache {
      * Remove data from the cache
      * @param string $pattern regexp
      */
-    function removeByPattern($pattern) {
+    static function removeByPattern($pattern) {
 	$cache =& GalleryDataCache::_getCache();
 	if (!$cache['memoryCacheEnabled']) {
 	    return;
@@ -140,7 +140,7 @@ class GalleryDataCache {
      * @param mixed $data
      * @param boolean $protected (optional) should this key survive a reset call?
      */
-    function putByReference($key, &$data, $protected=false) {
+    static function putByReference($key, &$data, $protected=false) {
 	$cache =& GalleryDataCache::_getCache();
 	if (!$cache['memoryCacheEnabled']) {
 	    return;
@@ -164,7 +164,7 @@ class GalleryDataCache {
      *
      * @access private
      */
-    function _performMaintenance() {
+    static function _performMaintenance() {
 	$cache =& GalleryDataCache::_getCache();
 	$numToExpire = count($cache['positions']) - $cache['minKeys'];
 	asort($cache['positions']);
@@ -211,7 +211,7 @@ class GalleryDataCache {
      * Return all the keys in the cache
      * @return array string keys
      */
-    function getAllKeys() {
+    static function getAllKeys() {
 	$cache =& GalleryDataCache::_getCache();
 	if (!$cache['memoryCacheEnabled']) {
 	    return array();
@@ -247,7 +247,7 @@ class GalleryDataCache {
      * Is caching to disk enabled?
      * @return boolean
      */
-    function &isFileCachingEnabled() {
+    static function &isFileCachingEnabled() {
 	$cache =& GalleryDataCache::_getCache();
 	return $cache['fileCacheEnabled'];
     }
@@ -257,7 +257,7 @@ class GalleryDataCache {
      * @param boolean $bool
 
      */
-    function setFileCachingEnabled($bool) {
+    static function setFileCachingEnabled($bool) {
 	$cache =& GalleryDataCache::_getCache();
 	$cache['fileCacheEnabled'] = $bool;
     }
@@ -475,7 +475,7 @@ class GalleryDataCache {
      * @param mixed $ids item ids (can be an array of ids or a single id)
      * @param string $permission
      */
-    function cachePermissions($ids, $permission) {
+    static function cachePermissions($ids, $permission) {
 	global $gallery;
 	$session =& $gallery->getSession();
 	if (!isset($session)) {
@@ -539,7 +539,7 @@ class GalleryDataCache {
      * @param string $permission
      * @return boolean
      */
-    function hasPermission($id, $permission) {
+    static function hasPermission($id, $permission) {
 	global $gallery;
 	$session =& $gallery->getSession();
 	if (!isset($session)) {
@@ -563,7 +563,7 @@ class GalleryDataCache {
     /**
      * Clear permission cache for active user.
      */
-    function clearPermissionCache() {
+    static function clearPermissionCache() {
 	global $gallery;
 	$session =& $gallery->getSession();
 	if (isset($session)) {
@@ -579,7 +579,7 @@ class GalleryDataCache {
      * @return array GalleryStatus a status code
      *               string the page data
      */
-    function getPageData($type, $keyData) {
+    static function getPageData($type, $keyData) {
 	global $gallery;
 
 	list ($ret, $acceleration) =
@@ -649,7 +649,7 @@ class GalleryDataCache {
      * @param string $value the page data
      * @return GalleryStatus a status code
      */
-    function putPageData($type, $itemId, $keyData, $value) {
+    static function putPageData($type, $itemId, $keyData, $value) {
 	global $gallery;
 
 	$userId = $gallery->getActiveUserId();
@@ -724,7 +724,7 @@ class GalleryDataCache {
      * @param mixed $itemIds one item id, or an array of item ids
      * @return GalleryStatus a status code
      */
-    function removePageData($itemIds) {
+    static function removePageData($itemIds) {
 	$ret = GalleryCoreApi::removeMapEntry('GalleryCacheMap', array('itemId' => $itemIds));
 	if ($ret) {
 	    return $ret;
@@ -788,7 +788,7 @@ class GalleryDataCache {
      * @return array GalleryStatus a status code
      *               string extra cache key
      */
-    function _getExtraPageCacheKey() {
+    static function _getExtraPageCacheKey() {
 	global $gallery;
 	$session =& $gallery->getSession();
 
@@ -813,7 +813,7 @@ class GalleryDataCache {
      *
      * @return GalleryStatus a status code
      */
-    function _cleanPageDataCache() {
+    static function _cleanPageDataCache() {
 	global $gallery;
 
 	list ($ret, $anonymousUserId) =

--- a/modules/core/classes/GalleryDataCache.class
+++ b/modules/core/classes/GalleryDataCache.class
@@ -741,7 +741,7 @@ class GalleryDataCache {
      * @param string $type the page type
      * @return GalleryStatus a status code
      */
-    function shouldCache($action, $type) {
+    static function shouldCache($action, $type) {
 	global $gallery;
 
 	if (GalleryUtilities::getServerVar('REQUEST_METHOD') != 'GET') {

--- a/modules/core/classes/GalleryDynamicAlbum.class
+++ b/modules/core/classes/GalleryDynamicAlbum.class
@@ -44,7 +44,7 @@ class GalleryDynamicAlbum extends GalleryItem {
      * @param string $title localized title
      * @param array $itemTypeNameData itemTypeName data, eg. array(Photo, photo), array(Foto, foto)
      */
-    function create($title, $itemTypeNameData=null) {
+    function createDynamicAlbum($title, $itemTypeNameData=null) {
 	global $gallery;
 
 	$this->setId(null);
@@ -114,7 +114,7 @@ class GalleryDynamicAlbum extends GalleryItem {
     /**
      * @see GalleryEntity::save
      */
-    function save($postEvent=true) {
+    function save($postEvent=true, $setAclId=null) {
 	return GalleryCoreApi::error(ERROR_UNSUPPORTED_OPERATION);
     }
 

--- a/modules/core/classes/GalleryEmbed.class
+++ b/modules/core/classes/GalleryEmbed.class
@@ -1040,7 +1040,8 @@ class GalleryEmbed /* implements GalleryEventListener */ {
 	    if ($template->hasVariable('head')) {
 		$head = $template->getVariable('head');
 		if (!empty($head['tpl'])) {
-		    list ($tpl) = each($head['tpl']);
+		    $tpl = current($head['tpl']);
+            next($head['tpl']);
 		    list ($ret, $headHtml) = $template->fetch("gallery:$tpl");
 		    if ($ret) {
 			return array($ret, null, null);

--- a/modules/core/classes/GalleryEvent.class
+++ b/modules/core/classes/GalleryEvent.class
@@ -49,7 +49,7 @@ class GalleryEvent {
     var $_data;
 
 
-    function GalleryEvent() {
+    function __construct() {
         $this->setEventName(null);
         $null = null;
         $this->setEntity($null);

--- a/modules/core/classes/GalleryLockSystem.class
+++ b/modules/core/classes/GalleryLockSystem.class
@@ -50,7 +50,7 @@ class GalleryLockSystem {
     var $_releaseQueue;
 
 
-    function GalleryLockSystem() {
+    function __construct() {
 	$this->_locks = $this->_releaseQueue = array();
     }
 

--- a/modules/core/classes/GalleryModule.class
+++ b/modules/core/classes/GalleryModule.class
@@ -89,7 +89,7 @@ class GalleryModule extends GalleryPlugin {
      *
      * @return array major number, minor number
      */
-    function getApiVersion() {
+    static function getApiVersion() {
 	return array(3, 9);
     }
 

--- a/modules/core/classes/GalleryPlatform.class
+++ b/modules/core/classes/GalleryPlatform.class
@@ -132,7 +132,7 @@ class GalleryPlatform {
 	}
 
 	$slash = $this->getDirectorySeparator();
-	$dir = $dir{strlen($dir) - 1} == $slash ? substr($dir, 0, strlen($dir) - 1) : $dir;
+	$dir = $dir[strlen($dir) - 1] == $slash ? substr($dir, 0, strlen($dir) - 1) : $dir;
 
 	$tempfile = tempnam($dir, $prefix);
 	if ($tempfile !== false) {
@@ -527,7 +527,7 @@ class GalleryPlatform {
 	    $gallery->debug("recursiveRmdir($dirname)");
 	}
 
-	if ($dirname{strlen($dirname)-1} != $this->getDirectorySeparator()) {
+	if ($dirname[strlen($dirname)-1] != $this->getDirectorySeparator()) {
 	    $dirname .= $this->getDirectorySeparator();
 	}
 

--- a/modules/core/classes/GalleryPlatform/WinNtPlatform.class
+++ b/modules/core/classes/GalleryPlatform/WinNtPlatform.class
@@ -196,8 +196,8 @@ class WinNtPlatform extends GalleryPlatform {
 	     * %d returns always 2 digits, 01 - 31
 	     * Replace leading 0 for single digit months with a space
 	     */
-	    $format{$pos} = ($replacement{0} == '0') ? ' ' : $replacement{0};
-	    $format{$pos+1} = $replacement{1};
+	    $format[$pos] = ($replacement[0] == '0') ? ' ' : $replacement[0];
+	    $format[$pos+1] = $replacement[1];
 	}
 	return parent::strftime($format, $timestamp);
     }

--- a/modules/core/classes/GalleryRepositoryIndex.class
+++ b/modules/core/classes/GalleryRepositoryIndex.class
@@ -58,7 +58,7 @@ class GalleryRepositoryIndex {
     var $_utilities;
 
 
-    function GalleryRepositoryIndex($source) {
+    function __construct($source) {
 	$this->_utilities = new GalleryRepositoryUtilities();
 	$this->_source = $source;
     }

--- a/modules/core/classes/GalleryStorage/Db2Storage.class
+++ b/modules/core/classes/GalleryStorage/Db2Storage.class
@@ -31,7 +31,7 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryStorage.class');
  */
 class Db2Storage extends GalleryStorage {
 
-    function Db2Storage($config) {
+    function __construct($config) {
     parent::__construct($config);
 	$this->_isTransactional = true;
     }

--- a/modules/core/classes/GalleryStorage/GalleryDatabaseImport.class
+++ b/modules/core/classes/GalleryStorage/GalleryDatabaseImport.class
@@ -69,7 +69,7 @@ class GalleryImportElement extends GalleryXmlHandler {
      * @param GalleryImportElement $parent The parent object. Used to follow the parent chain in
      *           order to set error messages and to provide status information to the caller.
      */
-    function GalleryImportElement($parent=null) {
+    function __construct($parent=null) {
 	global $gallery;
 
 	$this->_parent = $parent;
@@ -137,8 +137,8 @@ class GalleryDatabaseImport extends GalleryImportElement {
      */
     var $_fileReadChunkSize = 8192;
 
-    function GalleryDatabaseImport() {
-	parent::GalleryImportElement();
+    function __construct() {
+	parent::__construct();
     }
 
     /**
@@ -608,8 +608,8 @@ class _GalleryCreateSqlTag extends GalleryImportElement {
     /** Holds the generated insert for this table */
     var $_currentSql = '';
 
-    function GalleryTableImport($parent, $attributes) {
-	parent::GalleryImportElement($parent);
+    function __construct($parent, $attributes) {
+	parent::__construct($parent);
 	$this->_currentSql = '';
     }
 
@@ -846,7 +846,7 @@ class GalleryXmlProcessor {
      */
     var $_xmlParser;
     
-    function GalleryXmlProcessor($rootElement) {
+    function __construct($rootElement) {
 	$this->_elementStack[] = $rootElement;
 
 	$this->_xmlParser = xml_parser_create('UTF-8');

--- a/modules/core/classes/GalleryStorage/MSSqlStorage.class
+++ b/modules/core/classes/GalleryStorage/MSSqlStorage.class
@@ -39,7 +39,7 @@ class MSSqlStorage extends GalleryStorage {
      */
     var $_serverInfo;
 
-    function MSSqlStorage($config) {
+    function __construct($config) {
     parent::__construct($config);
 	$this->_isTransactional = true;
 	$this->_isEmptyAllowedForNotNullColumn = true;

--- a/modules/core/classes/GalleryStorage/OracleStorage.class
+++ b/modules/core/classes/GalleryStorage/OracleStorage.class
@@ -31,7 +31,7 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryStorage.class');
  */
 class OracleStorage extends GalleryStorage {
 
-    function OracleStorage($config) {
+    function __construct($config) {
     parent::__construct($config);
 	$this->_isTransactional = true;
 	$this->_isEmptyAllowedForNotNullColumn = false;

--- a/modules/core/classes/GalleryStorage/PostgreSqlStorage.class
+++ b/modules/core/classes/GalleryStorage/PostgreSqlStorage.class
@@ -31,7 +31,7 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryStorage.class');
  */
 class PostgreSqlStorage extends GalleryStorage {
 
-    function PostgreSqlStorage($config) {
+    function __construct($config) {
     parent::__construct($config);
 	$this->_isTransactional = true;
     }

--- a/modules/core/classes/GalleryStorage/SQLiteStorage.class
+++ b/modules/core/classes/GalleryStorage/SQLiteStorage.class
@@ -31,7 +31,7 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryStorage.class');
  */
 class SQLiteStorage extends GalleryStorage {
 
-    function SQLiteStorage($config) {
+    function __construct($config) {
     parent::__construct($config);
 	/**
 	 * SQLite supports transactions, but they seem to hang on some pages and some select

--- a/modules/core/classes/GalleryTemplate.class
+++ b/modules/core/classes/GalleryTemplate.class
@@ -321,7 +321,7 @@ class GalleryTemplate {
      * @static
      * @access private
      */
-    function _getSmarty($trimWhitespace) {
+    static function _getSmarty($trimWhitespace) {
 	global $gallery;
 
 	GalleryCoreApi::requireOnce('modules/core/classes/GallerySmarty.class');
@@ -414,7 +414,7 @@ class GalleryTemplate {
      * @param Smarty $smarty
      * @deprecated
      */
-    function resourceGetTemplateBaseDir($templateName, &$smarty) {
+    static function resourceGetTemplateBaseDir($templateName, &$smarty) {
 	if (preg_match('/^(module|theme)s\/(.+)(\/.+)/iU', $templateName, $pluginId)) {
 	    return GalleryCoreApi::getCodeBasePath();
 	} else {
@@ -431,7 +431,7 @@ class GalleryTemplate {
      *
      * @see function _getActualTemplatePath
      */
-    function resourceGetTemplate($templateName, &$templateSource, &$smarty) {
+    static function resourceGetTemplate($templateName, &$templateSource, &$smarty) {
 	$templatePath = GalleryTemplate::_getActualTemplatePath($templateName, $smarty);
 
 	$success = false;
@@ -456,7 +456,7 @@ class GalleryTemplate {
      *
      * @see function _getActualTemplatePath
      */
-    function resourceGetTimestamp($templateName, &$templateTimestamp, &$smarty) {
+    static function resourceGetTimestamp($templateName, &$templateTimestamp, &$smarty) {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
 
@@ -484,7 +484,7 @@ class GalleryTemplate {
      * @static
      * @access private
      */
-     function _getActualTemplatePath($templateName, &$smarty) {
+    static function _getActualTemplatePath($templateName, &$smarty) {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
 
@@ -555,7 +555,7 @@ class GalleryTemplate {
      * @static
      * @access private
      */
-    function _getThemeId() {
+    static function _getThemeId() {
 	$view = new GalleryView();
 	list ($ret, $itemId) = $view->getItem();
 	if ($ret) {

--- a/modules/core/classes/GalleryTemplate.class
+++ b/modules/core/classes/GalleryTemplate.class
@@ -122,8 +122,6 @@ class GalleryTemplate {
      * @param mixed $value
      */
     function setVariableByReference($key, &$value) {
-        global $gallery;
-        $gallery->debug("setVarByRef");
 	$this->_smarty->assign_by_ref($key, $value);
     }
 

--- a/modules/core/classes/GalleryTemplate.class
+++ b/modules/core/classes/GalleryTemplate.class
@@ -60,7 +60,7 @@ class GalleryTemplate {
     var $_compiledTemplateDir;
 
 
-    function GalleryTemplate($templateDir, $initSmarty=true, $trimWhitespace=true) {
+    function __construct($templateDir, $initSmarty=true, $trimWhitespace=true) {
 	global $gallery;
 	$this->_templateDir = $templateDir;
 
@@ -122,6 +122,8 @@ class GalleryTemplate {
      * @param mixed $value
      */
     function setVariableByReference($key, &$value) {
+        global $gallery;
+        $gallery->debug("setVarByRef");
 	$this->_smarty->assign_by_ref($key, $value);
     }
 

--- a/modules/core/classes/GalleryTemplateAdapter.class
+++ b/modules/core/classes/GalleryTemplateAdapter.class
@@ -66,7 +66,7 @@ class GalleryTemplateAdapter {
     var $_progressBarStats;
 
 
-    function GalleryTemplateAdapter() {
+    function __construct() {
 	$this->_callCount = array();
 	$this->_theme = null;
 	$this->_trailer = null;

--- a/modules/core/classes/GalleryTemplateAdapter.class
+++ b/modules/core/classes/GalleryTemplateAdapter.class
@@ -1170,7 +1170,7 @@ class GalleryTemplateAdapter {
 	    $timeRemaining = $coreModule->translate(
 		array('text' => 'Estimated time remaining: %d:%02d',
 		      'arg1' => (int)($timeRemaining / 60),
-		      'arg2' => $timeRemaining % 60));
+		      'arg2' => (int)($timeRemaining % 60)));
 	} else {
 	    $timeRemaining = '';
 	}

--- a/modules/core/classes/GalleryTemplateAdapter.class
+++ b/modules/core/classes/GalleryTemplateAdapter.class
@@ -518,11 +518,12 @@ class GalleryTemplateAdapter {
 		      'id' => '_all'),
 		$contents);
 	    if ($phpVm->function_exists('gzencode')) {
+		    $encodedContents = $phpVm->gzencode($contents, 9, FORCE_GZIP);
 		GalleryDataCache::putToDisk(
 		    array('type' => 'module',
 			  'itemId' => 'CombinedJavascript_gzip_' . $key,
 			  'id' => '_all'),
-		    $phpVm->gzencode($contents, 9, FORCE_GZIP));
+		    $encodedContents);
 	    }
 	}
 	return $urlGenerator->generateUrl(

--- a/modules/core/classes/GalleryTheme.class
+++ b/modules/core/classes/GalleryTheme.class
@@ -72,7 +72,7 @@ class GalleryTheme extends GalleryPlugin {
      *
      * @return array major number, minor number
      */
-    function getApiVersion() {
+    static function getApiVersion() {
 	return array(2, 6);
     }
 

--- a/modules/core/classes/GalleryTheme.class
+++ b/modules/core/classes/GalleryTheme.class
@@ -59,7 +59,7 @@ class GalleryTheme extends GalleryPlugin {
      * theme.inc are still in the themes folder.  The old themes call $this->GalleryTheme() in their
      * constructor.
      */
-    function GalleryTheme() {
+    function __construct() {
     }
 
     /**

--- a/modules/core/classes/GalleryUrlGenerator.class
+++ b/modules/core/classes/GalleryUrlGenerator.class
@@ -220,7 +220,7 @@ class GalleryUrlGenerator {
      * @static
      * @access private
      */
-    function _flattenParamsArray($nestedParams, &$flatParams, $keyBase=null) {
+    static function _flattenParamsArray($nestedParams, &$flatParams, $keyBase=null) {
 	foreach ($nestedParams as $key => $value) {
 	    $key = empty($keyBase) ? $key : $keyBase . '[' . $key . ']';
 	    if (is_array($value)) {
@@ -239,7 +239,7 @@ class GalleryUrlGenerator {
      * @static
      * @deprecated
      */
-    function getGalleryId() {
+    static function getGalleryId() {
 	return '';
     }
 

--- a/modules/core/classes/GalleryUtilities.class
+++ b/modules/core/classes/GalleryUtilities.class
@@ -504,7 +504,7 @@ class GalleryUtilities {
     function castToFloat($value) {
 	if (is_string($value) && (float)'1.1' != 1.1
 		&& ($test = (string)1.1) != '1.1' && strlen($test) == 3) {
-	    return (float)str_replace('.', $test{1}, $value);
+	    return (float)str_replace('.', $test[1], $value);
 	}
 	return (float)$value;
     }
@@ -958,7 +958,7 @@ class GalleryUtilities {
 	     * Make sure the compare directory has a trailing slash so that /tmp doesn't
 	     * accidentally match /tmpfoo
 	     */
-	    if ($element{strlen($element)-1} != $slash) {
+	    if ($element[strlen($element)-1] != $slash) {
 		$element .= $slash;
 	    }
 
@@ -1263,7 +1263,7 @@ class GalleryUtilities {
 	if (empty($salt)) {
 	    for ($i = 0; $i < 4; $i++) {
 		$char = mt_rand(48, 109);
-		$char += ($char > 90) ? 13 : ($char > 57) ? 7 : 0;
+		$char += ($char > 90) ? 13 : (($char > 57) ? 7 : 0);
 		$salt .= chr($char);
 	    }
 	} else {
@@ -1487,7 +1487,7 @@ class GalleryUtilities {
 		    $i = 0;
 		    $lastPos = 0;
 		    while ($i < $len) {
-			switch ($string{$i}) {
+			switch ($string[$i]) {
 			    /* Two attr-pair separators */
 			case ',':
 			case ';':
@@ -1569,8 +1569,8 @@ class GalleryUtilities {
 	}
 	/* Make it a binary safe variable name */
 	for ($i = 0; $i < $len; $i++) {
-	    if ($key{$i} == ' ' || $key{$i} == '.') {
-		$key{$i} = '_';
+	    if ($key[$i] == ' ' || $key[$i] == '.') {
+		$key[$i] = '_';
 	    }
 	}
 	/*
@@ -1616,7 +1616,7 @@ class GalleryUtilities {
      * @param string $header
      * @return bool true if the given header is safe
      */
-    function isSafeHttpHeader($header) {
+    static function isSafeHttpHeader($header) {
 	if (!is_string($header)) {
 	    return false;
 	}

--- a/modules/core/classes/GalleryUtilities.class
+++ b/modules/core/classes/GalleryUtilities.class
@@ -118,7 +118,7 @@ class GalleryUtilities {
      * @param boolean $prefix (optional) false to omit Gallery variable prefix (not recommended)
      * @return array key value pairs
      */
-    function getFormVariables($key, $prefix=true) {
+    static function getFormVariables($key, $prefix=true) {
 	if ($prefix) {
 	    $key = GALLERY_FORM_VARIABLE_PREFIX . $key;
 	}
@@ -153,7 +153,7 @@ class GalleryUtilities {
      * @param boolean $prefix (optional) if true, remove form variable prefix from keys in result
      * @return array unsanitized key value pairs
      */
-    function getUrlVariablesFiltered($skip=array(), $prefix=false) {
+    static function getUrlVariablesFiltered($skip=array(), $prefix=false) {
 	$filter = array();
 	foreach ($skip as $key) {
 	    $filter[GALLERY_FORM_VARIABLE_PREFIX . $key] = true;
@@ -183,7 +183,7 @@ class GalleryUtilities {
      * @author Tobias Tom <t.tom@succont.de>
      * @todo Verify that both arguments are arrays.
      */
-    function array_merge_replace($array, $newValues) {
+    static function array_merge_replace($array, $newValues) {
 	foreach ($newValues as $key => $value) {
 	    if (is_array($value)) {
 		if (!isset($array[$key])) {
@@ -211,7 +211,7 @@ class GalleryUtilities {
      * @param string $key
      * @param boolean $prefix (optional) false to omit Gallery variable prefix (not recommended)
      */
-    function removeFormVariables($key, $prefix=true) {
+    static function removeFormVariables($key, $prefix=true) {
 	/* Remove all matching GET and POST variables */
 	if ($prefix) {
 	    $key = GALLERY_FORM_VARIABLE_PREFIX . $key;
@@ -319,7 +319,7 @@ class GalleryUtilities {
      * @param mixed $value
      * @param array $array the destination
      */
-    function _internalPutRequestVariable($keyPath, $value, &$array) {
+    static function _internalPutRequestVariable($keyPath, $value, &$array) {
 	$key = array_shift($keyPath);
 	while (!empty($keyPath)) {
 	    $array =& $array[$key];
@@ -334,7 +334,7 @@ class GalleryUtilities {
      * @param string $key
      * @param boolean $prefix (optional) false to omit Gallery variable prefix (not recommended)
      */
-    function hasRequestVariable($key, $prefix=true) {
+    static function hasRequestVariable($key, $prefix=true) {
 	if ($prefix) {
 	    $key = GALLERY_FORM_VARIABLE_PREFIX . $key;
 	}
@@ -347,7 +347,7 @@ class GalleryUtilities {
      * @param string $key
      * @param boolean $prefix (optional) false to omit Gallery variable prefix (not recommended)
      */
-    function removeRequestVariable($key, $prefix=true) {
+    static function removeRequestVariable($key, $prefix=true) {
 	if ($prefix) {
 	    $key = GALLERY_FORM_VARIABLE_PREFIX . $key;
 	}
@@ -469,7 +469,7 @@ class GalleryUtilities {
      * @param int $targetHeight (optional) target height, defaults to same as width
      * @return array(width, height)
      */
-    function scaleDimensionsToFit($width, $height, $targetWidth, $targetHeight=null) {
+    static function scaleDimensionsToFit($width, $height, $targetWidth, $targetHeight=null) {
 	if (!isset($targetHeight)) {
 	    $targetHeight = $targetWidth;
 	}
@@ -501,7 +501,7 @@ class GalleryUtilities {
      * can ditch this method and just cast to (float).  (Note that newer PHP versions may accept
      * only "." even if locale uses ",").
      */
-    function castToFloat($value) {
+    static function castToFloat($value) {
 	if (is_string($value) && (float)'1.1' != 1.1
 		&& ($test = (string)1.1) != '1.1' && strlen($test) == 3) {
 	    return (float)str_replace('.', $test[1], $value);
@@ -830,7 +830,7 @@ class GalleryUtilities {
      * @param boolean $decode (optional) true to decode entities, process, then recode
      * @return string safe HTML
      */
-    function htmlSafe($html, $decode=false) {
+    static function htmlSafe($html, $decode=false) {
 	GalleryCoreApi::requireOnce('lib/pear/Safe.php');
 	static $parser;
 	if (!isset($parser)) {
@@ -931,7 +931,7 @@ class GalleryUtilities {
      * @return array key => value pairs of headers
      * @access private
      */
-    function &_getResponseHeaders() {
+    static function &_getResponseHeaders() {
 	static $responseHeaders;
 	return $responseHeaders;
     }
@@ -943,7 +943,7 @@ class GalleryUtilities {
      * @param string $list the list of legal paths
      * @return boolean
      */
-    function isPathInList($path, $list) {
+    static function isPathInList($path, $list) {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
 	$slash = $platform->getDirectorySeparator();
@@ -974,7 +974,7 @@ class GalleryUtilities {
      * @param string $addr an address in dotted quad form
      * @return boolean
      */
-    function isTrustedProxy($addr) {
+    static function isTrustedProxy($addr) {
 	return (boolean)preg_match('/^((10\.\d{1,3}\.\d{1,3}\.\d{1,3})|'
 	    . '(172\.(1[6-9]|2[0-9]|3[0-1])\.\d{1,3}\.\d{1,3})|'
 	    . '(192\.168\.\d{1,3}\.\d{1,3}))$/', $addr);
@@ -1007,7 +1007,7 @@ class GalleryUtilities {
      * @return array boolean true if dir exists or was created successfully
      *               array of directories that were created
      */
-    function guaranteeDirExists($dir) {
+    static function guaranteeDirExists($dir) {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
 	if ($platform->file_exists($dir)) {
@@ -1050,7 +1050,7 @@ class GalleryUtilities {
      * @return array an associative array of tree data.  Each node has a 'depth' element, and a
      *               'data' element that contains all the members of the current album item.
      */
-    function createAlbumTree($albums) {
+    static function createAlbumTree($albums) {
 	if (empty($albums)) {
 	    $tree = array(); return $tree;  /* Help CodeAudit match up returns */
 	}
@@ -1100,7 +1100,7 @@ class GalleryUtilities {
      * @param int $depth (optional) current depth
      * @access private
      */
-    function _createDepthTree(&$map, $id, $depth=0) {
+    static function _createDepthTree(&$map, $id, $depth=0) {
 	$data = array();
 	$data[] = array('depth' => $depth, 'data' => (array)$map[$id]['instance']);
 	if (isset($map[$id]['children'])) {
@@ -1166,7 +1166,7 @@ class GalleryUtilities {
      * @see Gallery::getHttpDate
      * @deprecated
      */
-    function getHttpDate($time='') {
+    static function getHttpDate($time='') {
 	global $gallery;
 	return $gallery->getHttpDate($time);
     }
@@ -1249,7 +1249,7 @@ class GalleryUtilities {
      * @param string $email email address
      * @return boolean
      */
-    function isValidEmailString($email) {
+    static function isValidEmailString($email) {
 	return (preg_match('/^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9_.-]+\.[a-zA-Z]{2,6}$/', $email) > 0);
     }
 
@@ -1259,7 +1259,7 @@ class GalleryUtilities {
      * @param string $salt (optional) salt or hash containing salt (randomly generated if omitted)
      * @return string hashed password
      */
-    function md5Salt($password, $salt='') {
+    static function md5Salt($password, $salt='') {
 	if (empty($salt)) {
 	    for ($i = 0; $i < 4; $i++) {
 		$char = mt_rand(48, 109);
@@ -1278,7 +1278,7 @@ class GalleryUtilities {
      * @param string $hashedPassword hashed password
      * @return boolean true if correct
      */
-    function isCorrectPassword($guess, $hashedPassword) {
+    static function isCorrectPassword($guess, $hashedPassword) {
 	return (GalleryUtilities::md5Salt($guess, $hashedPassword) === $hashedPassword);
     }
 
@@ -1318,7 +1318,7 @@ class GalleryUtilities {
      * @param array $array
      * @return array of keys
      */
-    function arrayKeysRecursive($array) {
+    static function arrayKeysRecursive($array) {
 	$keys = array();
 	foreach ($array as $key => $item) {
 	    $keys[] = $key;
@@ -1353,7 +1353,7 @@ class GalleryUtilities {
      * Return id of the search engine currently crawling the site by analyzing the current request.
      * @return string the crawler id, or null if it's a regular user
      */
-    function identifySearchEngine() {
+    static function identifySearchEngine() {
 	if (!isset($_SERVER['HTTP_USER_AGENT'])) {
 	    return null;
 	}
@@ -1397,7 +1397,7 @@ class GalleryUtilities {
      * @param string $key the key in the _COOKIE superglobal
      * @return string the value
      */
-    function getCookieVar($key) {
+    static function getCookieVar($key) {
 	if (!isset($_COOKIE[$key])) {
 	    return null;
 	}

--- a/modules/core/classes/GalleryUtilities.class
+++ b/modules/core/classes/GalleryUtilities.class
@@ -893,7 +893,7 @@ class GalleryUtilities {
      *     existing header.  This differs from the PHP header() $replace param which adds a header
      *     if it would otherwise replace and existing header.
      */
-    function setResponseHeader($header, $replace=true) {
+    static function setResponseHeader($header, $replace=true) {
 	/* Use our PHP VM for testability */
 	global $gallery;
 	$phpVm = $gallery->getPhpVm();

--- a/modules/core/classes/GalleryView.class
+++ b/modules/core/classes/GalleryView.class
@@ -338,7 +338,7 @@ class GalleryView {
      *               GalleryItem an item
      *               boolean true if item was specified, false if default was used
      */
-    function getItem($checkPermissions=true) {
+    static function getItem($checkPermissions=true) {
 	global $gallery;
 	$itemId = (int)GalleryUtilities::getRequestVariables('itemId');
 	$wasSpecified = true;

--- a/modules/core/classes/helpers/GalleryCharsetHelper_medium.class
+++ b/modules/core/classes/helpers/GalleryCharsetHelper_medium.class
@@ -32,7 +32,7 @@ class GalleryCharsetHelper_medium {
      * Return a mapping for the given character set.
      * @return array(int => character, ...)
      */
-    function &getCharsetTable($desired) {
+    static function &getCharsetTable($desired) {
 	static $charset;
 
 	$desired = str_replace('Windows-', 'CP', $desired);
@@ -756,7 +756,7 @@ class GalleryCharsetHelper_medium {
      *
      * @see GalleryCoreApi::utf8Substring
      */
-    function phpUtf8Substring($string, $start, $length) {
+    static function phpUtf8Substring($string, $start, $length) {
 	$strLenBytes = strlen($string);
 	$string = (string)$string;
 	if ($start >= $strLenBytes || $strLenBytes == 0 || $length == 0) {
@@ -820,7 +820,7 @@ class GalleryCharsetHelper_medium {
      *
      * @see GalleryCoreApi::utf8Strcut
      */
-    function phpUtf8Strcut($string, $start, $length) {
+    static function phpUtf8Strcut($string, $start, $length) {
 	$strLength = strlen($string);
 	$start = $start < 0 ? $strLength + $start : $start;
 	$start = $start < 0 ? 0 : $start;

--- a/modules/core/classes/helpers/GalleryCharsetHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryCharsetHelper_simple.class
@@ -32,7 +32,7 @@ class GalleryCharsetHelper_simple {
      * Detect the standard charset for this system
      * @return string an encoding (eg. "UTF-8" or "Windows-1252")
      */
-    function detectSystemCharset() {
+    static function detectSystemCharset() {
 	static $cacheKey = 'GalleryCharsetHelper_simple::detectSystemCharset';
 	if (GalleryDataCache::containsKey($cacheKey)) {
 	    return GalleryDataCache::get($cacheKey);
@@ -121,7 +121,7 @@ class GalleryCharsetHelper_simple {
     /**
      * @see GalleryCoreApi::convertToUtf8
      */
-    function convertToUtf8($string, $sourceEncoding=null) {
+    static function convertToUtf8($string, $sourceEncoding=null) {
 	global $gallery;
 	$phpVm = $gallery->getPhpVm();
 
@@ -164,7 +164,7 @@ class GalleryCharsetHelper_simple {
      *          INCOMPLETE. That is, we only convert the characters that are in our
      *          charset tables from GalleryCharsetHelper_medium.
      */
-    function convertFromUtf8($string, $targetEncoding=null) {
+    static function convertFromUtf8($string, $targetEncoding=null) {
 	global $gallery;
 	$phpVm = $gallery->getPhpVm();
 
@@ -234,7 +234,7 @@ class GalleryCharsetHelper_simple {
     /**
      * @see GalleryCoreApi::utf8Strcut
      */
-    function utf8Strcut($string, $start, $length) {
+    static function utf8Strcut($string, $start, $length) {
 	static $hasMbStrCut;
 	if (!isset($hasMbStrCut)) {
 	    if (!($hasMbStrCut = function_exists('mb_strcut'))) {

--- a/modules/core/classes/helpers/GalleryChildEntityHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryChildEntityHelper_simple.class
@@ -31,7 +31,7 @@ class GalleryChildEntityHelper_simple {
     /**
      * @see GalleryCoreApi::fetchChildItemIdsWithPermission
      */
-    function fetchChildItemIdsWithPermission($itemId, $permissionId) {
+    static function fetchChildItemIdsWithPermission($itemId, $permissionId) {
 	list ($ret, $item) = GalleryCoreApi::loadEntitiesById($itemId, 'GalleryItem');
 	if ($ret) {
 	    return array($ret, null);
@@ -53,7 +53,7 @@ class GalleryChildEntityHelper_simple {
     /**
      * @see GalleryCoreApi::fetchLinkableChildItemIdsWithPermission
      */
-    function fetchLinkableChildItemIdsWithPermission($itemId, $permissionId) {
+    static function fetchLinkableChildItemIdsWithPermission($itemId, $permissionId) {
 	list ($ret, $item) = GalleryCoreApi::loadEntitiesById($itemId, 'GalleryItem');
 	if ($ret) {
 	    return array($ret, null);
@@ -75,7 +75,7 @@ class GalleryChildEntityHelper_simple {
     /**
      * @see GalleryCoreApi::fetchChildItemIds
      */
-    function fetchChildItemIds($item, $offset=null, $count=null, $userId=null) {
+    static function fetchChildItemIds($item, $offset=null, $count=null, $userId=null) {
 	list ($ret, $ids) = GalleryChildEntityHelper_simple::_fetchChildItemIds(
 	    $item, $offset, $count, 'GalleryItem', 'core.view', false, $userId);
 	if ($ret) {
@@ -87,7 +87,7 @@ class GalleryChildEntityHelper_simple {
     /**
      * @see GalleryCoreApi::fetchChildDataItemIds
      */
-    function fetchChildDataItemIds($item, $offset=null, $count=null, $userId=null) {
+    static function fetchChildDataItemIds($item, $offset=null, $count=null, $userId=null) {
 	list ($ret, $ids) = GalleryChildEntityHelper_simple::_fetchChildItemIds(
 	    $item, $offset, $count, 'GalleryDataItem', 'core.view', false, $userId);
 	if ($ret) {
@@ -99,7 +99,7 @@ class GalleryChildEntityHelper_simple {
     /**
      * @see GalleryCoreApi::fetchChildAlbumItemIds
      */
-    function fetchChildAlbumItemIds($item, $offset=null, $count=null, $userId=null) {
+    static function fetchChildAlbumItemIds($item, $offset=null, $count=null, $userId=null) {
 	list ($ret, $ids) = GalleryChildEntityHelper_simple::_fetchChildItemIds(
 	    $item, $offset, $count, 'GalleryAlbumItem', 'core.view', false, $userId);
 	if ($ret) {
@@ -111,7 +111,7 @@ class GalleryChildEntityHelper_simple {
     /**
      * @see GalleryCoreApi::fetchChildItemIdsIgnorePermissions
      */
-    function fetchChildItemIdsIgnorePermissions($item, $offset=null, $count=null) {
+    static function fetchChildItemIdsIgnorePermissions($item, $offset=null, $count=null) {
 	list ($ret, $ids) = GalleryChildEntityHelper_simple::_fetchChildItemIds(
 	    $item, $offset, $count, 'GalleryItem', null, false, null);
 	if ($ret) {
@@ -135,7 +135,7 @@ class GalleryChildEntityHelper_simple {
      *               array of item ids
      * @access private
      */
-    function _fetchChildItemIds($item, $offset, $count, $class,
+    static function _fetchChildItemIds($item, $offset, $count, $class,
 				$requiredPermission, $linkableOnly, $userId) {
 	global $gallery;
 	$storage =& $gallery->getStorage();
@@ -176,7 +176,7 @@ class GalleryChildEntityHelper_simple {
     /**
      * @see GalleryCoreApi::buildItemQuery
      */
-    function buildItemQuery($baseTable, $baseIdColumn, $baseQuery, $orderBy, $orderDirection,
+    static function buildItemQuery($baseTable, $baseIdColumn, $baseQuery, $orderBy, $orderDirection,
 			    $class, $requiredPermission, $linkableOnly, $userId) {
 	list ($ret, $select, $join, $where, $order) =
 	    GalleryChildEntityHelper_simple::_getOrderInfo($orderBy, $orderDirection);
@@ -234,7 +234,7 @@ class GalleryChildEntityHelper_simple {
     /**
      * @see GalleryCoreApi::fetchParents
      */
-    function fetchParents($item, $permission=null, $filterBreadcrumb=false) {
+    static function fetchParents($item, $permission=null, $filterBreadcrumb=false) {
 	global $gallery;
 
 	if (!GalleryUtilities::isA($item, 'GalleryItem')) {
@@ -292,7 +292,7 @@ class GalleryChildEntityHelper_simple {
      *               array of ids
      * @access private
      */
-    function _fetchDescendentItemIds($item, $offset, $count, $class, $requiredPermission) {
+    static function _fetchDescendentItemIds($item, $offset, $count, $class, $requiredPermission) {
 	global $gallery;
 	$storage =& $gallery->getStorage();
 
@@ -373,7 +373,7 @@ class GalleryChildEntityHelper_simple {
     /**
      * @see GalleryCoreApi::fetchDescendentItemIds
      */
-    function fetchDescendentItemIds($item, $offset, $count, $requiredPermission) {
+    static function fetchDescendentItemIds($item, $offset, $count, $requiredPermission) {
 	list ($ret, $ids) = GalleryChildEntityHelper_simple::_fetchDescendentItemIds(
 	    $item, $offset, $count, 'GalleryItem', $requiredPermission);
 	if ($ret) {
@@ -385,7 +385,7 @@ class GalleryChildEntityHelper_simple {
     /**
      * @see GalleryCoreApi::fetchDescendentAlbumItemIds
      */
-    function fetchDescendentAlbumItemIds($item, $offset, $count, $requiredPermission) {
+    static function fetchDescendentAlbumItemIds($item, $offset, $count, $requiredPermission) {
 	list ($ret, $ids) = GalleryChildEntityHelper_simple::_fetchDescendentItemIds(
 	    $item, $offset, $count, 'GalleryAlbumItem', $requiredPermission);
 	if ($ret) {
@@ -412,7 +412,7 @@ class GalleryChildEntityHelper_simple {
      *               string optional join clause
      * @access private
      */
-    function _getOrderInfo($orderBy, $orderDirection) {
+    static function _getOrderInfo($orderBy, $orderDirection) {
 	global $gallery;
 	$storage =& $gallery->getStorage();
 

--- a/modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class
+++ b/modules/core/classes/helpers/GalleryDerivativeHelper_advanced.class
@@ -31,7 +31,7 @@ class GalleryDerivativeHelper_advanced {
     /**
      * @see GalleryCoreApi::fetchDerivativesBySourceIds
      */
-    function fetchDerivativesBySourceIds($ids, $types=array()) {
+    static function fetchDerivativesBySourceIds($ids, $types=array()) {
 	GalleryCoreApi::requireOnce(
 		'modules/core/classes/helpers/GalleryDerivativeHelper_simple.class');
 	list ($ret, $results) =
@@ -46,7 +46,7 @@ class GalleryDerivativeHelper_advanced {
     /**
      * @see GalleryCoreApi::fetchDerivativesByItemIds
      */
-    function fetchDerivativesByItemIds($ids) {
+    static function fetchDerivativesByItemIds($ids) {
 	GalleryCoreApi::requireOnce(
 		'modules/core/classes/helpers/GalleryDerivativeHelper_simple.class');
 	if (empty($ids)) {
@@ -63,7 +63,7 @@ class GalleryDerivativeHelper_advanced {
     /**
      * @see GalleryCoreApi::adjustDependentDerivatives
      */
-    function adjustDependentDerivatives($id, $operation, $reverse=false) {
+    static function adjustDependentDerivatives($id, $operation, $reverse=false) {
 	global $gallery;
 
 	$ids = array((int)$id => 1);
@@ -159,7 +159,7 @@ class GalleryDerivativeHelper_advanced {
     /**
      * @see GalleryCoreApi::applyToolkitOperation
      */
-    function applyToolkitOperation($operation, $args, $preserveOriginal,
+    static function applyToolkitOperation($operation, $args, $preserveOriginal,
 				   &$item, $preferred=null, $serialNumber=null) {
 	if ($item->isLinked()) {
 	    $isLinked = true;
@@ -359,7 +359,7 @@ class GalleryDerivativeHelper_advanced {
     /**
      * @see GalleryCoreApi::remapSourceIds
      */
-    function remapSourceIds($originalSourceId, $newSourceId) {
+    static function remapSourceIds($originalSourceId, $newSourceId) {
 	global $gallery;
 
 	if ($originalSourceId == $newSourceId) {
@@ -432,7 +432,7 @@ class GalleryDerivativeHelper_advanced {
     /**
      * @see GalleryCoreApi::copyDerivativePreferences
      */
-    function copyPreferences($sourceId, $targetId) {
+    static function copyPreferences($sourceId, $targetId) {
 	list ($ret, $preferences) = GalleryCoreApi::fetchDerivativePreferencesForItem($sourceId);
 	if ($ret) {
 	    return $ret;
@@ -453,7 +453,7 @@ class GalleryDerivativeHelper_advanced {
     /**
      * @see GalleryCoreApi::addDerivativePreference
      */
-    function addPreference($order, $itemId, $derivativeType, $derivativeOperations) {
+    static function addPreference($order, $itemId, $derivativeType, $derivativeOperations) {
 	if (is_array($itemId)) {
 	    /* Allow for adding same set of preferences to multiple items */
 	    $order = array_fill(0, count($itemId), $order);
@@ -476,7 +476,7 @@ class GalleryDerivativeHelper_advanced {
     /**
      * @see GalleryCoreApi::removeDerivativePreferencesForItem
      */
-    function removePreferencesForItem($itemId) {
+    static function removePreferencesForItem($itemId) {
 	$ret = GalleryCoreApi::removeMapEntry(
 	    'GalleryDerivativePreferencesMap', array('itemId' => $itemId));
 	if ($ret) {
@@ -489,7 +489,7 @@ class GalleryDerivativeHelper_advanced {
     /**
      * @see GalleryCoreApi::removeDerivativePreferencesForItemType
      */
-    function removePreferenceForItemType($itemId, $derivativeType) {
+    static function removePreferenceForItemType($itemId, $derivativeType) {
 	$ret = GalleryCoreApi::removeMapEntry(
 	    'GalleryDerivativePreferencesMap',
 	    array('itemId' => $itemId, 'derivativeType' => $derivativeType));
@@ -503,7 +503,7 @@ class GalleryDerivativeHelper_advanced {
     /**
      * @see GalleryCoreApi::fetchDerivativePreferencesForItem
      */
-    function fetchPreferencesForItem($targetId) {
+    static function fetchPreferencesForItem($targetId) {
 	global $gallery;
 
 	$query = '
@@ -536,7 +536,7 @@ class GalleryDerivativeHelper_advanced {
     /**
      * @see GalleryCoreApi::mergeDerivativeOperations
      */
-    function mergeOperations($operationSet1, $operationSet2, $highPriority=false) {
+    static function mergeOperations($operationSet1, $operationSet2, $highPriority=false) {
 	global $gallery;
 
 	/* Get all toolkits */
@@ -631,7 +631,7 @@ class GalleryDerivativeHelper_advanced {
     /**
      * @see GalleryCoreApi::removeDerivativeOperation
      */
-    function removeOperation($operation, $operationSet) {
+    static function removeOperation($operation, $operationSet) {
 	if (!empty($operationSet)) {
 	    $newOperations = array();
 	    $match = $operation . '|';
@@ -651,7 +651,7 @@ class GalleryDerivativeHelper_advanced {
     /**
      * @see GalleryCoreApi::expireDerivativeTreeBySourceIds
      */
-    function expireDerivativeTreeBySourceIds($ids) {
+    static function expireDerivativeTreeBySourceIds($ids) {
 	global $gallery;
 
 	if (!is_array($ids)) {
@@ -712,7 +712,7 @@ class GalleryDerivativeHelper_advanced {
     /**
      * @see GalleryCoreApi::invalidateDerivativeDimensionsBySourceIds
      */
-    function invalidateDerivativeDimensionsBySourceIds($ids) {
+    static function invalidateDerivativeDimensionsBySourceIds($ids) {
 	global $gallery;
 
 	if (!is_array($ids)) {
@@ -792,7 +792,7 @@ class GalleryDerivativeHelper_advanced {
     /**
      * @see GalleryCoreApi::rebuildDerivativeCache
      */
-    function rebuildCache($derivativeId) {
+    static function rebuildCache($derivativeId) {
 	global $gallery;
 
 	$gallery->guaranteeTimeLimit(10);
@@ -864,7 +864,7 @@ class GalleryDerivativeHelper_advanced {
     /**
      * @see GalleryCoreApi::fetchPreferredSource
      */
-    function fetchPreferredSource($item) {
+    static function fetchPreferredSource($item) {
 	$sourceIds = array();
 	$sourceIds[] = $item->getId();
 	if ($item->isLinked()) {

--- a/modules/core/classes/helpers/GalleryDerivativeHelper_medium.class
+++ b/modules/core/classes/helpers/GalleryDerivativeHelper_medium.class
@@ -31,7 +31,7 @@ class GalleryDerivativeHelper_medium {
     /**
      * @see GalleryCoreApi::fetchResizesByItemIds
      */
-    function fetchResizesByItemIds($ids) {
+    static function fetchResizesByItemIds($ids) {
 	if (!is_array($ids)) {
 	    return array(GalleryCoreApi::error(ERROR_BAD_PARAMETER), null);
 	}
@@ -53,7 +53,7 @@ class GalleryDerivativeHelper_medium {
     /**
      * @see GalleryCoreApi::fetchPreferredsByItemIds
      */
-    function fetchPreferredsByItemIds($ids) {
+    static function fetchPreferredsByItemIds($ids) {
 	if (!is_array($ids)) {
 	    return array(GalleryCoreApi::error(ERROR_BAD_PARAMETER), null);
 	}

--- a/modules/core/classes/helpers/GalleryDerivativeHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryDerivativeHelper_simple.class
@@ -31,7 +31,7 @@ class GalleryDerivativeHelper_simple {
     /**
      * @see GalleryCoreApi::rebuildDerivativeCacheIfNotCurrent
      */
-    function rebuildCacheIfNotCurrent($derivativeId, $fixBroken=false) {
+    static function rebuildCacheIfNotCurrent($derivativeId, $fixBroken=false) {
 	global $gallery;
 
 	list ($ret, $derivative) =
@@ -60,7 +60,7 @@ class GalleryDerivativeHelper_simple {
     /**
      * @see GalleryCoreApi::fetchThumbnailsByItemIds
      */
-    function fetchThumbnailsByItemIds($ids) {
+    static function fetchThumbnailsByItemIds($ids) {
 	if (!is_array($ids)) {
 	    return array(GalleryCoreApi::error(ERROR_BAD_PARAMETER), null);
 	}
@@ -93,7 +93,7 @@ class GalleryDerivativeHelper_simple {
      *               array(GalleryItem id => GalleryDerivativeImage, ...)
      * @access private
      */
-    function _loadDerivatives($itemIds, $sourceIds, $types=array()) {
+    static function _loadDerivatives($itemIds, $sourceIds, $types=array()) {
 	global $gallery;
 
 	if (empty($itemIds) && empty($sourceIds) ||

--- a/modules/core/classes/helpers/GalleryEntityHelper_medium.class
+++ b/modules/core/classes/helpers/GalleryEntityHelper_medium.class
@@ -31,7 +31,7 @@ class GalleryEntityHelper_medium {
     /**
      * @see GalleryCoreApi::deleteEntityById
      */
-    function deleteEntityById($id, $requiredEntityType=null) {
+    static function deleteEntityById($id, $requiredEntityType=null) {
 	if (empty($id)) {
 	    return GalleryCoreApi::error(ERROR_BAD_PARAMETER);
 	}
@@ -129,7 +129,7 @@ class GalleryEntityHelper_medium {
     /**
      * @see GalleryCoreApi::fetchEntitiesLinkedTo
      */
-    function fetchEntitiesLinkedTo($targetId) {
+    static function fetchEntitiesLinkedTo($targetId) {
 	global $gallery;
 
 	$query = '
@@ -159,7 +159,7 @@ class GalleryEntityHelper_medium {
     /**
      * @see GalleryCoreApi::removeOnLoadHandlers
      */
-    function removeOnLoadHandlers($handlerIds) {
+    static function removeOnLoadHandlers($handlerIds) {
 	global $gallery;
 
 	$query = 'SELECT [GalleryEntity::id] FROM [GalleryEntity]
@@ -204,7 +204,7 @@ class GalleryEntityHelper_medium {
     /**
      * @see GalleryCoreApi::updateModificationTimestamp
      */
-    function updateModificationTimestamp($entityId) {
+    static function updateModificationTimestamp($entityId) {
 	list ($ret, $lockId) = GalleryCoreApi::acquireWriteLock($entityId);
 	if ($ret) {
 	    return $ret;
@@ -230,7 +230,7 @@ class GalleryEntityHelper_medium {
     /**
      * @see GalleryCoreApi::deleteFastDownloadFileById
      */
-    function deleteFastDownloadFileById($entityId) {
+    static function deleteFastDownloadFileById($entityId) {
 	global $gallery;
 
 	$fastDownloadFilePath = GalleryDataCache::getCachePath(
@@ -244,7 +244,7 @@ class GalleryEntityHelper_medium {
     /**
      * @see GalleryCoreApi::createFastDownloadFile
      */
-    function createFastDownloadFile($entity, $runEvenInUnitTest=false) {
+    static function createFastDownloadFile($entity, $runEvenInUnitTest=false) {
 	global $gallery;
 
 	/* Disable this for unit tests, for now */
@@ -336,7 +336,7 @@ class GalleryEntityHelper_medium {
     /**
      * @see GalleryCoreApi::getExternalAccessMemberList
      */
-    function getExternalAccessMemberList($entityName) {
+    static function getExternalAccessMemberList($entityName) {
 	list ($ret, $entityInfo) = GalleryCoreApi::describeEntity($entityName);
 	if ($ret) {
 	    return array($ret, null);

--- a/modules/core/classes/helpers/GalleryEntityHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryEntityHelper_simple.class
@@ -31,7 +31,7 @@ class GalleryEntityHelper_simple {
     /**
      * @see GalleryCoreApi::loadEntitiesById
      */
-    function loadEntitiesById($ids, $requiredEntityType=null) {
+    static function loadEntitiesById($ids, $requiredEntityType=null) {
 	global $gallery;
 	$gallery->guaranteeTimeLimit(5);
 
@@ -142,7 +142,7 @@ class GalleryEntityHelper_simple {
     /**
      * @see GalleryCoreApi::loadEntityByExternalId
      */
-    function loadEntityByExternalId($externalId, $entityType) {
+    static function loadEntityByExternalId($externalId, $entityType) {
 	global $gallery;
 
 	list ($ret, $results) = GalleryCoreApi::getMapEntry('ExternalIdMap',

--- a/modules/core/classes/helpers/GalleryEventHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryEventHelper_simple.class
@@ -31,7 +31,7 @@ class GalleryEventHelper_simple {
     /**
      * @see GalleryCoreApi::newEvent
      */
-    function newEvent($eventName) {
+    static function newEvent($eventName) {
 	GalleryCoreApi::requireOnce('modules/core/classes/GalleryEvent.class');
 	$event = new GalleryEvent();
 	$event->setEventName($eventName);
@@ -41,7 +41,7 @@ class GalleryEventHelper_simple {
     /**
      * @see GalleryCoreApi::postEvent
      */
-    function postEvent($event) {
+    static function postEvent($event) {
 	list ($ret, $eventListeners) = GalleryCoreApi::getAllFactoryImplementationIdsWithHint(
 	    'GalleryEventListener', $event->getEventName());
 	if ($ret) {

--- a/modules/core/classes/helpers/GalleryEventHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryEventHelper_simple.class
@@ -128,7 +128,7 @@ class GalleryEventHelper_simple {
      * @access private
      * @todo Remove on next major API bump
      */
-    function &_getEventListeners() {
+    static function &_getEventListeners() {
 	static $allListeners = array();
 	return $allListeners;
     }
@@ -137,7 +137,7 @@ class GalleryEventHelper_simple {
      * @see GalleryCoreApi::registerEventListener
      * @todo Remove on next major API bump
      */
-    function registerEventListener($eventName, &$eventListener, $disableForTests=false) {
+    static function registerEventListener($eventName, &$eventListener, $disableForTests=false) {
 	if ($disableForTests && class_exists('GalleryTestCase')) {
 	    return;
 	}

--- a/modules/core/classes/helpers/GalleryEventLogHelper_medium.class
+++ b/modules/core/classes/helpers/GalleryEventLogHelper_medium.class
@@ -32,7 +32,7 @@ class GalleryEventLogHelper_medium {
     /**
      * @see GalleryCoreApi::addEventLogEntry
      */
-    function addEventLogEntry($type, $summary, $details) {
+    static function addEventLogEntry($type, $summary, $details) {
 	global $gallery;
 	$phpVm = $gallery->getPhpVm();
 	$storage =& $gallery->getStorage();

--- a/modules/core/classes/helpers/GalleryFactoryHelper_medium.class
+++ b/modules/core/classes/helpers/GalleryFactoryHelper_medium.class
@@ -71,7 +71,7 @@ class GalleryFactoryHelper_medium {
     /**
      * @see GalleryCoreApi::updateFactoryDefinitionHints
      */
-    function updateFactoryDefinitionHints($classType, $implId, $hints) {
+    static function updateFactoryDefinitionHints($classType, $implId, $hints) {
 	foreach ($hints as $i => $hint) {
 	    $hints[$i] = GalleryUtilities::strToLower($hint);
 	}
@@ -92,7 +92,7 @@ class GalleryFactoryHelper_medium {
     /**
      * @see GalleryCoreApi::unregisterFactoryImplementationsByModuleId
      */
-    function unregisterImplementationsByModuleId($moduleId) {
+    static function unregisterImplementationsByModuleId($moduleId) {
 	$ret = GalleryCoreApi::removeMapEntry(
 	    'GalleryFactoryMap', array('implModuleId' => $moduleId));
 	if ($ret) {
@@ -107,7 +107,7 @@ class GalleryFactoryHelper_medium {
     /**
      * @see GalleryCoreApi::unregisterFactoryImplementation
      */
-    function unregisterImplementation($classType, $implId) {
+    static function unregisterImplementation($classType, $implId) {
 	$ret = GalleryCoreApi::removeMapEntry(
 	    'GalleryFactoryMap',
 	    array('classType' => $classType, 'implId' => $implId));
@@ -123,7 +123,7 @@ class GalleryFactoryHelper_medium {
     /**
      * @see GalleryCoreApi::registerFactoryImplementation
      */
-    function registerImplementation($classType, $className, $implId, $implPath,
+    static function registerImplementation($classType, $className, $implId, $implPath,
 				    $implModuleId, $hints, $orderWeight) {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
@@ -164,7 +164,7 @@ class GalleryFactoryHelper_medium {
     /**
      * @see GalleryCoreApi::registerFactoryImplementation
      */
-    function registerFactoryImplementationForRequest($classType, $className, $implId, $implPath,
+    static function registerFactoryImplementationForRequest($classType, $className, $implId, $implPath,
 						     $implModuleId, $hints) {
 	$registryData =& GalleryFactoryHelper_simple::_getFactoryData();
 	if ($registryData[0]) {
@@ -207,7 +207,7 @@ class GalleryFactoryHelper_medium {
      * @param string $value the value of the new entry
      * @access private
      */
-    function _array_unshift_key_value(&$array, $key, $value) {
+    static function _array_unshift_key_value(&$array, $key, $value) {
 	unset($array[$key]);
 	$array = array_merge(array($key => $value), $array);
     }

--- a/modules/core/classes/helpers/GalleryFactoryHelper_medium.class
+++ b/modules/core/classes/helpers/GalleryFactoryHelper_medium.class
@@ -34,7 +34,7 @@ class GalleryFactoryHelper_medium {
     /**
      * @see GalleryCoreApi::getAllFactoryImplementationIdsWithHint
      */
-    function getAllImplementationIdsWithHint($classType, $hint) {
+    static function getAllImplementationIdsWithHint($classType, $hint) {
 	list ($ret, $registry) = GalleryFactoryHelper_simple::_getFactoryData();
 	if ($ret) {
 	    return array($ret, null);
@@ -52,7 +52,7 @@ class GalleryFactoryHelper_medium {
     /**
      * @see GalleryCoreApi::getFactoryDefinitionHints
      */
-    function getFactoryDefinitionHints($classType, $implId) {
+    static function getFactoryDefinitionHints($classType, $implId) {
 	list ($ret, $registry) = GalleryFactoryHelper_simple::_getFactoryData();
 	if ($ret) {
 	    return array($ret, null);

--- a/modules/core/classes/helpers/GalleryFactoryHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryFactoryHelper_simple.class
@@ -31,7 +31,7 @@ class GalleryFactoryHelper_simple {
     /**
      * Reset the static factory registry
      */
-    function deleteCache() {
+    static function deleteCache() {
 	$cacheParams = array('type' => 'module',
 			     'itemId' => 'GalleryFactoryHelper_loadRegistry',
 			     'id' => '_all');

--- a/modules/core/classes/helpers/GalleryFactoryHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryFactoryHelper_simple.class
@@ -209,7 +209,7 @@ class GalleryFactoryHelper_simple {
     /**
      * @see GalleryCoreApi::getAllFactoryImplementationIds
      */
-    function getAllImplementationIds($classType) {
+    static function getAllImplementationIds($classType) {
 	list ($ret, $registry) = GalleryFactoryHelper_simple::_getFactoryData();
 	if ($ret) {
 	    return array($ret, null);

--- a/modules/core/classes/helpers/GalleryFactoryHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryFactoryHelper_simple.class
@@ -47,7 +47,7 @@ class GalleryFactoryHelper_simple {
      * @return array factory registry data
      * @access private
      */
-    function &_getSingleton() {
+    static function &_getSingleton() {
 	static $registry = array();
 	return $registry;
     }
@@ -59,7 +59,7 @@ class GalleryFactoryHelper_simple {
      * @return array factory data
      * @access private
      */
-    function &_getFactoryData() {
+    static function &_getFactoryData() {
 	$registry =& GalleryFactoryHelper_simple::_getSingleton();
 	if (empty($registry)) {
 	    $cacheParams = array('type' => 'module',
@@ -101,7 +101,7 @@ class GalleryFactoryHelper_simple {
     /**
      * @see GalleryCoreApi::newFactoryInstanceByHint
      */
-    function newInstanceByHint($classType, $hints) {
+    static function newInstanceByHint($classType, $hints) {
 	list ($ret, $registry) = GalleryFactoryHelper_simple::_getFactoryData();
 	if ($ret) {
 	    return array($ret, null);
@@ -135,7 +135,7 @@ class GalleryFactoryHelper_simple {
     /**
      * @see GalleryCoreApi::newFactoryInstance
      */
-    function newInstance($classType, $className=null) {
+    static function newInstance($classType, $className=null) {
 	global $gallery;
 
 	list ($ret, $registry) = GalleryFactoryHelper_simple::_getFactoryData();
@@ -187,7 +187,7 @@ class GalleryFactoryHelper_simple {
     /**
      * @see GalleryCoreApi::newFactoryInstanceById
      */
-    function newInstanceById($classType, $id) {
+    static function newInstanceById($classType, $id) {
 	list ($ret, $registry) = GalleryFactoryHelper_simple::_getFactoryData();
 	if ($ret) {
 	    return array($ret, null);

--- a/modules/core/classes/helpers/GalleryFileSystemEntityHelper_medium.class
+++ b/modules/core/classes/helpers/GalleryFileSystemEntityHelper_medium.class
@@ -31,7 +31,7 @@ class GalleryFileSystemEntityHelper_medium {
     /**
      * @see GalleryCoreApi::checkPathCollision
      */
-    function checkPathCollision($pathComponent, $parentId, $selfId=null) {
+    static function checkPathCollision($pathComponent, $parentId, $selfId=null) {
 	global $gallery;
 
 	$pathComponent =
@@ -72,7 +72,7 @@ class GalleryFileSystemEntityHelper_medium {
     /**
      * @see GalleryCoreApi::getLegalPathComponent
      */
-    function getLegalPathComponent($pathComponent, $parentId, $selfId=null, $forDirectory=false) {
+    static function getLegalPathComponent($pathComponent, $parentId, $selfId=null, $forDirectory=false) {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
 
@@ -140,7 +140,7 @@ class GalleryFileSystemEntityHelper_medium {
      * @return string truncated path component
      * @access private
      */
-    function _truncatePathComponent($baseName, $variablePart='', $extension='') {
+    static function _truncatePathComponent($baseName, $variablePart='', $extension='') {
 
 	$length = 128 - strlen($variablePart) - strlen($extension);
 	$baseName = GalleryCoreApi::utf8Substring($baseName, 0, $length);

--- a/modules/core/classes/helpers/GalleryFileSystemEntityHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryFileSystemEntityHelper_simple.class
@@ -31,7 +31,7 @@ class GalleryFileSystemEntityHelper_simple {
     /**
      * @see GalleryCoreApi::fetchItemIdByPath
      */
-    function fetchItemIdByPath($path) {
+    static function fetchItemIdByPath($path) {
 	global $gallery;
 	if (empty($path)) {
 	    return array(GalleryCoreApi::error(ERROR_BAD_PARAMETER), null);
@@ -62,7 +62,7 @@ class GalleryFileSystemEntityHelper_simple {
     /**
      * @see GalleryCoreApi::fetchChildIdByPathComponent
      */
-    function fetchChildIdByPathComponent($parentId, $pathComponent) {
+    static function fetchChildIdByPathComponent($parentId, $pathComponent) {
 	global $gallery;
 
 	if (empty($parentId) || empty($pathComponent)) {

--- a/modules/core/classes/helpers/GalleryGroupHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryGroupHelper_simple.class
@@ -31,7 +31,7 @@ class GalleryGroupHelper_simple {
     /**
      * @see GalleryCoreApi::fetchGroupNames
      */
-    function fetchGroupNames($count=null, $offset=null, $substring=null) {
+    static function fetchGroupNames($count=null, $offset=null, $substring=null) {
 	global $gallery;
 
 	$data = array();
@@ -76,7 +76,7 @@ class GalleryGroupHelper_simple {
     /**
      * @see GalleryCoreApi::fetchGroupCount
      */
-    function fetchGroupCount($substring=null) {
+    static function fetchGroupCount($substring=null) {
 	global $gallery;
 
 	$data = array();
@@ -108,7 +108,7 @@ class GalleryGroupHelper_simple {
     /**
      * @see GalleryCoreApi::fetchGroupByGroupName
      */
-    function fetchGroupByGroupName($groupName=null) {
+    static function fetchGroupByGroupName($groupName=null) {
 	global $gallery;
 
 	$query = '

--- a/modules/core/classes/helpers/GalleryItemAttributesHelper_advanced.class
+++ b/modules/core/classes/helpers/GalleryItemAttributesHelper_advanced.class
@@ -31,7 +31,7 @@ class GalleryItemAttributesHelper_advanced {
     /**
      * @see GalleryCoreApi::rebalanceChildOrderWeights
      */
-    function rebalanceChildOrderWeights($parentItemId, $spacing=1000) {
+    static function rebalanceChildOrderWeights($parentItemId, $spacing=1000) {
 	global $gallery;
 
 	list ($ret, $parentItem) = GalleryCoreApi::loadEntitiesById($parentItemId, 'GalleryItem');
@@ -60,7 +60,7 @@ class GalleryItemAttributesHelper_advanced {
     /**
      * @see GalleryCoreApi::fetchExtremeChildWeight
      */
-    function fetchExtremeChildWeight($itemId, $direction) {
+    static function fetchExtremeChildWeight($itemId, $direction) {
 	global $gallery;
 
 	$aggregate = ($direction == LOWER_WEIGHT) ? 'MIN' : 'MAX';
@@ -89,7 +89,7 @@ class GalleryItemAttributesHelper_advanced {
     /**
      * @see GalleryCoreApi::fetchNextItemWeight
      */
-    function fetchNextWeight($itemId, $direction) {
+    static function fetchNextWeight($itemId, $direction) {
 	global $gallery;
 
 	if ($direction == LOWER_WEIGHT) {
@@ -132,7 +132,7 @@ class GalleryItemAttributesHelper_advanced {
     /**
      * @see GalleryCoreApi::setItemViewCount
      */
-    function setViewCount($itemId, $count) {
+    static function setViewCount($itemId, $count) {
 	$ret = GalleryCoreApi::updateMapEntry(
 	    'GalleryItemAttributesMap',
 	    array('itemId' => $itemId),
@@ -147,7 +147,7 @@ class GalleryItemAttributesHelper_advanced {
     /**
      * @see GalleryCoreApi::setParentSequence
      */
-    function setParentSequence($itemId, $parentSequence) {
+    static function setParentSequence($itemId, $parentSequence) {
 	if (empty($parentSequence)) {
 	    $parentSequence = '';
 	} else {
@@ -168,7 +168,7 @@ class GalleryItemAttributesHelper_advanced {
     /**
      * @see GalleryCoreApi::createItemAttributes
      */
-    function createItemAttributes($itemId, $parentSequence) {
+    static function createItemAttributes($itemId, $parentSequence) {
 	if (empty($parentSequence)) {
 	    $parentSequence = '';
 	} else {
@@ -190,7 +190,7 @@ class GalleryItemAttributesHelper_advanced {
     /**
      * @see GalleryCoreApi::removeItemAttributes
      */
-    function removeItemAttributes($itemId) {
+    static function removeItemAttributes($itemId) {
 	$ret = GalleryCoreApi::removeMapEntry(
 	    'GalleryItemAttributesMap', array('itemId' => $itemId));
 	if ($ret) {
@@ -203,7 +203,7 @@ class GalleryItemAttributesHelper_advanced {
     /**
      * @see GalleryCoreApi::setItemOrderWeight
      */
-    function setOrderWeight($itemId, $orderWeight) {
+    static function setOrderWeight($itemId, $orderWeight) {
 	$ret = GalleryCoreApi::updateMapEntry(
 	    'GalleryItemAttributesMap',
 	    array('itemId' => $itemId),
@@ -218,7 +218,7 @@ class GalleryItemAttributesHelper_advanced {
     /**
      * @see GalleryCoreApi::updateParentSequence
      */
-    function updateParentSequence($oldParentSequence, $newParentSequence) {
+    static function updateParentSequence($oldParentSequence, $newParentSequence) {
 	global $gallery;
 
 	$oldParentSequence = join('/', $oldParentSequence) . '/';

--- a/modules/core/classes/helpers/GalleryItemAttributesHelper_medium.class
+++ b/modules/core/classes/helpers/GalleryItemAttributesHelper_medium.class
@@ -31,7 +31,7 @@ class GalleryItemAttributesHelper_medium {
     /**
      * @see GalleryCoreApi::fetchItemOrderWeight
      */
-    function fetchOrderWeight($itemId) {
+    static function fetchOrderWeight($itemId) {
 	list ($ret, $orderWeights) =
 	    GalleryItemAttributesHelper_medium::fetchOrderWeights(array($itemId));
 	if ($ret) {
@@ -48,7 +48,7 @@ class GalleryItemAttributesHelper_medium {
     /**
      * @see GalleryCoreApi::fetchItemOrderWeights
      */
-    function fetchOrderWeights($itemIds) {
+    static function fetchOrderWeights($itemIds) {
 	global $gallery;
 
 	foreach ($itemIds as $idx => $id) {

--- a/modules/core/classes/helpers/GalleryItemAttributesHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryItemAttributesHelper_simple.class
@@ -31,7 +31,7 @@ class GalleryItemAttributesHelper_simple {
     /**
      * @see GalleryCoreApi::incrementItemViewCount
      */
-    function incrementViewCount($itemId, $step=1) {
+    static function incrementViewCount($itemId, $step=1) {
 	global $gallery;
 	$session =& $gallery->getSession();
 
@@ -97,7 +97,7 @@ class GalleryItemAttributesHelper_simple {
     /**
      * @see GalleryCoreApi::fetchItemViewCount
      */
-    function fetchViewCount($itemId) {
+    static function fetchViewCount($itemId) {
 	list ($ret, $viewCounts) =
 	    GalleryItemAttributesHelper_simple::fetchViewCounts(array($itemId));
 	if ($ret) {
@@ -110,7 +110,7 @@ class GalleryItemAttributesHelper_simple {
     /**
      * @see GalleryCoreApi::fetchItemViewCounts
      */
-    function fetchViewCounts($itemIds) {
+    static function fetchViewCounts($itemIds) {
 	foreach ($itemIds as $idx => $id) {
 	    $itemIds[$idx] = (int)$id;
 	}
@@ -135,7 +135,7 @@ class GalleryItemAttributesHelper_simple {
     /**
      * @see GalleryCoreApi::fetchParentSequence
      */
-    function fetchParentSequence($itemId, $filterBreadcrumb=false) {
+    static function fetchParentSequence($itemId, $filterBreadcrumb=false) {
 	global $gallery;
 	if ($filterBreadcrumb && ($filter = $gallery->getConfig('breadcrumbRootId'))
 		&& $itemId == $filter) {

--- a/modules/core/classes/helpers/GalleryItemHelper_advanced.class
+++ b/modules/core/classes/helpers/GalleryItemHelper_advanced.class
@@ -31,7 +31,7 @@ class GalleryItemHelper_advanced {
     /**
      * @see GalleryCoreApi::fetchItemizedDescendentCounts
      */
-    function fetchItemizedDescendentCounts($itemIds) {
+    static function fetchItemizedDescendentCounts($itemIds) {
 	global $gallery;
 
 	foreach ($itemIds as $idx => $id) {
@@ -115,7 +115,7 @@ class GalleryItemHelper_advanced {
     /**
      * @see GalleryCoreApi::guaranteeAlbumHasThumbnail
      */
-    function guaranteeAlbumHasThumbnail($albumId) {
+    static function guaranteeAlbumHasThumbnail($albumId) {
 	global $gallery;
 
 	list ($ret, $thumbnails) = GalleryCoreApi::fetchThumbnailsByItemIds(array($albumId));
@@ -195,7 +195,7 @@ class GalleryItemHelper_advanced {
     /**
      * @see GalleryCoreApi::createAlbum
      */
-    function createAlbum($parentAlbumId, $name, $title, $summary, $description, $keywords) {
+    static function createAlbum($parentAlbumId, $name, $title, $summary, $description, $keywords) {
 	global $gallery;
 
 	/* Can't work without a name and a parentAlbum */
@@ -274,7 +274,7 @@ class GalleryItemHelper_advanced {
      * @see GalleryCoreApi::remapOwnerId
      * @todo Scalability - Lock and load the items in batches (open files limit).
      */
-    function remapOwnerId($oldUserId, $newUserId) {
+    static function remapOwnerId($oldUserId, $newUserId) {
 	global $gallery;
 
 	if (empty($oldUserId) || empty($newUserId)) {
@@ -388,7 +388,7 @@ class GalleryItemHelper_advanced {
     /**
      * @see GalleryCoreApi::deleteSortOrder
      */
-    function deleteSortOrder($sortOrder) {
+    static function deleteSortOrder($sortOrder) {
 	global $gallery;
 
 	$query = '
@@ -462,7 +462,7 @@ class GalleryItemHelper_advanced {
     /**
      * @see GalleryCoreApi::deleteRenderer
      */
-    function deleteRenderer($rendererClassName) {
+    static function deleteRenderer($rendererClassName) {
 	global $gallery;
 
 	$query = '

--- a/modules/core/classes/helpers/GalleryItemHelper_medium.class
+++ b/modules/core/classes/helpers/GalleryItemHelper_medium.class
@@ -31,7 +31,7 @@ class GalleryItemHelper_medium /* extends GalleryEventListener */ {
     /**
      * @see GalleryCoreApi::fetchAllItemIds
      */
-    function fetchAllItemIds($itemType, $permission='core.view') {
+    static function fetchAllItemIds($itemType, $permission='core.view') {
 	global $gallery;
 
 	if (empty($itemType)) {
@@ -84,7 +84,7 @@ class GalleryItemHelper_medium /* extends GalleryEventListener */ {
     /**
      * @see GalleryCoreApi::fetchAllItemIdsByOwnerId
      */
-    function fetchAllItemIdsByOwnerId($ownerId) {
+    static function fetchAllItemIdsByOwnerId($ownerId) {
 	global $gallery;
 
 	if (empty($ownerId)) {
@@ -117,7 +117,7 @@ class GalleryItemHelper_medium /* extends GalleryEventListener */ {
     /**
      * @see GalleryCoreApi::newItemByMimeType
      */
-    function newItemByMimeType($mimeType) {
+    static function newItemByMimeType($mimeType) {
 
 	/* Try the whole mime type first, fallback to major type only */
 	list ($ret, $instance) = GalleryCoreApi::newFactoryInstanceByHint('GalleryItem',
@@ -132,7 +132,7 @@ class GalleryItemHelper_medium /* extends GalleryEventListener */ {
     /**
      * @see GalleryCoreApi::addItemToAlbum
      */
-    function addItemToAlbum($fileName, $itemName, $title, $summary,
+    static function addItemToAlbum($fileName, $itemName, $title, $summary,
 			    $description, $mimeType, $albumId, $symlink=false) {
 	global $gallery;
 
@@ -196,7 +196,7 @@ class GalleryItemHelper_medium /* extends GalleryEventListener */ {
     /**
      * @see GalleryCoreApi::fetchOriginationTimestamp
      */
-    function fetchOriginationTimestamp($item) {
+    static function fetchOriginationTimestamp($item) {
 	if (! GalleryUtilities::isA($item, 'GalleryDataItem')) {
 	    return array(null, null);
 	}
@@ -229,7 +229,7 @@ class GalleryItemHelper_medium /* extends GalleryEventListener */ {
     /**
      * @see GalleryCoreApi::addExistingItemToAlbum
      */
-    function addExistingItemToAlbum($item, $albumId, $isNew=false) {
+    static function addExistingItemToAlbum($item, $albumId, $isNew=false) {
 
 	/* Set the order weight */
 	list ($ret, $maxWeight) = GalleryCoreApi::fetchExtremeChildWeight($albumId, HIGHER_WEIGHT);
@@ -252,7 +252,7 @@ class GalleryItemHelper_medium /* extends GalleryEventListener */ {
     /**
      * @see GalleryCoreApi::applyDerivativePreferences
      */
-    function applyDerivativePreferences($item, $albumId, $isNew=false) {
+    static function applyDerivativePreferences($item, $albumId, $isNew=false) {
 	list ($ret, $preferences) = GalleryCoreApi::fetchDerivativePreferencesForItem($albumId);
 	if ($ret) {
 	    return $ret;
@@ -541,7 +541,7 @@ class GalleryItemHelper_medium /* extends GalleryEventListener */ {
     /**
      * @see GalleryCoreApi::setThumbnailFromItem
      */
-    function setThumbnailFromItem($itemId, $fromItemId) {
+    static function setThumbnailFromItem($itemId, $fromItemId) {
 	global $gallery;
 
 	/* Load the current album thumbnail. */
@@ -812,7 +812,7 @@ class GalleryItemHelper_medium /* extends GalleryEventListener */ {
      * @param mixed $itemId item id or array of ids or null
      * @return GalleryStatus a status code
      */
-    function invalidateDescendentCountCaches($userId, $itemId) {
+    static function invalidateDescendentCountCaches($userId, $itemId) {
 	if (!empty($userId) && empty($itemId)) {
 	    $ret = GalleryCoreApi::removeMapEntry(
 		'GalleryDescendentCountsMap', array('userId' => $userId));
@@ -866,7 +866,7 @@ class GalleryItemHelper_medium /* extends GalleryEventListener */ {
      *
      * @see GalleryEventListener::handleEvent
      */
-    function handleEvent($event) {
+    static function handleEvent($event) {
 	$param = $event->getData();
 	if ($event->getEventName() == 'Gallery::ViewableTreeChange') {
 	    $ret = GalleryItemHelper_medium::invalidateDescendentCountCaches(

--- a/modules/core/classes/helpers/GalleryItemHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryItemHelper_simple.class
@@ -31,7 +31,7 @@ class GalleryItemHelper_simple {
     /**
      * @see GalleryCoreApi::fetchThemeId
      */
-    function fetchThemeId($item) {
+    static function fetchThemeId($item) {
 	global $gallery;
 
 	/* Find the right theme for this item */
@@ -66,7 +66,7 @@ class GalleryItemHelper_simple {
     /**
      * @see GalleryCoreApi::fetchChildCounts
      */
-    function fetchChildCounts($itemIds, $userId=null) {
+    static function fetchChildCounts($itemIds, $userId=null) {
 	global $gallery;
 	if (!isset($userId)) {
 	    $userId = $gallery->getActiveUserId();
@@ -134,7 +134,7 @@ class GalleryItemHelper_simple {
     /**
      * @see GalleryCoreApi::fetchDescendentCounts
      */
-    function fetchDescendentCounts($itemIds, $userId=null) {
+    static function fetchDescendentCounts($itemIds, $userId=null) {
 	global $gallery;
 	if (!isset($userId)) {
 	    $userId = $gallery->getActiveUserId();
@@ -200,7 +200,7 @@ class GalleryItemHelper_simple {
      * @return array GalleryStatus a status code
      *               array(id => ##, id => ##)
      */
-    function fetchUncachedDescendentCounts($itemIds, $userId) {
+    static function fetchUncachedDescendentCounts($itemIds, $userId) {
 	global $gallery;
 
 	if (!isset($userId)) {
@@ -284,7 +284,7 @@ class GalleryItemHelper_simple {
     /**
      * @see GalleryCoreApi::fetchItemIdCount
      */
-    function fetchItemIdCount($itemType, $permission='core.view', $userId=null) {
+    static function fetchItemIdCount($itemType, $permission='core.view', $userId=null) {
 	global $gallery;
 	if (!isset($userId)) {
 	    $userId = $gallery->getActiveUserId();
@@ -346,7 +346,7 @@ class GalleryItemHelper_simple {
     /**
      * @see GalleryCoreApi::fetchAlbumTree
      */
-    function fetchAlbumTree($itemId=null, $depth=null, $userId=null) {
+    static function fetchAlbumTree($itemId=null, $depth=null, $userId=null) {
 	global $gallery;
 	$storage =& $gallery->getStorage();
 	if (!isset($userId)) {

--- a/modules/core/classes/helpers/GalleryLockHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryLockHelper_simple.class
@@ -33,7 +33,7 @@ class GalleryLockHelper_simple {
      * @see GalleryCoreApi::getLockIds
      * @see GalleryLockSystem::getLockIds
      */
-    function getLockIds() {
+    static function getLockIds() {
 	global $gallery;
 	$result =& $gallery->getLockSystem();
 	$ret = $result[0];
@@ -50,7 +50,7 @@ class GalleryLockHelper_simple {
      * @see GalleryCoreApi::acquireReadLock
      * @see GalleryLockSystem::acquireReadLock
      */
-    function acquireReadLock($ids, $timeout=10) {
+    static function acquireReadLock($ids, $timeout=10) {
 	global $gallery;
 	$result =& $gallery->getLockSystem();
 	$ret = $result[0];
@@ -70,7 +70,7 @@ class GalleryLockHelper_simple {
     /**
      * @see GalleryCoreApi::acquireReadLockParents
      */
-    function acquireReadLockParents($id, $timeout=10) {
+    static function acquireReadLockParents($id, $timeout=10) {
 	global $gallery;
 
 	/*
@@ -144,7 +144,7 @@ class GalleryLockHelper_simple {
      * @see GalleryCoreApi::isReadLocked
      * @see GalleryLockSystem::isReadLocked
      */
-    function isReadLocked($ids) {
+    static function isReadLocked($ids) {
 	global $gallery;
 	$result =& $gallery->getLockSystem();
 	$ret = $result[0];
@@ -164,7 +164,7 @@ class GalleryLockHelper_simple {
      * @see GalleryCoreApi::acquireWriteLock
      * @see GalleryLockSystem::acquireWriteLock
      */
-    function acquireWriteLock($ids, $timeout=10) {
+    static function acquireWriteLock($ids, $timeout=10) {
 	global $gallery;
 	$result =& $gallery->getLockSystem();
 	$ret = $result[0];
@@ -185,7 +185,7 @@ class GalleryLockHelper_simple {
      * @see GalleryCoreApi::isWriteLocked
      * @see GalleryLockSystem::isWriteLocked
      */
-    function isWriteLocked($ids) {
+    static function isWriteLocked($ids) {
 	global $gallery;
 	$result =& $gallery->getLockSystem();
 	$ret = $result[0];
@@ -205,7 +205,7 @@ class GalleryLockHelper_simple {
      * @see GalleryCoreApi::releaseLocks
      * @see GalleryLockSystem::releaseLocks
      */
-    function releaseLocks($lockIds) {
+    static function releaseLocks($lockIds) {
 	global $gallery;
 	$result =& $gallery->getLockSystem();
 	$ret = $result[0];
@@ -226,7 +226,7 @@ class GalleryLockHelper_simple {
      * @see GalleryCoreApi::releaseAllLocks
      * @see GalleryLockSystem::releaseAllLocks
      */
-    function releaseAllLocks() {
+    static function releaseAllLocks() {
 	global $gallery;
 	$result =& $gallery->getLockSystem();
 	$ret = $result[0];
@@ -247,7 +247,7 @@ class GalleryLockHelper_simple {
      * @see GalleryCoreApi::refreshLocks
      * @see GalleryLockSystem::refreshLocks
      */
-    function refreshLocks($freshUntil) {
+    static function refreshLocks($freshUntil) {
 	global $gallery;
 	$result =& $gallery->getLockSystem();
 	$ret = $result[0];

--- a/modules/core/classes/helpers/GalleryMimeTypeHelper_advanced.class
+++ b/modules/core/classes/helpers/GalleryMimeTypeHelper_advanced.class
@@ -35,7 +35,7 @@ class GalleryMimeTypeHelper_advanced {
      * Initialize mime types and store them in the database
      * @return GalleryStatus a status code
      */
-    function initializeMimeTypes() {
+    static function initializeMimeTypes() {
 	$mimeTypes = array(
 	    /* This data was lifted from Apache's mime.types listing. */
 	    'z' => 'application/x-compress',
@@ -228,7 +228,7 @@ class GalleryMimeTypeHelper_advanced {
     /**
      * @see GalleryCoreApi::removeMimeType
      */
-    function removeMimeType($mimeMatch) {
+    static function removeMimeType($mimeMatch) {
 	$ret = GalleryCoreApi::removeMapEntry('GalleryMimeTypeMap', $mimeMatch);
 	if ($ret) {
 	    return $ret;
@@ -240,7 +240,7 @@ class GalleryMimeTypeHelper_advanced {
     /**
      * @see GalleryCoreApi::addMimeType
      */
-    function addMimeType($extension, $mimeType, $viewable) {
+    static function addMimeType($extension, $mimeType, $viewable) {
 	global $gallery;
 
 	/* Check to see if the extension already exists. */

--- a/modules/core/classes/helpers/GalleryMimeTypeHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryMimeTypeHelper_simple.class
@@ -31,7 +31,7 @@ class GalleryMimeTypeHelper_simple {
     /**
      * @see GalleryCoreApi::getMimeType
      */
-    function getMimeType($filename, $requestMimeType=null) {
+    static function getMimeType($filename, $requestMimeType=null) {
 	$extension = GalleryUtilities::getFileExtension($filename);
 	list ($ret, $mimetype) = GalleryMimeTypeHelper_simple::convertExtensionToMime($extension);
 	if ($ret) {
@@ -58,7 +58,7 @@ class GalleryMimeTypeHelper_simple {
     /**
      * @see GalleryCoreApi::convertExtensionToMime
      */
-    function convertExtensionToMime($extension) {
+    static function convertExtensionToMime($extension) {
 	list ($ret, $mimeData) = GalleryMimeTypeHelper_simple::_getMimeData();
 	if ($ret) {
 	    return array($ret, null);
@@ -73,7 +73,7 @@ class GalleryMimeTypeHelper_simple {
     /**
      * @see GalleryCoreApi::convertMimeToExtensions
      */
-    function convertMimeToExtensions($mimeType) {
+    static function convertMimeToExtensions($mimeType) {
 	list ($ret, $mimeData) = GalleryMimeTypeHelper_simple::_getMimeData();
 	if ($ret) {
 	    return array($ret, null);
@@ -88,7 +88,7 @@ class GalleryMimeTypeHelper_simple {
     /**
      * @see GalleryCoreApi::isViewableMimeType
      */
-    function isViewableMimeType($mimeType) {
+    static function isViewableMimeType($mimeType) {
 	list ($ret, $mimeData) = GalleryMimeTypeHelper_simple::_getMimeData();
 	if ($ret) {
 	    return array($ret, null);
@@ -108,7 +108,7 @@ class GalleryMimeTypeHelper_simple {
      *                                                                 'viewable' => boolean)))
      * @access private
      */
-    function &_getMimeData() {
+    static function &_getMimeData() {
 	$mimeData =& GalleryMimeTypeHelper_simple::_getSingleton();
 	if (empty($mimeData)) {
 	    $cacheParams = array('type' => 'module', 'id' => '_all',
@@ -162,7 +162,7 @@ class GalleryMimeTypeHelper_simple {
      * @staticvar array $mimeData
      * @access private
      */
-    function &_getSingleton() {
+    static function &_getSingleton() {
 	static $mimeData = array();
 	return $mimeData;
     }
@@ -171,7 +171,7 @@ class GalleryMimeTypeHelper_simple {
      * Clear cached mime type data
      * @access private
      */
-    function _deleteCache() {
+    static function _deleteCache() {
 	GalleryDataCache::removeFromDisk(array('type' => 'module', 'id' => '_all',
 					       'itemId' => 'GalleryMimeTypeHelper_mimeData'));
 	$mimeData =& GalleryMimeTypeHelper_simple::_getSingleton();

--- a/modules/core/classes/helpers/GalleryPermissionHelper_advanced.class
+++ b/modules/core/classes/helpers/GalleryPermissionHelper_advanced.class
@@ -33,7 +33,7 @@ class GalleryPermissionHelper_advanced {
     /**
      * @see GalleryCoreApi::addUserPermission
      */
-    function addUserPermission($itemId, $userId, $permission, $applyToChildren=false) {
+    static function addUserPermission($itemId, $userId, $permission, $applyToChildren=false) {
 	$ret = GalleryPermissionHelper_advanced::_changePermission(
 	    'add', $itemId, $userId, $permission, $applyToChildren);
 	if ($ret) {
@@ -55,7 +55,7 @@ class GalleryPermissionHelper_advanced {
     /**
      * @see GalleryCoreApi::addGroupPermission
      */
-    function addGroupPermission($itemId, $groupId, $permission, $applyToChildren=false) {
+    static function addGroupPermission($itemId, $groupId, $permission, $applyToChildren=false) {
 	$ret = GalleryPermissionHelper_advanced::_changePermission(
 	    'add', $itemId, $groupId, $permission, $applyToChildren);
 	if ($ret) {
@@ -82,7 +82,7 @@ class GalleryPermissionHelper_advanced {
      * @return GalleryStatus a status code
      * @access private
      */
-    function _postGroupEvent($groupId, $itemId, $permission, $applyToChildren, $changeType) {
+    static function _postGroupEvent($groupId, $itemId, $permission, $applyToChildren, $changeType) {
 	$userId = null;
 	list ($ret, $group) = GalleryCoreApi::loadEntitiesById($groupId, 'GalleryGroup');
 	if ($ret) {
@@ -112,7 +112,7 @@ class GalleryPermissionHelper_advanced {
     /**
      * @see GalleryCoreApi::addEntityPermission
      */
-    function addEntityPermission($itemId, $entityId, $permission, $applyToChildren=false) {
+    static function addEntityPermission($itemId, $entityId, $permission, $applyToChildren=false) {
 	$ret = GalleryPermissionHelper_advanced::_changePermission(
 	    'add', $itemId, $entityId, $permission, $applyToChildren);
 	if ($ret) {
@@ -125,7 +125,7 @@ class GalleryPermissionHelper_advanced {
     /**
      * @see GalleryCoreApi::removeUserPermission
      */
-    function removeUserPermission($itemId, $userId, $permission, $applyToChildren=false) {
+    static function removeUserPermission($itemId, $userId, $permission, $applyToChildren=false) {
 	$ret = GalleryPermissionHelper_advanced::_changePermission(
 	    'remove', $itemId, $userId, $permission, $applyToChildren,
 	    array('userId' => (int)$userId, 'groupId' => null));
@@ -148,7 +148,7 @@ class GalleryPermissionHelper_advanced {
     /**
      * @see GalleryCoreApi::removeGroupPermission
      */
-    function removeGroupPermission($itemId, $groupId, $permission, $applyToChildren=false) {
+    static function removeGroupPermission($itemId, $groupId, $permission, $applyToChildren=false) {
 	$ret = GalleryPermissionHelper_advanced::_changePermission(
 	    'remove', $itemId, $groupId, $permission, $applyToChildren,
 	    array('userId' => null, 'groupId' => (int)$groupId));
@@ -168,7 +168,7 @@ class GalleryPermissionHelper_advanced {
     /**
      * @see GalleryCoreApi::removeEntityPermission
      */
-    function removeEntityPermission($itemId, $entityId, $permission, $applyToChildren=false) {
+    static function removeEntityPermission($itemId, $entityId, $permission, $applyToChildren=false) {
 	$ret = GalleryPermissionHelper_advanced::_changePermission(
 	    'remove', $itemId, $entityId, $permission, $applyToChildren);
 	if ($ret) {
@@ -190,7 +190,7 @@ class GalleryPermissionHelper_advanced {
      * @return GalleryStatus a status code
      * @access private
      */
-    function _changePermission($changeType, $itemId, $entityId,
+    static function _changePermission($changeType, $itemId, $entityId,
 			       $permission, $applyToChildren, $removeEventIds=null) {
 	global $gallery;
 	if (empty($itemId) || empty($entityId) || empty($permission) ||
@@ -441,7 +441,7 @@ class GalleryPermissionHelper_advanced {
     /**
      * @see GalleryCoreApi::removeItemPermissions
      */
-    function removeItemPermissions($itemId) {
+    static function removeItemPermissions($itemId) {
 	global $gallery;
 	if (empty($itemId) || !is_int($itemId)) {
 	    return GalleryCoreApi::error(ERROR_BAD_PARAMETER);
@@ -490,7 +490,7 @@ class GalleryPermissionHelper_advanced {
     /**
      * @see GalleryCoreApi::fetchAllPermissionsForItem
      */
-    function fetchAllPermissionsForItem($itemId, $compress=false) {
+    static function fetchAllPermissionsForItem($itemId, $compress=false) {
 	global $gallery;
 
 	if (empty($itemId)) {
@@ -550,7 +550,7 @@ class GalleryPermissionHelper_advanced {
      *               int permissions or null if not found
      * @access private
      */
-    function _fetchPermissionBitsForItem($itemId, $userOrGroupId) {
+    static function _fetchPermissionBitsForItem($itemId, $userOrGroupId) {
 	global $gallery;
 
 	if (empty($itemId) || empty($userOrGroupId)) {
@@ -587,7 +587,7 @@ class GalleryPermissionHelper_advanced {
     /**
      * @see GalleryCoreApi::fetchAccessListId
      */
-    function fetchAccessListId($itemId) {
+    static function fetchAccessListId($itemId) {
 	global $gallery;
 
 	if(empty($itemId)) {
@@ -612,7 +612,7 @@ class GalleryPermissionHelper_advanced {
      *               int AccessListId the new access list's id
      * @access private
      */
-    function _copyAccessList($oldAccessListId) {
+    static function _copyAccessList($oldAccessListId) {
 	global $gallery;
 
 	$storage =& $gallery->getStorage();
@@ -650,7 +650,7 @@ class GalleryPermissionHelper_advanced {
     /**
      * @see GalleryCoreApi::copyPermissions
      */
-    function copyPermissions($toId, $fromId) {
+    static function copyPermissions($toId, $fromId) {
 	global $gallery;
 
 	if (empty($toId) || empty($fromId)) {
@@ -688,7 +688,7 @@ class GalleryPermissionHelper_advanced {
     /**
      * @see GalleryCoreApi::hasPermission
      */
-    function hasPermission($itemId, $entityIds, $permissions) {
+    static function hasPermission($itemId, $entityIds, $permissions) {
 	global $gallery;
 
 	if (empty($permissions) || empty($entityIds)) {
@@ -742,7 +742,7 @@ class GalleryPermissionHelper_advanced {
     /**
      * @see GalleryCoreApi::registerPermission
      */
-    function registerPermission($module, $permissionId, $description,
+    static function registerPermission($module, $permissionId, $description,
 				$flags=0, $composites=array()) {
 	global $gallery;
 
@@ -807,7 +807,7 @@ class GalleryPermissionHelper_advanced {
     /**
      * @see GalleryCoreApi::getPermissionIds
      */
-    function getPermissionIds($flags=0) {
+    static function getPermissionIds($flags=0) {
 	GalleryCoreApi::requireOnce(
 		'modules/core/classes/helpers/GalleryPermissionHelper_simple.class');
 	list ($ret, $allPermissions) = GalleryPermissionHelper_simple::_fetchAllPermissions();
@@ -828,7 +828,7 @@ class GalleryPermissionHelper_advanced {
     /**
      * @see GalleryCoreApi::getSubPermissions
      */
-    function getSubPermissions($permissionId) {
+    static function getSubPermissions($permissionId) {
 	list ($ret, $bits) =
 	    GalleryCoreApi::convertPermissionIdsToBits(array($permissionId));
 	if ($ret) {
@@ -846,7 +846,7 @@ class GalleryPermissionHelper_advanced {
     /**
      * @see GalleryCoreApi::unregisterModulePermissions
      */
-    function unregisterModulePermissions($moduleId) {
+    static function unregisterModulePermissions($moduleId) {
 	if (empty($moduleId)) {
 	    return GalleryCoreApi::error(ERROR_BAD_PARAMETER);
 	}
@@ -888,7 +888,7 @@ class GalleryPermissionHelper_advanced {
      *               int location of a bit (1, 2, 3, etc)
      * @access private
      */
-    function _newPermissionBit() {
+    static function _newPermissionBit() {
 	list ($ret, $allPermissions) = GalleryPermissionHelper_simple::_fetchAllPermissions();
 	if ($ret) {
 	    return array($ret, null);
@@ -937,7 +937,7 @@ class GalleryPermissionHelper_advanced {
      * @return GalleryStatus a status code
      * @access private
      */
-    function _setPermission($data) {
+    static function _setPermission($data) {
 	$cacheKey = 'GalleryPermissionHelper::_allPermissions';
 	if (GalleryDataCache::containsKey($cacheKey)) {
 	    $permissions = GalleryDataCache::get($cacheKey);
@@ -964,7 +964,7 @@ class GalleryPermissionHelper_advanced {
      * @param array $permissionIds permission ids
      * @return GalleryStatus a status code
      */
-    function _removePermissionsFromAllItems($permissionIds) {
+    static function _removePermissionsFromAllItems($permissionIds) {
 	global $gallery;
 
 	list ($ret, $removeBits) = GalleryCoreApi::convertPermissionIdsToBits($permissionIds);
@@ -1027,7 +1027,7 @@ class GalleryPermissionHelper_advanced {
      *         int lock id
      * @access private
      */
-    function _getAccessListCompacterLock($type) {
+    static function _getAccessListCompacterLock($type) {
 	list ($ret, $semaphoreId) =
 	    GalleryCoreApi::getPluginParameter('module', 'core', 'id.accessListCompacterLock');
 	if ($ret) {
@@ -1068,7 +1068,7 @@ class GalleryPermissionHelper_advanced {
     /**
      * @see GalleryCoreApi::maybeCompactAccessLists
      */
-    function maybeCompactAccessLists() {
+    static function maybeCompactAccessLists() {
 	/* We use a high tech genetic algorithm to make our decision */
 	if (rand(1, 100) <= 50) {
 	    $ret = GalleryPermissionHelper_advanced::compactAccessLists();
@@ -1082,7 +1082,7 @@ class GalleryPermissionHelper_advanced {
     /**
      * @see GalleryCoreApi::compactAccessLists
      */
-    function compactAccessLists() {
+    static function compactAccessLists() {
 	global $gallery;
 	$storage =& $gallery->getStorage();
 

--- a/modules/core/classes/helpers/GalleryPermissionHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryPermissionHelper_simple.class
@@ -31,7 +31,7 @@ class GalleryPermissionHelper_simple {
     /**
      * @see GalleryCoreApi::fetchAccessListIds
      */
-    function fetchAccessListIds($permission, $userId, $sessionPermissions=true) {
+    static function fetchAccessListIds($permission, $userId, $sessionPermissions=true) {
 	$permission = is_array($permission) ? $permission : array($permission);
 	$aclIds = false;
 	foreach ($permission as $permissionId) {
@@ -54,7 +54,7 @@ class GalleryPermissionHelper_simple {
      * Like GalleryCoreApi::fetchAccessListIds but only processes a single permission id
      * @access private
      */
-    function _fetchAccessListIds($permission, $userId, $sessionPermissions=true) {
+    static function _fetchAccessListIds($permission, $userId, $sessionPermissions=true) {
 	global $gallery;
 
 	$sessionPermissions = (int)$sessionPermissions;
@@ -127,14 +127,14 @@ class GalleryPermissionHelper_simple {
      * Clear all cached access list ids
      * @access private
      */
-    function _clearCachedAccessListIds() {
+    static function _clearCachedAccessListIds() {
 	GalleryDataCache::removeByPattern("GalleryPermissionHelper::fetchAccessListIds");
     }
 
     /**
      * @see GalleryCoreApi::convertPermissionIdsToBits
      */
-    function convertIdsToBits($permissionIds) {
+    static function convertIdsToBits($permissionIds) {
 	global $gallery;
 	if (!is_array($permissionIds)) {
 	    $permissionIds = array($permissionIds);
@@ -170,7 +170,7 @@ class GalleryPermissionHelper_simple {
      *                      ...)
      * @access protected
      */
-    function _fetchAllPermissions() {
+    static function _fetchAllPermissions() {
 	global $gallery;
 
 	$cacheKey = 'GalleryPermissionHelper::_allPermissions';
@@ -215,7 +215,7 @@ class GalleryPermissionHelper_simple {
     /**
      * @see GalleryCoreApi::studyPermissions
      */
-    function studyPermissions($itemIds, $userId=null, $sessionPermissions=true) {
+    static function studyPermissions($itemIds, $userId=null, $sessionPermissions=true) {
 	list ($ret, $permissionsTable) =
 	    GalleryCoreApi::fetchPermissionsForItems($itemIds, $userId, $sessionPermissions);
 	if ($ret) {
@@ -228,7 +228,7 @@ class GalleryPermissionHelper_simple {
     /**
      * @see GalleryCoreApi::fetchPermissionsForItems
      */
-    function fetchPermissionsForItems($itemIds, $userId=null, $sessionPermissions=true) {
+    static function fetchPermissionsForItems($itemIds, $userId=null, $sessionPermissions=true) {
 	global $gallery;
 
 	if (!is_array($itemIds) || empty($itemIds)) {
@@ -354,7 +354,7 @@ class GalleryPermissionHelper_simple {
     /**
      * @see GalleryCoreApi::convertPermissionBitsToIds
      */
-    function convertBitsToIds($permissionBits, $compress=false) {
+    static function convertBitsToIds($permissionBits, $compress=false) {
 	global $gallery;
 
 	if (empty($permissionBits)) {
@@ -447,7 +447,7 @@ class GalleryPermissionHelper_simple {
     /**
      * @see GalleryCoreApi::getPermissions
      */
-    function getPermissions($itemId, $userId=null, $sessionPermissions=true) {
+    static function getPermissions($itemId, $userId=null, $sessionPermissions=true) {
 	global $gallery;
 
 	if (!isset($userId)) {
@@ -482,7 +482,7 @@ class GalleryPermissionHelper_simple {
     /**
      * @see GalleryCoreApi::addPermissionToSession
      */
-    function addPermissionToSession($entityId) {
+    static function addPermissionToSession($entityId) {
 	global $gallery;
 	$session =& $gallery->getSession();
 

--- a/modules/core/classes/helpers/GalleryPluginHelper_medium.class
+++ b/modules/core/classes/helpers/GalleryPluginHelper_medium.class
@@ -31,7 +31,7 @@ class GalleryPluginHelper_medium {
     /**
      * @see GalleryCoreApi::activatePlugin
      */
-    function activate($pluginType, $pluginId) {
+    static function activate($pluginType, $pluginId) {
 	if (empty($pluginId) || empty($pluginType)) {
 	    return array(GalleryCoreApi::error(ERROR_BAD_PARAMETER),
 			 null);
@@ -54,7 +54,7 @@ class GalleryPluginHelper_medium {
     /**
      * @see GalleryCoreApi::deactivatePlugin
      */
-    function deactivate($pluginType, $pluginId) {
+    static function deactivate($pluginType, $pluginId) {
 	if (empty($pluginId) || empty($pluginType)) {
 	    return array(GalleryCoreApi::error(ERROR_BAD_PARAMETER),
 			 null);
@@ -77,7 +77,7 @@ class GalleryPluginHelper_medium {
     /**
      * @see GalleryCoreApi::removePlugin
      */
-    function removePlugin($pluginType, $pluginId) {
+    static function removePlugin($pluginType, $pluginId) {
 	if (empty($pluginId) || empty($pluginType)) {
 	    return GalleryCoreApi::error(ERROR_BAD_PARAMETER);
 	}
@@ -107,7 +107,7 @@ class GalleryPluginHelper_medium {
     /**
      * @see GalleryCoreApi::getAllPluginIds
      */
-    function getAllPluginIds($pluginType) {
+    static function getAllPluginIds($pluginType) {
 	$cacheKey = "GalleryPluginHelper::getAllPluginIds($pluginType)";
 	if (GalleryDataCache::containsKey($cacheKey)) {
 	    $pluginIds = GalleryDataCache::get($cacheKey);
@@ -150,7 +150,7 @@ class GalleryPluginHelper_medium {
     /**
      * @see GalleryCoreApi::removePluginParametersForItemId
      */
-    function removeParametersForItemId($itemId) {
+    static function removeParametersForItemId($itemId) {
 	global $gallery;
 
 	if (empty($itemId)) {
@@ -177,7 +177,7 @@ class GalleryPluginHelper_medium {
     /**
      * @see GalleryCoreApi::removePluginParameter
      */
-    function removeParameter($pluginType, $pluginId, $parameterName, $itemIds=0) {
+    static function removeParameter($pluginType, $pluginId, $parameterName, $itemIds=0) {
 	global $gallery;
 
 	if (empty($pluginType) || empty($pluginId) || empty($parameterName)) {
@@ -216,7 +216,7 @@ class GalleryPluginHelper_medium {
     /**
      * @see GalleryCoreApi::removePluginParameterByValue
      */
-    function removeParameterByValue($pluginType, $pluginId, $parameterName, $parameterValue) {
+    static function removeParameterByValue($pluginType, $pluginId, $parameterName, $parameterValue) {
 	global $gallery;
 
 	if (empty($pluginType) || empty($pluginId) ||
@@ -246,7 +246,7 @@ class GalleryPluginHelper_medium {
     /**
      * @see GalleryCoreApi::removeAllPluginParameters
      */
-    function removeAllParameters($pluginType, $pluginId) {
+    static function removeAllParameters($pluginType, $pluginId) {
 	if (empty($pluginType) || empty($pluginId)) {
 	    return GalleryCoreApi::error(ERROR_BAD_PARAMETER);
 	}

--- a/modules/core/classes/helpers/GalleryPluginHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryPluginHelper_simple.class
@@ -190,7 +190,7 @@ class GalleryPluginHelper_simple {
     /**
      * @see GalleryCoreApi::isPluginCompatibleWithApis
      */
-    function isPluginCompatibleWithApis($plugin) {
+    static function isPluginCompatibleWithApis($plugin) {
 	$pluginType = $plugin->getPluginType();
 	return GalleryUtilities::isCompatibleWithApi(
 	    $plugin->getRequiredCoreApi(), GalleryCoreApi::getApiVersion()) &&
@@ -235,7 +235,7 @@ class GalleryPluginHelper_simple {
     /**
      * @see GalleryCoreApi::fetchAllPluginParameters
      */
-    function fetchAllParameters($pluginType, $pluginId, $itemId=0, $ignoreDiskCache=false) {
+    static function fetchAllParameters($pluginType, $pluginId, $itemId=0, $ignoreDiskCache=false) {
 	/* Convert null to 0, just in case */
 	if ($itemId == null) {
 	    $itemId = 0;

--- a/modules/core/classes/helpers/GalleryPluginHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryPluginHelper_simple.class
@@ -409,7 +409,8 @@ class GalleryPluginHelper_simple {
 
 				/* Separate out the major/minor version. */
 				if (!strncmp($paramName, 'required', 8)) {
-				    $tmp = explode(',', $plugins[$pluginId][$paramName]);
+				    $pluginParamName = $plugins[$pluginId][$paramName];
+				    $tmp = explode(',', is_null($pluginParamName) ? '' : $pluginParamName);
 				    $plugins[$pluginId][$paramName] = (count($tmp) < 2)
 					? array(-1, -1) : array((int)$tmp[0], (int)$tmp[1]);
 				}

--- a/modules/core/classes/helpers/GalleryPluginHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryPluginHelper_simple.class
@@ -340,7 +340,7 @@ class GalleryPluginHelper_simple {
     /**
      * @see GalleryCoreApi::fetchPluginStatus
      */
-    function fetchPluginStatus($pluginType, $ignoreCache=false) {
+    static function fetchPluginStatus($pluginType, $ignoreCache=false) {
 	global $gallery;
 
 	$cacheKey = "GalleryPluginHelper::fetchPluginStatus($pluginType)";
@@ -388,7 +388,7 @@ class GalleryPluginHelper_simple {
 		$pluginBasePath = GalleryCoreApi::getCodeBasePath($pluginsDir);
 		if ($dir = $platform->opendir($pluginBasePath)) {
 		    while ($pluginId = $platform->readdir($dir)) {
-			if ($pluginId{0} == '.') {
+			if ($pluginId[0] == '.') {
 			    continue;
 			}
 			if (!$platform->is_dir($pluginBasePath . $pluginId)) {
@@ -452,7 +452,7 @@ class GalleryPluginHelper_simple {
     /**
      * @see GalleryCoreApi::fetchPluginList
      */
-    function fetchPluginList($pluginType) {
+    static function fetchPluginList($pluginType) {
 	global $gallery;
 
 	if (empty($pluginType)) {

--- a/modules/core/classes/helpers/GalleryThemeHelper_medium.class
+++ b/modules/core/classes/helpers/GalleryThemeHelper_medium.class
@@ -32,7 +32,7 @@ class GalleryThemeHelper_medium {
     /**
      * @see GalleryCoreApi::loadThemeSettingsForm
      */
-    function loadThemeSettingsForm($themeId, $itemId, &$template, &$form) {
+    static function loadThemeSettingsForm($themeId, $itemId, &$template, &$form) {
 	$data = array();
 	if (empty($themeId)) {
 	    list ($ret, $themeId) =
@@ -115,7 +115,7 @@ class GalleryThemeHelper_medium {
     /**
      * @see GalleryCoreApi::loadAvailableBlocks
      */
-    function loadAvailableBlocks($getInactive=false) {
+    static function loadAvailableBlocks($getInactive=false) {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
 
@@ -150,7 +150,7 @@ class GalleryThemeHelper_medium {
     /**
      * @see GalleryCoreApi::handleThemeSettingsRequest
      */
-    function handleThemeSettingsRequest($themeId, $itemId, $form) {
+    static function handleThemeSettingsRequest($themeId, $itemId, $form) {
 	if (empty($themeId)) {
 	    list ($ret, $themeId) =
 		GalleryCoreApi::getPluginParameter('module', 'core', 'default.theme');

--- a/modules/core/classes/helpers/GalleryToolkitHelper_medium.class
+++ b/modules/core/classes/helpers/GalleryToolkitHelper_medium.class
@@ -35,7 +35,7 @@ class GalleryToolkitHelper_medium {
     /**
      * @see GalleryCoreApi::registerToolkitOperation
      */
-    function registerOperation($toolkitId, $mimeTypes, $operationName,
+    static function registerOperation($toolkitId, $mimeTypes, $operationName,
 			       $parameterTypesArray, $description,
 			       $outputMimeType='', $priority=5) {
 	global $gallery;
@@ -130,7 +130,7 @@ class GalleryToolkitHelper_medium {
     /**
      * @see GalleryCoreApi::registerToolkitProperty
      */
-    function registerProperty($toolkitId, $mimeTypes, $propertyName, $type, $description) {
+    static function registerProperty($toolkitId, $mimeTypes, $propertyName, $type, $description) {
 	global $gallery;
 
 	/* Check to see if the property name exists, but with a different unique id. */
@@ -184,7 +184,7 @@ class GalleryToolkitHelper_medium {
     /**
      * @see GalleryCoreApi::unregisterToolkitOperation
      */
-    function unregisterOperation($toolkitId, $operationName, $mimeTypes=array()) {
+    static function unregisterOperation($toolkitId, $operationName, $mimeTypes=array()) {
 	$entry = array('toolkitId' => $toolkitId, 'operationName' => $operationName);
 	if (!empty($mimeTypes)) {
 	    $entry['mimeType'] = $mimeTypes;
@@ -203,7 +203,7 @@ class GalleryToolkitHelper_medium {
     /**
      * @see GalleryCoreApi::unregisterToolkit
      */
-    function unregisterToolkit($toolkitId) {
+    static function unregisterToolkit($toolkitId) {
 	global $gallery;
 
 	/* Remove our toolkit/operation mappings */
@@ -292,7 +292,7 @@ class GalleryToolkitHelper_medium {
     /**
      * @see GalleryCoreApi::unregisterToolkitsByModuleId
      */
-    function unregisterToolkitsByModuleId($moduleId) {
+    static function unregisterToolkitsByModuleId($moduleId) {
 	list ($ret, $searchResults) = GalleryCoreApi::getMapEntry('GalleryFactoryMap',
 	    array('implId'), array('implModuleId' => $moduleId));
 	if ($ret) {
@@ -318,7 +318,7 @@ class GalleryToolkitHelper_medium {
      * @see GalleryCoreApi::getToolkitOperations
      * @todo use priorities for choosing the correct toolkit
      */
-    function getOperations($mimeType) {
+    static function getOperations($mimeType) {
 	global $gallery;
 
 	$cacheKey = "GalleryToolkitHelper::getOperations($mimeType)";
@@ -381,7 +381,7 @@ class GalleryToolkitHelper_medium {
      * @see GalleryCoreApi::getToolkitProperties
      * @todo use priorities for choosing the correct toolkit
      */
-    function getProperties($mimeType) {
+    static function getProperties($mimeType) {
 	global $gallery;
 
 	$cacheKey = "GalleryToolkitHelper::getProperties($mimeType)";
@@ -423,7 +423,7 @@ class GalleryToolkitHelper_medium {
     /**
      * @see GalleryCoreApi::getToolkitOperationMimeTypes
      */
-    function getOperationMimeTypes($operationName) {
+    static function getOperationMimeTypes($operationName) {
 	global $gallery;
 
 	$cacheKey = "GalleryToolkitHelper::getOperationMimeTypes($operationName)";
@@ -455,7 +455,7 @@ class GalleryToolkitHelper_medium {
     /**
      * @see GalleryCoreApi::getRedundantToolkitPriorities
      */
-    function getRedundantPriorities() {
+    static function getRedundantPriorities() {
 	global $gallery;
 
 	$cacheKey = "GalleryToolkitHelper::getRedundantPriorities()";
@@ -499,7 +499,7 @@ class GalleryToolkitHelper_medium {
     /**
      * @see GalleryCoreApi::isSupportedOperationSequence
      */
-    function isSupportedOperationSequence($mimeType, $operations) {
+    static function isSupportedOperationSequence($mimeType, $operations) {
 
 	$isSupported = true;
 	foreach (explode(';', $operations) as $operation) {
@@ -528,7 +528,7 @@ class GalleryToolkitHelper_medium {
     /**
      * @see GalleryCoreApi::makeSupportedViewableOperationSequence
      */
-    function makeSupportedViewableOperationSequence($mimeType, $operations,
+    static function makeSupportedViewableOperationSequence($mimeType, $operations,
 						    $prependConversion=true) {
 	if (empty($operations)) {
 	    $isSupported = true;
@@ -598,7 +598,7 @@ class GalleryToolkitHelper_medium {
     /**
      * @see GalleryCoreApi::estimateDerivativeDimensions
      */
-    function estimateDerivativeDimensions(&$derivative, $source) {
+    static function estimateDerivativeDimensions(&$derivative, $source) {
 	if (preg_match('/^(thumbnail|scale|resize)\|/',
 		       $derivative->getDerivativeOperations(), $matches)) {
 	    if (!empty($matches[1])) {

--- a/modules/core/classes/helpers/GalleryToolkitHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryToolkitHelper_simple.class
@@ -35,7 +35,7 @@ class GalleryToolkitHelper_simple {
     /**
      * @see GalleryCoreApi::getToolkitByOperation
      */
-    function getToolkitByOperation($mimeType, $operationName) {
+    static function getToolkitByOperation($mimeType, $operationName) {
 	global $gallery;
 
 	$cacheKey = "GalleryToolkitHelper::getToolkitByOperation($mimeType, $operationName)";
@@ -93,7 +93,7 @@ class GalleryToolkitHelper_simple {
     /**
      * @see GalleryCoreApi::getToolkitByProperty
      */
-    function getToolkitByProperty($mimeType, $propertyName) {
+    static function getToolkitByProperty($mimeType, $propertyName) {
 	$cacheKey = "GalleryToolkitHelper::getToolkitByProperty($mimeType, $propertyName)";
 	if (!GalleryDataCache::containsKey($cacheKey)) {
 	    list ($ret, $toolkits) =
@@ -111,7 +111,7 @@ class GalleryToolkitHelper_simple {
     /**
      * @see GalleryCoreApi::getToolkitsByProperty
      */
-    function getToolkitsByProperty($mimeType, $propertyName) {
+    static function getToolkitsByProperty($mimeType, $propertyName) {
 	global $gallery;
 
 	$cacheKey = "GalleryToolkitHelper::getToolkitsByProperty($mimeType, $propertyName)";
@@ -158,7 +158,7 @@ class GalleryToolkitHelper_simple {
     /**
      * @see GalleryCoreApi::getMaximumManagedToolkitPriority
      */
-    function getMaximumManagedPriority() {
+    static function getMaximumManagedPriority() {
 	global $gallery;
 
 	$query =
@@ -189,7 +189,7 @@ class GalleryToolkitHelper_simple {
     /**
      * @see GalleryCoreApi::getToolkitPriorityById
      */
-    function getToolkitPriorityById($toolkitId) {
+    static function getToolkitPriorityById($toolkitId) {
 	list ($ret, $searchResults) = GalleryCoreApi::getMapEntry(
 	    'GalleryToolkitOperationMimeTypeMap',
 	    array('priority'), array('toolkitId' => (string)$toolkitId));

--- a/modules/core/classes/helpers/GalleryTranslatorHelper_medium.class
+++ b/modules/core/classes/helpers/GalleryTranslatorHelper_medium.class
@@ -31,7 +31,7 @@ class GalleryTranslatorHelper_medium {
     /**
      * @see GalleryCoreApi::installTranslationsForPlugin
      */
-    function installTranslationsForPlugin($pluginType, $pluginId) {
+    static function installTranslationsForPlugin($pluginType, $pluginId) {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
 	$codeBase = GalleryCoreApi::getCodeBasePath();
@@ -77,7 +77,7 @@ class GalleryTranslatorHelper_medium {
     /**
      * @see GalleryCoreApi::removeTranslationsForPlugin
      */
-    function removeTranslationsForPlugin($pluginType, $pluginId) {
+    static function removeTranslationsForPlugin($pluginType, $pluginId) {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
 
@@ -97,7 +97,7 @@ class GalleryTranslatorHelper_medium {
     /**
      * @see GalleryCoreApi::installTranslationsForLocale
      */
-    function installTranslationsForLocale($locale=null) {
+    static function installTranslationsForLocale($locale=null) {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
 	$codeBase = GalleryCoreApi::getCodeBasePath();
@@ -143,7 +143,7 @@ class GalleryTranslatorHelper_medium {
     /**
      * @see GalleryCoreApi::getLanguageDescription
      */
-    function getLanguageDescription($languageCode) {
+    static function getLanguageDescription($languageCode) {
 	$cacheKey = "GalleryTranslator::LanguageDescription::$languageCode";
 	if (!GalleryDataCache::containsKey($cacheKey)) {
 	    list ($newLanguageCode, $languageData) =
@@ -170,7 +170,7 @@ class GalleryTranslatorHelper_medium {
     /**
      * @see GalleryCoreApi::getSupportedLanguages
      */
-    function getSupportedLanguages() {
+    static function getSupportedLanguages() {
 	global $gallery;
 
 	$cacheKey = 'GalleryTranslator::SupportedLanguages';

--- a/modules/core/classes/helpers/GalleryUserGroupHelper_medium.class
+++ b/modules/core/classes/helpers/GalleryUserGroupHelper_medium.class
@@ -31,7 +31,7 @@ class GalleryUserGroupHelper_medium {
     /**
      * @see GalleryCoreApi::addUserToGroup
      */
-    function addUserToGroup($userId, $groupId) {
+    static function addUserToGroup($userId, $groupId) {
 	global $gallery;
 	if (empty($userId) || empty($groupId)) {
 	    return GalleryCoreApi::error(ERROR_BAD_PARAMETER);
@@ -70,7 +70,7 @@ class GalleryUserGroupHelper_medium {
     /**
      * @see GalleryCoreApi::removeUserFromGroup
      */
-    function removeUserFromGroup($userId, $groupId) {
+    static function removeUserFromGroup($userId, $groupId) {
 	global $gallery;
 	if (empty($userId) || empty($groupId)) {
 	    return GalleryCoreApi::error(ERROR_BAD_PARAMETER);
@@ -100,7 +100,7 @@ class GalleryUserGroupHelper_medium {
     /**
      * @see GalleryCoreApi::removeUserFromAllGroups
      */
-    function removeUserFromAllGroups($userId) {
+    static function removeUserFromAllGroups($userId) {
 	global $gallery;
 	if (empty($userId)) {
 	    return GalleryCoreApi::error(ERROR_BAD_PARAMETER);
@@ -127,7 +127,7 @@ class GalleryUserGroupHelper_medium {
     /**
      * @see GalleryCoreApi::removeAllUsersFromGroup
      */
-    function removeAllUsersFromGroup($groupId) {
+    static function removeAllUsersFromGroup($groupId) {
 	global $gallery;
 	if (empty($groupId)) {
 	    return GalleryCoreApi::error(ERROR_BAD_PARAMETER);
@@ -165,7 +165,7 @@ class GalleryUserGroupHelper_medium {
     /**
      * @see GalleryCoreApi::fetchUsersForGroup
      */
-    function fetchUsersForGroup($groupId, $count=null, $offset=null, $substring=null) {
+    static function fetchUsersForGroup($groupId, $count=null, $offset=null, $substring=null) {
 	global $gallery;
 
 	$data = array();

--- a/modules/core/classes/helpers/GalleryUserGroupHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryUserGroupHelper_simple.class
@@ -31,7 +31,7 @@ class GalleryUserGroupHelper_simple {
     /**
      * @see GalleryCoreApi::isUserInSiteAdminGroup
      */
-    function isUserInSiteAdminGroup($userId=null) {
+    static function isUserInSiteAdminGroup($userId=null) {
 	global $gallery;
 	if (!isset($userId)) {
 	    $userId = $gallery->getActiveUserId();
@@ -54,7 +54,7 @@ class GalleryUserGroupHelper_simple {
     /**
      * @see GalleryCoreApi::isUserInGroup
      */
-    function isUserInGroup($userId, $groupId) {
+    static function isUserInGroup($userId, $groupId) {
 	$userId = (int) $userId;
 	$groupId = (int) $groupId;
 
@@ -78,7 +78,7 @@ class GalleryUserGroupHelper_simple {
     /**
      * @see GalleryCoreApi::fetchGroupsForUser
      */
-    function fetchGroupsForUser($userId, $count=null, $offset=null) {
+    static function fetchGroupsForUser($userId, $count=null, $offset=null) {
 	global $gallery;
 
 	$cacheKey = "GalleryUserGroupHelper::fetchGroupsForUser($userId,$count,$offset)";

--- a/modules/core/classes/helpers/GalleryUserHelper_medium.class
+++ b/modules/core/classes/helpers/GalleryUserHelper_medium.class
@@ -31,7 +31,7 @@ class GalleryUserHelper_medium /* extends GalleryEventListener */ {
     /**
      * @see GalleryCoreApi::fetchUsernames
      */
-    function fetchUsernames($count=null, $offset=null, $substring=null) {
+    static function fetchUsernames($count=null, $offset=null, $substring=null) {
 	global $gallery;
 
 	$data = array();
@@ -73,7 +73,7 @@ class GalleryUserHelper_medium /* extends GalleryEventListener */ {
     /**
      * @see GalleryCoreApi::fetchUserCount
      */
-    function fetchUserCount($substring=null, $groupId=null) {
+    static function fetchUserCount($substring=null, $groupId=null) {
 	global $gallery;
 	if (empty($groupId)) {
 	    list($ret, $groupId) =
@@ -123,7 +123,7 @@ class GalleryUserHelper_medium /* extends GalleryEventListener */ {
     /**
      * @see GalleryCoreApi::fetchUserByUserName
      */
-    function fetchUserByUserName($userName=null) {
+    static function fetchUserByUserName($userName=null) {
 	global $gallery;
 
 	$query = '
@@ -156,7 +156,7 @@ class GalleryUserHelper_medium /* extends GalleryEventListener */ {
     /**
      * @see GalleryCoreApi::fetchLanguageCodeForUser
      */
-    function fetchLanguageCodeForUser($userId) {
+    static function fetchLanguageCodeForUser($userId) {
 	global $gallery;
 
 	list ($ret, $user) = GalleryCoreApi::loadEntitiesById($userId, 'GalleryUser');
@@ -178,7 +178,7 @@ class GalleryUserHelper_medium /* extends GalleryEventListener */ {
     /**
      * @see GalleryCoreApi::assertUserIsSiteAdministrator
      */
-    function assertSiteAdministrator() {
+    static function assertSiteAdministrator() {
 	global $gallery;
 	$session =& $gallery->getSession();
 	$phpVm = $gallery->getPhpVm();
@@ -209,7 +209,7 @@ class GalleryUserHelper_medium /* extends GalleryEventListener */ {
     /**
      * @see GalleryCoreApi::deleteUserItems
      */
-    function deleteUserItems($userId) {
+    static function deleteUserItems($userId) {
 	global $gallery;
 
 	if (empty($userId)) {
@@ -345,7 +345,7 @@ class GalleryUserHelper_medium /* extends GalleryEventListener */ {
      *
      * @see GalleryEventListener::handleEvent
      */
-    function handleEvent($event) {
+    static function handleEvent($event) {
 	global $gallery;
 	$phpVm = $gallery->getPhpVm();
 
@@ -416,7 +416,7 @@ class GalleryUserHelper_medium /* extends GalleryEventListener */ {
     /**
      * @see GalleryCoreApi::isDisabledUsername
      */
-    function isDisabledUsername($userName) {
+    static function isDisabledUsername($userName) {
 	global $gallery;
 
 	list ($ret, $searchResults) = GalleryCoreApi::getMapEntry(
@@ -448,7 +448,7 @@ class GalleryUserHelper_medium /* extends GalleryEventListener */ {
      * @return bool true if the account is disabled
      * @access private
      */
-    function _isDisabled($count, $lastAttempt) {
+    static function _isDisabled($count, $lastAttempt) {
 	global $gallery;
 
 	if ($count >= 10) {

--- a/modules/core/classes/helpers/GalleryUserHelper_simple.class
+++ b/modules/core/classes/helpers/GalleryUserHelper_simple.class
@@ -31,7 +31,7 @@ class GalleryUserHelper_simple {
     /**
      * @see GalleryCoreApi::assertHasItemPermission
      */
-    function assertHasItemPermission($itemId, $permission) {
+    static function assertHasItemPermission($itemId, $permission) {
 	global $gallery;
 
 	list ($ret, $hasPermission) =
@@ -53,7 +53,7 @@ class GalleryUserHelper_simple {
     /**
      * @see GalleryCoreApi::hasItemPermission
      */
-    function hasItemPermission($itemId, $permission, $userId=null, $sessionPermissions=true) {
+    static function hasItemPermission($itemId, $permission, $userId=null, $sessionPermissions=true) {
 	global $gallery;
 	if (!isset($userId)) {
 	    $userId = $gallery->getActiveUserId();

--- a/modules/core/classes/helpers/MailHelper_simple.class
+++ b/modules/core/classes/helpers/MailHelper_simple.class
@@ -31,7 +31,7 @@ class MailHelper_simple {
     /**
      * @see GalleryCoreApi::sendTemplatedEmail
      */
-    function sendTemplatedEmail($file, $data, $from, $to, $subject, $headers='') {
+    static function sendTemplatedEmail($file, $data, $from, $to, $subject, $headers='') {
 	global $gallery;
 
 	GalleryCoreApi::requireOnce('modules/core/classes/GalleryTemplate.class');

--- a/modules/core/classes/helpers/MailHelper_simple.class
+++ b/modules/core/classes/helpers/MailHelper_simple.class
@@ -73,8 +73,8 @@ class MailHelper_simple {
 	}
 	if (!empty($subject)) {
 	    for ($buf = '', $i = 0; $i < strlen($subject); $i++) {
-		$val = ord($subject{$i});
-		$buf .= ($val > 127) ? '=' . dechex($val) : $subject{$i};
+		$val = ord($subject[$i]);
+		$buf .= ($val > 127) ? '=' . dechex($val) : $subject[$i];
 	    }
 	    if ($buf != $subject) {
 		/* Encode subject for UTF-8 display if any extended characters are present */

--- a/modules/core/classes/helpers/MaintenanceHelper_simple.class
+++ b/modules/core/classes/helpers/MaintenanceHelper_simple.class
@@ -33,7 +33,7 @@ class MaintenanceHelper_simple {
      * @return array GalleryStatus a status code
      *               array(taskId => MaintenanceTask, ...)
      */
-    function fetchTasks() {
+    static function fetchTasks() {
 	/* Get all the option plugins */
 	list ($ret, $allTaskIds) =
 	    GalleryCoreApi::getAllFactoryImplementationIds('MaintenanceTask');
@@ -64,7 +64,7 @@ class MaintenanceHelper_simple {
      *                     success => bool,
      *                     details => string)
      */
-    function fetchLastRun($taskId) {
+    static function fetchLastRun($taskId) {
 	list ($ret, $searchResults) = GalleryCoreApi::getMapEntry('GalleryMaintenanceMap',
 	    array('runId', 'timestamp', 'success', 'details'), array('taskId' => $taskId),
 	    array('orderBy' => array('timestamp' => ORDER_DESCENDING),
@@ -93,7 +93,7 @@ class MaintenanceHelper_simple {
      * @param array $details string task details
      * @return GalleryStatus a status code
      */
-    function addRun($taskId, $timestamp, $success, $details) {
+    static function addRun($taskId, $timestamp, $success, $details) {
 	global $gallery;
 
 	$storage =& $gallery->getStorage();
@@ -119,7 +119,7 @@ class MaintenanceHelper_simple {
     /**
      * @see GalleryCoreApi::setMaintenanceMode
      */
-    function setMaintenanceMode($mode) {
+    static function setMaintenanceMode($mode) {
 	global $gallery;
 
 	$currentMode = $gallery->getConfig('mode.maintenance');

--- a/modules/core/classes/helpers/UserRecoverPasswordHelper_simple.class
+++ b/modules/core/classes/helpers/UserRecoverPasswordHelper_simple.class
@@ -37,7 +37,7 @@ class UserRecoverPasswordHelper_simple {
      * @return array GalleryStatus a status code
      *               int epoch-based request expiration
      */
-    function getRequestExpires($username, $authString) {
+    static function getRequestExpires($username, $authString) {
 	$searchParams['userName'] = $username;
 
 	if (!empty($authString)) {
@@ -66,7 +66,7 @@ class UserRecoverPasswordHelper_simple {
      * @return array GalleryStatus a status code
      *               string authString
      */
-    function getAuthString($username) {
+    static function getAuthString($username) {
 	list ($ret, $searchResults) = GalleryCoreApi::getMapEntry('GalleryRecoverPasswordMap',
 	    array('authString'), array('userName' => $username));
 	if ($ret) {

--- a/modules/core/classes/helpers/WebHelper_simple.class
+++ b/modules/core/classes/helpers/WebHelper_simple.class
@@ -35,7 +35,7 @@ class WebHelper_simple {
      *       header to verify that we got all the data we expected.
      *
      */
-    function fetchWebFile($url, $outputFile, $extraHeaders=array(), $postDataArray=array(),
+    static function fetchWebFile($url, $outputFile, $extraHeaders=array(), $postDataArray=array(),
 	    $depth=0) {
 	global $gallery;
 
@@ -153,7 +153,7 @@ class WebHelper_simple {
     /**
      * @see GalleryCoreApi::fetchWebPage
      */
-    function fetchWebPage($url, $extraHeaders=array(), $depth=0) {
+    static function fetchWebPage($url, $extraHeaders=array(), $depth=0) {
 	global $gallery;
 
 	/* Don't redirect too far */
@@ -190,7 +190,7 @@ class WebHelper_simple {
     /**
      * @see GalleryCoreApi::postToWebPage
      */
-    function postToWebPage($url, $postDataArray, $extraHeaders=array()) {
+    static function postToWebPage($url, $postDataArray, $extraHeaders=array()) {
 	$postDataRaw = WebHelper_simple::_encodePostData($postDataArray, $extraHeaders);
 
 	/* Read the web page into a buffer */
@@ -208,7 +208,7 @@ class WebHelper_simple {
      * @param array $extraHeaders extra headers to pass to the server
      * @return string the encoded post data
      */
-    function _encodePostData($postDataArray, &$extraHeaders) {
+    static function _encodePostData($postDataArray, &$extraHeaders) {
 	$postDataRaw = '';
 	foreach ($postDataArray as $key => $value) {
 	    if (!empty($postDataRaw)) {
@@ -226,7 +226,7 @@ class WebHelper_simple {
     /**
      * @see GalleryCoreApi::requestWebPage
      */
-    function requestWebPage($url, $requestMethod='GET', $requestHeaders=array(), $requestBody='') {
+    static function requestWebPage($url, $requestMethod='GET', $requestHeaders=array(), $requestBody='') {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
 
@@ -307,7 +307,7 @@ class WebHelper_simple {
      * @return array url components
      * @access private
      */
-    function _parseUrlForFsockopen($url) {
+    static function _parseUrlForFsockopen($url) {
 	$urlComponents = parse_url($url);
 	if (GalleryUtilities::strToLower($urlComponents['scheme']) == 'https') {
 	    $urlComponents['fsockhost'] = 'ssl://' . $urlComponents['host'];
@@ -335,7 +335,7 @@ class WebHelper_simple {
      * @param array $fromComponents context we're redirecting from
      * @param string redirect URL
      */
-    function _parseLocation($location, $fromComponents) {
+    static function _parseLocation($location, $fromComponents) {
 	if (is_array($location)) {
 	    /* If odd http response has multiple Location headers just pick the first */
 	    $location = array_shift($location);

--- a/modules/customfield/classes/CustomFieldHelper.class
+++ b/modules/customfield/classes/CustomFieldHelper.class
@@ -49,7 +49,7 @@ class CustomFieldHelper extends CustomFieldInterface_1_0 /* and GalleryEventList
      *               mixed containing custom field data
      *               boolean true if album-specific settings are returned
      */
-    function loadParameters($containerId=0, $fallback=true,
+    static function loadParameters($containerId=0, $fallback=true,
 			    $sets = array('common', 'album', 'photo')) {
 	$isContainer = ($containerId > 0);
 	list ($ret, $param) =
@@ -83,7 +83,7 @@ class CustomFieldHelper extends CustomFieldInterface_1_0 /* and GalleryEventList
      * @param int $containerId id of container; to save album-specific settings
      * @return GalleryStatus a status code
      */
-    function saveParameters($param, $containerId=0) {
+    static function saveParameters($param, $containerId=0) {
 	foreach (array('common', 'album', 'photo') as $set) {
 	    if (!isset($param[$set])) {
 		continue;
@@ -112,7 +112,7 @@ class CustomFieldHelper extends CustomFieldInterface_1_0 /* and GalleryEventList
      * @return array GalleryStatus a status code
      *               boolean true on success, false on duplicate field name
      */
-    function addField($newField, $set, $containerId=0) {
+    static function addField($newField, $set, $containerId=0) {
 	list ($ret, $param) = CustomFieldHelper::loadParameters($containerId, false);
 	if ($ret) {
 	    return array($ret, null);
@@ -139,7 +139,7 @@ class CustomFieldHelper extends CustomFieldInterface_1_0 /* and GalleryEventList
      * @param string $field field to find
      * @return int index or -1 if not found
      */
-    function findParameter(&$list, $field) {
+    static function findParameter(&$list, $field) {
 	foreach ($list as $i => $item) {
 	    if ($item['field'] == $field) {
 		return $i;
@@ -156,7 +156,7 @@ class CustomFieldHelper extends CustomFieldInterface_1_0 /* and GalleryEventList
      * @param string $exceptType 'album' or 'photo' -- don't delete values for items of this type
      * @return GalleryStatus a status code
      */
-    function deleteField($field, $containerId=0, $exceptType='') {
+    static function deleteField($field, $containerId=0, $exceptType='') {
 	switch ($exceptType) {
 
 	case 'album':
@@ -196,7 +196,7 @@ class CustomFieldHelper extends CustomFieldInterface_1_0 /* and GalleryEventList
      *               array(itemId => array) loadParameters results
      *               array(itemId => boolean) loadParameters results
      */
-    function fetchFieldValues($items, $viewType=null, $fillSet=null) {
+    static function fetchFieldValues($items, $viewType=null, $fillSet=null) {
 	global $gallery;
 	$data = $result = array();
 
@@ -255,7 +255,7 @@ class CustomFieldHelper extends CustomFieldInterface_1_0 /* and GalleryEventList
      * @param array $fields (field => value)
      * @return GalleryStatus a status code
      */
-    function saveFieldValues(&$item, $fields) {
+    static function saveFieldValues(&$item, $fields) {
 	$set = GalleryUtilities::isA($item, 'GalleryAlbumItem') ? 1
 	     : (GalleryUtilities::isA($item, 'GalleryPhotoItem') ? 2 : 0);
 	$containerId = ($set == 1) ? $item->getId() : $item->getParentId();
@@ -309,7 +309,7 @@ class CustomFieldHelper extends CustomFieldInterface_1_0 /* and GalleryEventList
      * @return array GalleryStatus a status code
      *               mixed status to return from controller
      */
-    function handleAdminAction($form, $containerId=0) {
+    static function handleAdminAction($form, $containerId=0) {
 	$status = array();
 
 	if (isset($form['action']['save'])) {
@@ -450,7 +450,7 @@ class CustomFieldHelper extends CustomFieldInterface_1_0 /* and GalleryEventList
      * @param int $containerId id of container, for album-specific settings
      * @return GalleryStatus a status code
      */
-    function loadAdminForm(&$form, $containerId=0) {
+    static function loadAdminForm(&$form, $containerId=0) {
 	list ($ret, $module) = GalleryCoreApi::loadPlugin('module', 'customfield');
 	if ($ret) {
 	    return $ret;

--- a/modules/customfield/module.inc
+++ b/modules/customfield/module.inc
@@ -29,7 +29,7 @@
  */
 class CustomFieldModule extends GalleryModule {
 
-    function CustomFieldModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('customfield');

--- a/modules/dcraw/module.inc
+++ b/modules/dcraw/module.inc
@@ -29,7 +29,7 @@
  */
 class DcrawModule extends GalleryModule {
 
-    function DcrawModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('dcraw');

--- a/modules/dcraw/module.inc
+++ b/modules/dcraw/module.inc
@@ -190,7 +190,7 @@ class DcrawModule extends GalleryModule {
 		if (empty($path)) {
 		    continue;
 		}
-		if ($path{strlen($path)-1} != $slash) {
+		if ($path[strlen($path)-1] != $slash) {
 		    $path .= $slash;
 		}
 		$paths[] = $path;
@@ -209,7 +209,7 @@ class DcrawModule extends GalleryModule {
 		if (empty($path)) {
 		    continue;
 		}
-		if ($path{strlen($path)-1} != $slash) {
+		if ($path[strlen($path)-1] != $slash) {
 		    $path .= $slash;
 		}
 		$paths[] = $path;

--- a/modules/debug/module.inc
+++ b/modules/debug/module.inc
@@ -29,7 +29,7 @@
  */
 class DebugModule extends GalleryModule {
 
-    function DebugModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('debug');

--- a/modules/digibug/module.inc
+++ b/modules/digibug/module.inc
@@ -130,7 +130,7 @@ class DigibugModule extends GalleryModule {
     /**
      * @see GalleryModule::getItemLinks
      */
-    function getItemLinks($items, $wantsDetailedLinks, $permissions) {
+    function getItemLinks($items, $wantsDetailedLinks, $permissions, $userId) {
 	global $gallery;
 	$session =& $gallery->getSession();
 

--- a/modules/digibug/module.inc
+++ b/modules/digibug/module.inc
@@ -27,7 +27,7 @@
  */
 class DigibugModule extends GalleryModule {
 
-    function DigibugModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('digibug');

--- a/modules/dynamicalbum/PopularAlbum.inc
+++ b/modules/dynamicalbum/PopularAlbum.inc
@@ -29,7 +29,7 @@ GalleryCoreApi::requireOnce('modules/dynamicalbum/UpdatesAlbum.inc');
  */
 class PopularAlbumView extends UpdatesAlbumView {
 
-    function PopularAlbumView() {
+    function __construct() {
 	global $gallery;
 	$this->_view = 'dynamicalbum.PopularAlbum';
 	$this->_title = $gallery->i18n('Most Viewed Items');

--- a/modules/dynamicalbum/RandomAlbum.inc
+++ b/modules/dynamicalbum/RandomAlbum.inc
@@ -29,7 +29,7 @@ GalleryCoreApi::requireOnce('modules/dynamicalbum/UpdatesAlbum.inc');
  */
 class RandomAlbumView extends UpdatesAlbumView {
 
-    function RandomAlbumView() {
+    function __construct() {
 	global $gallery;
 	$this->_view = 'dynamicalbum.RandomAlbum';
 	$this->_title = $gallery->i18n('Random Items');

--- a/modules/dynamicalbum/UpdatesAlbum.inc
+++ b/modules/dynamicalbum/UpdatesAlbum.inc
@@ -27,7 +27,7 @@
  */
 class UpdatesAlbumView extends GalleryView {
 
-    function UpdatesAlbumView() {
+    function __construct() {
 	global $gallery;
 	$this->_view = 'dynamicalbum.UpdatesAlbum';
 	$this->_title = $gallery->i18n('Recent Updates');

--- a/modules/dynamicalbum/UpdatesAlbum.inc
+++ b/modules/dynamicalbum/UpdatesAlbum.inc
@@ -58,7 +58,7 @@ class UpdatesAlbumView extends GalleryView {
 	if ($ret) {
 	    return array($ret, null, null, null);
 	}
-	$item->create(
+	$item->createDynamicAlbum(
 	    $module->translate($this->_title),
 	    array($this->_itemType, array_map(array($module, 'translate'), $this->_itemType))
 	);

--- a/modules/dynamicalbum/module.inc
+++ b/modules/dynamicalbum/module.inc
@@ -27,7 +27,7 @@
  */
 class DynamicAlbumModule extends GalleryModule {
 
-    function DynamicAlbumModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('dynamicalbum');
 	$this->setName($gallery->i18n('Dynamic Albums'));

--- a/modules/ecard/SendEcard.inc
+++ b/modules/ecard/SendEcard.inc
@@ -213,8 +213,8 @@ class SendEcardController extends GalleryController {
 		$hdrs .= $key . ': ' . $value . "\n";
 	    }
 	    for ($buf = '', $i = 0; $i < strlen($headers['subject']); $i++) {
-		$val = ord($headers['subject']{$i});
-		$buf .= ($val > 127) ? '=' . dechex($val) : $headers['subject']{$i};
+		$val = ord($headers['subject'][$i]);
+		$buf .= ($val > 127) ? '=' . dechex($val) : $headers['subject'][$i];
 	    }
 	    if ($buf != $headers['subject']) {
 		/* Encode subject for UTF-8 display if any extended characters are present */

--- a/modules/ecard/classes/EcardHelper.class
+++ b/modules/ecard/classes/EcardHelper.class
@@ -35,7 +35,7 @@ class EcardHelper {
      * @return array GalleryStatus a status code
      *               GalleryItem an item
      */
-    function getSmallestSize($itemId) {
+    static function getSmallestSize($itemId) {
 	list ($ret, $permissions) = GalleryCoreApi::getPermissions($itemId);
 	if ($ret) {
 	    return array($ret, null);
@@ -97,7 +97,7 @@ class EcardHelper {
      * @param array $array the submitted form
      * @return string output string
      */
-    function replaceKeywords($str, $array) {
+    static function replaceKeywords($str, $array) {
 	$result = $str;
 	foreach (array('from', 'fromName', 'to', 'toName',
 		       'text', 'header', 'footer', 'image', 'link') as $key) {
@@ -114,7 +114,7 @@ class EcardHelper {
      * @return array GalleryStatus a status code
      *               boolean true to use validation plugins
      */
-    function useValidationPlugins() {
+    static function useValidationPlugins() {
 	list ($ret, $level) =
 	    GalleryCoreApi::getPluginParameter('module', 'ecard', 'validation.level');
 	if ($ret) {

--- a/modules/ecard/module.inc
+++ b/modules/ecard/module.inc
@@ -28,7 +28,7 @@
  */
 class EcardModule extends GalleryModule {
 
-    function EcardModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('ecard');

--- a/modules/exif/ExifDescriptionOption.inc
+++ b/modules/exif/ExifDescriptionOption.inc
@@ -93,7 +93,7 @@ class ExifDescriptionOption extends ItemAddOption {
 		    return array($ret, null, null);
 		}
 
-		list ($ret, $exifData) = ExifExtractor::getMetaData($currentItemIds, $needed);
+		list ($ret, $exifData) = ExifExtractor::getMetaDataStatic($currentItemIds, $needed);
 		if ($ret) {
 		    GalleryCoreApi::releaseLocks($lockId);
 		    return array($ret, null, null);

--- a/modules/exif/classes/ExifExtractor.class
+++ b/modules/exif/classes/ExifExtractor.class
@@ -30,10 +30,7 @@ GalleryCoreApi::requireOnce('modules/exif/classes/ExifInterface_1_0.class');
  */
 class ExifExtractor extends ExifInterface_1_0 {
 
-    /**
-     * @see ExifInterface_1_0::getMetaData
-     */
-    function getMetaData($itemIds, $properties=array()) {
+    static function getMetaDataStatic($itemIds, $properties=array()) {
 	global $gallery;
 	GalleryCoreApi::requireOnce('modules/exif/lib/exifer/exif.inc');
 
@@ -86,6 +83,13 @@ class ExifExtractor extends ExifInterface_1_0 {
 	}
 
 	return array(null, $data);
+    }
+
+    /**
+     * @see ExifInterface_1_0::getMetaData
+     */
+    function getMetaData($itemIds, $properties=array()) {
+        return ExifExtractor::getMetaDataStatic($itemIds, $properties);
     }
 }
 ?>

--- a/modules/exif/classes/ExifHelper.class
+++ b/modules/exif/classes/ExifHelper.class
@@ -82,7 +82,7 @@ class ExifHelper {
      * @param int $viewMode
      * @return GalleryStatus a status code
      */
-    function setDefaultProperties($viewMode) {
+    static function setDefaultProperties($viewMode) {
 	switch ($viewMode) {
 	case EXIF_SUMMARY:
 	    /* This is an initial install; make sure that we have some reasonable defaults */
@@ -154,7 +154,7 @@ class ExifHelper {
      * @param int $viewMode
      * @return GalleryStatus a status code
      */
-    function addDefaultIptcProperties($viewMode) {
+    static function addDefaultIptcProperties($viewMode) {
 	list ($ret, $properties) = ExifHelper::getProperties($viewMode);
 	if ($ret) {
 	    return $ret;
@@ -191,7 +191,7 @@ class ExifHelper {
      * @param array $rawExifData reference to an array where to store the results
      *        as returned by read_exif_data_raw() from exifer
      */
-    function _fetchRawExifData($path, &$rawExifData) {
+    static function _fetchRawExifData($path, &$rawExifData) {
 	global $gallery;
 	GalleryCoreApi::requireOnce('modules/exif/lib/exifer/exif.inc');
 
@@ -219,7 +219,7 @@ class ExifHelper {
      * @todo (xlerb) reduce size of lib/JPEG: 1. remove whitespace/comments; 2. refactor according
      *      to lazy reading. Before refactoring, add timing tests.
      */
-    function getIptcObject($path) {
+    static function getIptcObject($path) {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
 
@@ -251,7 +251,7 @@ class ExifHelper {
      * @return array GalleryStatus a status code
      *               array title/value pairs
      */
-    function getExifData($path, $viewMode) {
+    static function getExifData($path, $viewMode) {
 	$rawExifData = array();
 	ExifHelper::_fetchRawExifData($path, $rawExifData);
 	list ($ret, $iptcObj) = ExifHelper::getIptcObject($path);
@@ -295,7 +295,7 @@ class ExifHelper {
      * @param string $value the value (eg. "f 2.8")
      * @return string the result (eg. "f/2.8")
      */
-    function postProcessValue($property, $value) {
+    static function postProcessValue($property, $value) {
 	global $gallery;
 
 	GalleryUtilities::sanitizeInputValues($value, false);
@@ -352,7 +352,7 @@ class ExifHelper {
      *      has it: it was explicitely set by the editor, thus first priority? Or to be considered
      *      just before IFD0.DateTime == last modification time?
      */
-    function getOriginationTimestamp($path) {
+    static function getOriginationTimestamp($path) {
 	$rawExifData = array();
 	ExifHelper::_fetchRawExifData($path, $rawExifData);
 	/*
@@ -379,7 +379,7 @@ class ExifHelper {
      * Parse date string into unix timestamp.
      * @access private
      */
-    function _parseDate($value) {
+    static function _parseDate($value) {
 	/* Ignore "blank" value */
 	if ($value == '0000:00:00 00:00:00') {
 	    return null;
@@ -426,7 +426,7 @@ class ExifHelper {
      * @return array GalleryStatus a status code
      *               string value
      */
-    function getExifValue(&$source, $keyPath) {
+    static function getExifValue(&$source, $keyPath) {
 	$key = array_shift($keyPath);
 	if (!isset($source[$key])) {
 	    return null;
@@ -455,7 +455,7 @@ class ExifHelper {
      *      where users from different countries can upload images with IPTC data. It is such a
      *      pain, that the charset used isn't recorded in IPTC headers.
      */
-    function getIptcValue(&$object, $keyPath, $sourceEncoding=null) {
+    static function getIptcValue(&$object, $keyPath, $sourceEncoding=null) {
 	if ($keyPath[0] != 'IPTC') {
 	    return null;
 	}
@@ -477,7 +477,7 @@ class ExifHelper {
      * @return array GalleryStatus a status code
      *               array logical exif property names
      */
-    function getProperties($viewMode) {
+    static function getProperties($viewMode) {
 	list ($ret, $searchResults) = GalleryCoreApi::getMapEntry('ExifPropertiesMap',
 	    array('property', 'sequence'), array('viewMode' => $viewMode),
 	    array('orderBy' => array('sequence' => ORDER_ASCENDING)));
@@ -500,7 +500,7 @@ class ExifHelper {
      * @param array $properties logical property key/value pairs
      * @return GalleryStatus a status code
      */
-    function setProperties($viewMode, $properties) {
+    static function setProperties($viewMode, $properties) {
 
 	/* Remove all old map entries */
 	$ret = GalleryCoreApi::removeMapEntry(
@@ -543,7 +543,7 @@ class ExifHelper {
      *
      * @return array exif keys
      */
-    function getExifKeys() {
+    static function getExifKeys() {
 	global $gallery;
 	static $data;
 

--- a/modules/exif/lib/JPEG/JPEG.inc
+++ b/modules/exif/lib/JPEG/JPEG.inc
@@ -82,7 +82,7 @@ class JPEG // extends PEAR
      *
      * @param string  the name or url of the jpeg file
      */
-    function JPEG($fileName)
+    function __construct($fileName)
     {
         //$this->PEAR();
 

--- a/modules/exif/lib/JPEG/JPEG.inc
+++ b/modules/exif/lib/JPEG/JPEG.inc
@@ -430,8 +430,8 @@ class JPEG // extends PEAR
             $dates['ExifDateTime'] = $this->_info['exif']['DateTime'];
 
             $aux = $this->_info['exif']['DateTime'];
-            $aux{4} = "-";
-            $aux{7} = "-";
+            $aux[4] = "-";
+            $aux[7] = "-";
             $t = strtotime($aux);
 
             if ($t > $latestTime) {
@@ -449,8 +449,8 @@ class JPEG // extends PEAR
             $dates['ExifDateTimeOriginal'] = $this->_info['exif']['DateTime'];
 
             $aux = $this->_info['exif']['DateTimeOriginal'];
-            $aux{4} = "-";
-            $aux{7} = "-";
+            $aux[4] = "-";
+            $aux[7] = "-";
             $t = strtotime($aux);
 
             if ($t > $latestTime) {
@@ -468,8 +468,8 @@ class JPEG // extends PEAR
             $dates['ExifDateTimeDigitized'] = $this->_info['exif']['DateTime'];
 
             $aux = $this->_info['exif']['DateTimeDigitized'];
-            $aux{4} = "-";
-            $aux{7} = "-";
+            $aux[4] = "-";
+            $aux[7] = "-";
             $t = strtotime($aux);
 
             if ($t > $latestTime) {
@@ -2058,7 +2058,7 @@ class JPEG // extends PEAR
             $pos += 1;
             $header = '';
             for ($i = 0; $i < $strlen; $i++) {
-                $header .= $data{$pos + $i};
+                $header .= $data[$pos + $i];
             }
             $pos += $strlen + 1 - ($strlen % 2);  // The string is padded to even length, counting the length byte itself
 
@@ -2770,7 +2770,7 @@ class JPEG // extends PEAR
      */
     function _getByte(&$data, $pos)
     {
-        return ord($data{$pos});
+        return ord($data[$pos]);
     }
 
     /**
@@ -2785,7 +2785,7 @@ class JPEG // extends PEAR
     {
         $val = intval($val);
 
-        $data{$pos} = chr($val);
+        $data[$pos] = chr($val);
 
         return $pos + 1;
     }
@@ -2801,12 +2801,12 @@ class JPEG // extends PEAR
     function _getShort(&$data, $pos, $bigEndian = true)
     {
         if ($bigEndian) {
-            return (ord($data{$pos}) << 8)
-                   + ord($data{$pos + 1});
+            return (ord($data[$pos]) << 8)
+                   + ord($data[$pos + 1]);
         }
         else {
-            return ord($data{$pos})
-                   + (ord($data{$pos + 1}) << 8);
+            return ord($data[$pos])
+                   + (ord($data[$pos + 1]) << 8);
         }
     }
 
@@ -2824,12 +2824,12 @@ class JPEG // extends PEAR
         $val = intval($val);
 
         if ($bigEndian) {
-            $data{$pos + 0} = chr(($val & 0x0000FF00) >> 8);
-            $data{$pos + 1} = chr(($val & 0x000000FF) >> 0);
+            $data[$pos + 0] = chr(($val & 0x0000FF00) >> 8);
+            $data[$pos + 1] = chr(($val & 0x000000FF) >> 0);
         }
         else {
-            $data{$pos + 0} = chr(($val & 0x00FF) >> 0);
-            $data{$pos + 1} = chr(($val & 0xFF00) >> 8);
+            $data[$pos + 0] = chr(($val & 0x00FF) >> 0);
+            $data[$pos + 1] = chr(($val & 0xFF00) >> 8);
         }
 
         return $pos + 2;
@@ -2846,15 +2846,15 @@ class JPEG // extends PEAR
     function _getLong(&$data, $pos, $bigEndian = true)
     {
         if ($bigEndian) {
-            return (ord($data{$pos}) << 24)
-                   + (ord($data{$pos + 1}) << 16)
-                   + (ord($data{$pos + 2}) << 8)
-                   + ord($data{$pos + 3});
+            return (ord($data[$pos]) << 24)
+                   + (ord($data[$pos + 1]) << 16)
+                   + (ord($data[$pos + 2]) << 8)
+                   + ord($data[$pos + 3]);
         }
-        return ord($data{$pos})
-               + (ord($data{$pos + 1}) << 8)
-               + (ord($data{$pos + 2}) << 16)
-               + (ord($data{$pos + 3}) << 24);
+        return ord($data[$pos])
+               + (ord($data[$pos + 1]) << 8)
+               + (ord($data[$pos + 2]) << 16)
+               + (ord($data[$pos + 3]) << 24);
     }
 
     /**
@@ -2871,16 +2871,16 @@ class JPEG // extends PEAR
         $val = intval($val);
 
         if ($bigEndian) {
-            $data{$pos + 0} = chr(($val & 0xFF000000) >> 24);
-            $data{$pos + 1} = chr(($val & 0x00FF0000) >> 16);
-            $data{$pos + 2} = chr(($val & 0x0000FF00) >> 8);
-            $data{$pos + 3} = chr(($val & 0x000000FF) >> 0);
+            $data[$pos + 0] = chr(($val & 0xFF000000) >> 24);
+            $data[$pos + 1] = chr(($val & 0x00FF0000) >> 16);
+            $data[$pos + 2] = chr(($val & 0x0000FF00) >> 8);
+            $data[$pos + 3] = chr(($val & 0x000000FF) >> 0);
         }
         else {
-            $data{$pos + 0} = chr(($val & 0x000000FF) >> 0);
-            $data{$pos + 1} = chr(($val & 0x0000FF00) >> 8);
-            $data{$pos + 2} = chr(($val & 0x00FF0000) >> 16);
-            $data{$pos + 3} = chr(($val & 0xFF000000) >> 24);
+            $data[$pos + 0] = chr(($val & 0x000000FF) >> 0);
+            $data[$pos + 1] = chr(($val & 0x0000FF00) >> 8);
+            $data[$pos + 2] = chr(($val & 0x00FF0000) >> 16);
+            $data[$pos + 3] = chr(($val & 0xFF000000) >> 24);
         }
 
         return $pos + 4;
@@ -2893,11 +2893,11 @@ class JPEG // extends PEAR
         $max = strlen($data);
 
         while ($pos < $max) {
-            if (ord($data{$pos}) == 0) {
+            if (ord($data[$pos]) == 0) {
                 return $str;
             }
             else {
-                $str .= $data{$pos};
+                $str .= $data[$pos];
             }
             $pos++;
         }
@@ -2929,7 +2929,7 @@ class JPEG // extends PEAR
     {
         $len = strlen($str);
         for ($i = 0; $i < $len; $i++) {
-          $data{$pos + $i} = $str{$i};
+          $data[$pos + $i] = $str[$i];
         }
 
         return $pos + $len;
@@ -2955,7 +2955,7 @@ class JPEG // extends PEAR
                 echo sprintf('%04d', $count) . ': ';
             }
 
-            $c = ord($data{$start});
+            $c = ord($data[$start]);
             $count++;
             $start++;
 

--- a/modules/exif/lib/exifer/exif.inc
+++ b/modules/exif/lib/exifer/exif.inc
@@ -516,7 +516,7 @@ function formatData($type,$tag,$intel,$data) {
 	} else if($type=="UNDEFINED") {
 
 		if($tag=="9000" || $tag=="a000" || $tag=="0002") { //ExifVersion,FlashPixVersion,InteroperabilityVersion
-			$data="version ".$data/100;
+			$data="version ".intval($data)/100;
 		}
 		if($tag=="a300") { //FileSource
 			$data = bin2hex($data);

--- a/modules/exif/lib/exifer/makers/nikon.inc
+++ b/modules/exif/lib/exifer/makers/nikon.inc
@@ -160,7 +160,7 @@ function formatNikonData($type,$tag,$intel,$model,$data) {
 	} else if($type=="UNDEFINED") {
 		
 		if($tag=="0001" && $model==1) { //Unknown (Version?)
-			$data=$data/100;
+			$data=intval($data)/100;
 		}
 		if($tag=="0088" && $model==1) { //AF Focus Position
 			$temp = "Center";

--- a/modules/exif/module.inc
+++ b/modules/exif/module.inc
@@ -31,7 +31,7 @@
  */
 class ExifModule extends GalleryModule {
 
-    function ExifModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('exif');

--- a/modules/ffmpeg/module.inc
+++ b/modules/ffmpeg/module.inc
@@ -29,7 +29,7 @@
  */
 class FfmpegModule extends GalleryModule {
 
-    function FfmpegModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('ffmpeg');

--- a/modules/ffmpeg/module.inc
+++ b/modules/ffmpeg/module.inc
@@ -138,7 +138,7 @@ class FfmpegModule extends GalleryModule {
 		if (empty($path)) {
 		    continue;
 		}
-		if ($path{strlen($path)-1} != $slash) {
+		if ($path[strlen($path)-1] != $slash) {
 		    $path .= $slash;
 		}
 		$paths[] = $path . 'ffmpeg.exe';
@@ -152,7 +152,7 @@ class FfmpegModule extends GalleryModule {
 		if (empty($path)) {
 		    continue;
 		}
-		if ($path{strlen($path)-1} != $slash) {
+		if ($path[strlen($path)-1] != $slash) {
 		    $path .= $slash;
 		}
 		$paths[] = $path . 'ffmpeg';

--- a/modules/flashvideo/module.inc
+++ b/modules/flashvideo/module.inc
@@ -27,7 +27,7 @@
  */
 class FlashVideoModule extends GalleryModule {
 
-    function FlashVideoModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('flashvideo');
 	$this->setName($gallery->i18n('Flash Video'));

--- a/modules/fotokasten/lib/nusoap.inc
+++ b/modules/fotokasten/lib/nusoap.inc
@@ -532,7 +532,7 @@ class XMLSchema extends nusoap_base  {
 	* @param    string $xml xml document URI
 	* @access   public
 	*/
-	function XMLSchema($schema='',$xml=''){
+	function __construct($schema='',$xml=''){
 
 		$this->debug('xmlschema class instantiated, inside constructor');
 		// files

--- a/modules/fotokasten/module.inc
+++ b/modules/fotokasten/module.inc
@@ -30,7 +30,7 @@ define('FOTOKASTEN_GALLERY_AFFILIATE_PASSWORD', 'f12a65d90445f95b90e5fd30c75ee74
  */
 class FotokastenModule extends GalleryModule {
 
-    function FotokastenModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('fotokasten');

--- a/modules/gd/module.inc
+++ b/modules/gd/module.inc
@@ -29,7 +29,7 @@
  */
 class GdModule extends GalleryModule {
 
-    function GdModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('gd');

--- a/modules/getid3/lib/getid3/getid3.inc
+++ b/modules/getid3/lib/getid3/getid3.inc
@@ -47,7 +47,7 @@ class getID3
 
 
 	// public: constructor
-	function getID3()
+	function __construct()
 	{
 
 		$this->startup_error   = '';

--- a/modules/getid3/lib/getid3/getid3.inc
+++ b/modules/getid3/lib/getid3/getid3.inc
@@ -250,8 +250,8 @@ class getID3
 			$header = fread($fp, 10);
 			if (substr($header, 0, 3) == 'ID3') {
 				$this->info['id3v2']['header']           = true;
-				$this->info['id3v2']['majorversion']     = ord($header{3});
-				$this->info['id3v2']['minorversion']     = ord($header{4});
+				$this->info['id3v2']['majorversion']     = ord($header[3]);
+				$this->info['id3v2']['minorversion']     = ord($header[4]);
 				$this->info['id3v2']['headerlength']     = getid3_lib::BigEndian2Int(substr($header, 6, 4), 1) + 10; // length of ID3v2 tag in 10-byte header doesn't include 10-byte header length
 
 				$this->info['id3v2']['tag_offset_start'] = 0;

--- a/modules/getid3/lib/getid3/getid3.lib.inc
+++ b/modules/getid3/lib/getid3/getid3.lib.inc
@@ -18,9 +18,9 @@ class getid3_lib
 		$returnstring = '';
 		for ($i = 0; $i < strlen($string); $i++) {
 			if ($hex) {
-				$returnstring .= str_pad(dechex(ord($string{$i})), 2, '0', STR_PAD_LEFT);
+				$returnstring .= str_pad(dechex(ord($string[$i])), 2, '0', STR_PAD_LEFT);
 			} else {
-				$returnstring .= ' '.(ereg("[\x20-\x7E]", $string{$i}) ? $string{$i} : '¤');
+				$returnstring .= ' '.(ereg("[\x20-\x7E]", $string[$i]) ? $string[$i] : '¤');
 			}
 			if ($spaces) {
 				$returnstring .= ' ';
@@ -81,11 +81,11 @@ class getid3_lib
 		// http://www.scri.fsu.edu/~jac/MAD3401/Backgrnd/binary.html
 		if (strpos($binarypointnumber, '.') === false) {
 			$binarypointnumber = '0.'.$binarypointnumber;
-		} elseif ($binarypointnumber{0} == '.') {
+		} elseif ($binarypointnumber[0] == '.') {
 			$binarypointnumber = '0'.$binarypointnumber;
 		}
 		$exponent = 0;
-		while (($binarypointnumber{0} != '1') || (substr($binarypointnumber, 1, 1) != '.')) {
+		while (($binarypointnumber[0] != '1') || (substr($binarypointnumber, 1, 1) != '.')) {
 			if (substr($binarypointnumber, 1, 1) == '.') {
 				$exponent--;
 				$binarypointnumber = substr($binarypointnumber, 2, 1).'.'.substr($binarypointnumber, 3);
@@ -93,7 +93,7 @@ class getid3_lib
 				$pointpos = strpos($binarypointnumber, '.');
 				$exponent += ($pointpos - 1);
 				$binarypointnumber = str_replace('.', '', $binarypointnumber);
-				$binarypointnumber = $binarypointnumber{0}.'.'.substr($binarypointnumber, 1);
+				$binarypointnumber = $binarypointnumber[0].'.'.substr($binarypointnumber, 1);
 			}
 		}
 		$binarypointnumber = str_pad(substr($binarypointnumber, 0, $maxbits + 2), $maxbits + 2, '0', STR_PAD_RIGHT);
@@ -159,7 +159,7 @@ class getid3_lib
 		// http://www.scri.fsu.edu/~jac/MAD3401/Backgrnd/ieee.html
 
 		$bitword = getid3_lib::BigEndian2Bin($byteword);
-		$signbit = $bitword{0};
+		$signbit = $bitword[0];
 
 		switch (strlen($byteword) * 8) {
 			case 32:
@@ -176,7 +176,7 @@ class getid3_lib
 				// 80-bit Apple SANE format
 				// http://www.mactech.com/articles/mactech/Vol.06/06.01/SANENormalized/
 				$exponentstring = substr($bitword, 1, 15);
-				$isnormalized = intval($bitword{16});
+				$isnormalized = intval($bitword[16]);
 				$fractionstring = substr($bitword, 17, 63);
 				$exponent = pow(2, getid3_lib::Bin2Dec($exponentstring) - 16383);
 				$fraction = $isnormalized + getid3_lib::DecimalBinary2Float($fractionstring);
@@ -233,9 +233,9 @@ class getid3_lib
 		$bytewordlen = strlen($byteword);
 		for ($i = 0; $i < $bytewordlen; $i++) {
 			if ($synchsafe) { // disregard MSB, effectively 7-bit bytes
-				$intvalue = $intvalue | (ord($byteword{$i}) & 0x7F) << (($bytewordlen - 1 - $i) * 7);
+				$intvalue = $intvalue | (ord($byteword[$i]) & 0x7F) << (($bytewordlen - 1 - $i) * 7);
 			} else {
-				$intvalue += ord($byteword{$i}) * pow(256, ($bytewordlen - 1 - $i));
+				$intvalue += ord($byteword[$i]) * pow(256, ($bytewordlen - 1 - $i));
 			}
 		}
 		if ($signed && !$synchsafe) {
@@ -269,7 +269,7 @@ class getid3_lib
 		$binvalue = '';
 		$bytewordlen = strlen($byteword);
 		for ($i = 0; $i < $bytewordlen; $i++) {
-			$binvalue .= str_pad(decbin(ord($byteword{$i})), 8, '0', STR_PAD_LEFT);
+			$binvalue .= str_pad(decbin(ord($byteword[$i])), 8, '0', STR_PAD_LEFT);
 		}
 		return $binvalue;
 	}
@@ -313,7 +313,7 @@ class getid3_lib
 	function Bin2Dec($binstring, $signed=false) {
 		$signmult = 1;
 		if ($signed) {
-			if ($binstring{0} == '1') {
+			if ($binstring[0] == '1') {
 				$signmult = -1;
 			}
 			$binstring = substr($binstring, 1);
@@ -466,7 +466,7 @@ class getid3_lib
 		//   $foo = array('path'=>array('to'=>'array('my'=>array('file.txt'))));
 		// or
 		//   $foo['path']['to']['my'] = 'file.txt';
-		while ($ArrayPath && ($ArrayPath{0} == $Separator)) {
+		while ($ArrayPath && ($ArrayPath[0] == $Separator)) {
 			$ArrayPath = substr($ArrayPath, 1);
 		}
 		if (($pos = strpos($ArrayPath, $Separator)) !== false) {
@@ -697,7 +697,7 @@ class getid3_lib
 			$newcharstring .= "\xEF\xBB\xBF";
 		}
 		for ($i = 0; $i < strlen($string); $i++) {
-			$charval = ord($string{$i});
+			$charval = ord($string[$i]);
 			$newcharstring .= getid3_lib::iconv_fallback_int_utf8($charval);
 		}
 		return $newcharstring;
@@ -710,7 +710,7 @@ class getid3_lib
 			$newcharstring .= "\xFE\xFF";
 		}
 		for ($i = 0; $i < strlen($string); $i++) {
-			$newcharstring .= "\x00".$string{$i};
+			$newcharstring .= "\x00".$string[$i];
 		}
 		return $newcharstring;
 	}
@@ -722,7 +722,7 @@ class getid3_lib
 			$newcharstring .= "\xFF\xFE";
 		}
 		for ($i = 0; $i < strlen($string); $i++) {
-			$newcharstring .= $string{$i}."\x00";
+			$newcharstring .= $string[$i]."\x00";
 		}
 		return $newcharstring;
 	}
@@ -742,27 +742,27 @@ class getid3_lib
 		$offset = 0;
 		$stringlength = strlen($string);
 		while ($offset < $stringlength) {
-			if ((ord($string{$offset}) | 0x07) == 0xF7) {
+			if ((ord($string[$offset]) | 0x07) == 0xF7) {
 				// 11110bbb 10bbbbbb 10bbbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x07) << 18) &
-				           ((ord($string{($offset + 1)}) & 0x3F) << 12) &
-				           ((ord($string{($offset + 2)}) & 0x3F) <<  6) &
-				            (ord($string{($offset + 3)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x07) << 18) &
+				           ((ord($string[($offset + 1)]) & 0x3F) << 12) &
+				           ((ord($string[($offset + 2)]) & 0x3F) <<  6) &
+				            (ord($string[($offset + 3)]) & 0x3F);
 				$offset += 4;
-			} elseif ((ord($string{$offset}) | 0x0F) == 0xEF) {
+			} elseif ((ord($string[$offset]) | 0x0F) == 0xEF) {
 				// 1110bbbb 10bbbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x0F) << 12) &
-				           ((ord($string{($offset + 1)}) & 0x3F) <<  6) &
-				            (ord($string{($offset + 2)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x0F) << 12) &
+				           ((ord($string[($offset + 1)]) & 0x3F) <<  6) &
+				            (ord($string[($offset + 2)]) & 0x3F);
 				$offset += 3;
-			} elseif ((ord($string{$offset}) | 0x1F) == 0xDF) {
+			} elseif ((ord($string[$offset]) | 0x1F) == 0xDF) {
 				// 110bbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x1F) <<  6) &
-				            (ord($string{($offset + 1)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x1F) <<  6) &
+				            (ord($string[($offset + 1)]) & 0x3F);
 				$offset += 2;
-			} elseif ((ord($string{$offset}) | 0x7F) == 0x7F) {
+			} elseif ((ord($string[$offset]) | 0x7F) == 0x7F) {
 				// 0bbbbbbb
-				$charval = ord($string{$offset});
+				$charval = ord($string[$offset]);
 				$offset += 1;
 			} else {
 				// error? throw some kind of warning here?
@@ -785,27 +785,27 @@ class getid3_lib
 		$offset = 0;
 		$stringlength = strlen($string);
 		while ($offset < $stringlength) {
-			if ((ord($string{$offset}) | 0x07) == 0xF7) {
+			if ((ord($string[$offset]) | 0x07) == 0xF7) {
 				// 11110bbb 10bbbbbb 10bbbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x07) << 18) &
-				           ((ord($string{($offset + 1)}) & 0x3F) << 12) &
-				           ((ord($string{($offset + 2)}) & 0x3F) <<  6) &
-				            (ord($string{($offset + 3)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x07) << 18) &
+				           ((ord($string[($offset + 1)]) & 0x3F) << 12) &
+				           ((ord($string[($offset + 2)]) & 0x3F) <<  6) &
+				            (ord($string[($offset + 3)]) & 0x3F);
 				$offset += 4;
-			} elseif ((ord($string{$offset}) | 0x0F) == 0xEF) {
+			} elseif ((ord($string[$offset]) | 0x0F) == 0xEF) {
 				// 1110bbbb 10bbbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x0F) << 12) &
-				           ((ord($string{($offset + 1)}) & 0x3F) <<  6) &
-				            (ord($string{($offset + 2)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x0F) << 12) &
+				           ((ord($string[($offset + 1)]) & 0x3F) <<  6) &
+				            (ord($string[($offset + 2)]) & 0x3F);
 				$offset += 3;
-			} elseif ((ord($string{$offset}) | 0x1F) == 0xDF) {
+			} elseif ((ord($string[$offset]) | 0x1F) == 0xDF) {
 				// 110bbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x1F) <<  6) &
-				            (ord($string{($offset + 1)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x1F) <<  6) &
+				            (ord($string[($offset + 1)]) & 0x3F);
 				$offset += 2;
-			} elseif ((ord($string{$offset}) | 0x7F) == 0x7F) {
+			} elseif ((ord($string[$offset]) | 0x7F) == 0x7F) {
 				// 0bbbbbbb
-				$charval = ord($string{$offset});
+				$charval = ord($string[$offset]);
 				$offset += 1;
 			} else {
 				// error? throw some kind of warning here?
@@ -828,27 +828,27 @@ class getid3_lib
 		$offset = 0;
 		$stringlength = strlen($string);
 		while ($offset < $stringlength) {
-			if ((ord($string{$offset}) | 0x07) == 0xF7) {
+			if ((ord($string[$offset]) | 0x07) == 0xF7) {
 				// 11110bbb 10bbbbbb 10bbbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x07) << 18) &
-				           ((ord($string{($offset + 1)}) & 0x3F) << 12) &
-				           ((ord($string{($offset + 2)}) & 0x3F) <<  6) &
-				            (ord($string{($offset + 3)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x07) << 18) &
+				           ((ord($string[($offset + 1)]) & 0x3F) << 12) &
+				           ((ord($string[($offset + 2)]) & 0x3F) <<  6) &
+				            (ord($string[($offset + 3)]) & 0x3F);
 				$offset += 4;
-			} elseif ((ord($string{$offset}) | 0x0F) == 0xEF) {
+			} elseif ((ord($string[$offset]) | 0x0F) == 0xEF) {
 				// 1110bbbb 10bbbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x0F) << 12) &
-				           ((ord($string{($offset + 1)}) & 0x3F) <<  6) &
-				            (ord($string{($offset + 2)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x0F) << 12) &
+				           ((ord($string[($offset + 1)]) & 0x3F) <<  6) &
+				            (ord($string[($offset + 2)]) & 0x3F);
 				$offset += 3;
-			} elseif ((ord($string{$offset}) | 0x1F) == 0xDF) {
+			} elseif ((ord($string[$offset]) | 0x1F) == 0xDF) {
 				// 110bbbbb 10bbbbbb
-				$charval = ((ord($string{($offset + 0)}) & 0x1F) <<  6) &
-				            (ord($string{($offset + 1)}) & 0x3F);
+				$charval = ((ord($string[($offset + 0)]) & 0x1F) <<  6) &
+				            (ord($string[($offset + 1)]) & 0x3F);
 				$offset += 2;
-			} elseif ((ord($string{$offset}) | 0x7F) == 0x7F) {
+			} elseif ((ord($string[$offset]) | 0x7F) == 0x7F) {
 				// 0bbbbbbb
-				$charval = ord($string{$offset});
+				$charval = ord($string[$offset]);
 				$offset += 1;
 			} else {
 				// error? maybe throw some warning here?
@@ -1058,22 +1058,22 @@ class getid3_lib
 			case 'UTF-8':
 				$strlen = strlen($string);
 				for ($i = 0; $i < $strlen; $i++) {
-					$char_ord_val = ord($string{$i});
+					$char_ord_val = ord($string[$i]);
 					$charval = 0;
 					if ($char_ord_val < 0x80) {
 						$charval = $char_ord_val;
 					} elseif ((($char_ord_val & 0xF0) >> 4) == 0x0F) {
 						$charval  = (($char_ord_val & 0x07) << 18);
-						$charval += ((ord($string{++$i}) & 0x3F) << 12);
-						$charval += ((ord($string{++$i}) & 0x3F) << 6);
-						$charval +=  (ord($string{++$i}) & 0x3F);
+						$charval += ((ord($string[++$i]) & 0x3F) << 12);
+						$charval += ((ord($string[++$i]) & 0x3F) << 6);
+						$charval +=  (ord($string[++$i]) & 0x3F);
 					} elseif ((($char_ord_val & 0xE0) >> 5) == 0x07) {
 						$charval  = (($char_ord_val & 0x0F) << 12);
-						$charval += ((ord($string{++$i}) & 0x3F) << 6);
-						$charval +=  (ord($string{++$i}) & 0x3F);
+						$charval += ((ord($string[++$i]) & 0x3F) << 6);
+						$charval +=  (ord($string[++$i]) & 0x3F);
 					} elseif ((($char_ord_val & 0xC0) >> 6) == 0x03) {
 						$charval  = (($char_ord_val & 0x1F) << 6);
-						$charval += (ord($string{++$i}) & 0x3F);
+						$charval += (ord($string[++$i]) & 0x3F);
 					}
 					if (($charval >= 32) && ($charval <= 127)) {
 						$HTMLstring .= chr($charval);

--- a/modules/getid3/lib/getid3/module.archive.tar.inc
+++ b/modules/getid3/lib/getid3/module.archive.tar.inc
@@ -30,13 +30,13 @@ class getid3_tar {
 			// check the block
 			$checksum = 0;
 			for ($i = 0; $i < 148; $i++) {
-				$checksum += ord($buffer{$i});
+				$checksum += ord($buffer[$i]);
 			}
 			for ($i = 148; $i < 156; $i++) {
 				$checksum += ord(' ');
 			}
 			for ($i = 156; $i < 512; $i++) {
-				$checksum += ord($buffer{$i});
+				$checksum += ord($buffer[$i]);
 			}
 			$attr    = unpack($unpack_header, $buffer);
 			$name    =        trim(@$attr['fname']);

--- a/modules/getid3/lib/getid3/module.archive.zip.inc
+++ b/modules/getid3/lib/getid3/module.archive.zip.inc
@@ -17,7 +17,7 @@
 class getid3_zip
 {
 
-	function getid3_zip(&$fd, &$ThisFileInfo) {
+	function __construct(&$fd, &$ThisFileInfo) {
 
 		$ThisFileInfo['fileformat']      = 'zip';
 		$ThisFileInfo['zip']['encoding'] = 'ISO-8859-1';

--- a/modules/getid3/lib/getid3/module.audio-video.quicktime.inc
+++ b/modules/getid3/lib/getid3/module.audio-video.quicktime.inc
@@ -18,7 +18,7 @@ getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio.mp3.inc', __FILE_
 class getid3_quicktime
 {
 
-	function getid3_quicktime(&$fd, &$ThisFileInfo, $ReturnAtomData=true, $ParseAllPossibleAtoms=false) {
+	function __construct(&$fd, &$ThisFileInfo, $ReturnAtomData=true, $ParseAllPossibleAtoms=false) {
 
 		$ThisFileInfo['fileformat'] = 'quicktime';
 		$ThisFileInfo['quicktime']['hinting'] = false;

--- a/modules/getid3/lib/getid3/module.audio-video.riff.inc
+++ b/modules/getid3/lib/getid3/module.audio-video.riff.inc
@@ -1315,7 +1315,7 @@ class getid3_riff
 			$RIFFdataLength = strlen($RIFFdata);
 			$NewLengthString = getid3_lib::LittleEndian2String($RIFFdataLength, 4);
 			for ($i = 0; $i < 4; $i++) {
-				$RIFFdata{$i + 4} = $NewLengthString{$i};
+				$RIFFdata[$i + 4] = $NewLengthString[$i];
 			}
 			fwrite($fp_temp, $RIFFdata);
 			fclose($fp_temp);

--- a/modules/getid3/lib/getid3/module.audio-video.riff.inc
+++ b/modules/getid3/lib/getid3/module.audio-video.riff.inc
@@ -21,7 +21,7 @@ getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio.mp3.inc', __FILE_
 class getid3_riff
 {
 
-	function getid3_riff(&$fd, &$ThisFileInfo) {
+	function __construct(&$fd, &$ThisFileInfo) {
 
 		// initialize these values to an empty array, otherwise they default to NULL
 		// and you can't append array values to a NULL value

--- a/modules/getid3/lib/getid3/module.audio.flac.inc
+++ b/modules/getid3/lib/getid3/module.audio.flac.inc
@@ -19,7 +19,7 @@ getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio.ogg.inc', __FILE_
 class getid3_flac
 {
 
-	function getid3_flac(&$fd, &$ThisFileInfo) {
+	function __construct(&$fd, &$ThisFileInfo) {
 		// http://flac.sourceforge.net/format.html
 
 		fseek($fd, $ThisFileInfo['avdataoffset'], SEEK_SET);

--- a/modules/getid3/lib/getid3/module.audio.mp3.inc
+++ b/modules/getid3/lib/getid3/module.audio.mp3.inc
@@ -26,7 +26,7 @@ class getid3_mp3
 
 	var $allow_bruteforce = false; // forces getID3() to scan the file byte-by-byte and log all the valid audio frame headers - extremely slow, unrecommended, but may provide data from otherwise-unusuable files
 
-	function getid3_mp3(&$fd, &$ThisFileInfo) {
+	function __construct(&$fd, &$ThisFileInfo) {
 
 		if (!$this->getOnlyMPEGaudioInfo($fd, $ThisFileInfo, $ThisFileInfo['avdataoffset'])) {
 			if ($this->allow_bruteforce) {

--- a/modules/getid3/lib/getid3/module.audio.mp3.inc
+++ b/modules/getid3/lib/getid3/module.audio.mp3.inc
@@ -668,7 +668,7 @@ class getid3_mp3
 				if ($thisfile_mpeg_audio['xing_flags']['toc']) {
 					$LAMEtocData = substr($headerstring, $VBRidOffset + 16, 100);
 					for ($i = 0; $i < 100; $i++) {
-						$thisfile_mpeg_audio['toc'][$i] = ord($LAMEtocData{$i});
+						$thisfile_mpeg_audio['toc'][$i] = ord($LAMEtocData[$i]);
 					}
 				}
 				if ($thisfile_mpeg_audio['xing_flags']['vbr_scale']) {
@@ -1381,7 +1381,7 @@ class getid3_mp3
 				return false;
 			}
 
-			if (($header{$SynchSeekOffset} == "\xFF") && ($header{($SynchSeekOffset + 1)} > "\xE0")) { // synch detected
+			if (($header[$SynchSeekOffset] == "\xFF") && ($header[($SynchSeekOffset + 1)] > "\xE0")) { // synch detected
 
 				if (!isset($FirstFrameThisfileInfo) && !isset($ThisFileInfo['mpeg']['audio'])) {
 					$FirstFrameThisfileInfo = $ThisFileInfo;
@@ -1707,18 +1707,18 @@ class getid3_mp3
 		}
 
 		$MPEGrawHeader['synch']         = (getid3_lib::BigEndian2Int(substr($Header4Bytes, 0, 2)) & 0xFFE0) >> 4;
-		$MPEGrawHeader['version']       = (ord($Header4Bytes{1}) & 0x18) >> 3; //    BB
-		$MPEGrawHeader['layer']         = (ord($Header4Bytes{1}) & 0x06) >> 1; //      CC
-		$MPEGrawHeader['protection']    = (ord($Header4Bytes{1}) & 0x01);      //        D
-		$MPEGrawHeader['bitrate']       = (ord($Header4Bytes{2}) & 0xF0) >> 4; // EEEE
-		$MPEGrawHeader['sample_rate']   = (ord($Header4Bytes{2}) & 0x0C) >> 2; //     FF
-		$MPEGrawHeader['padding']       = (ord($Header4Bytes{2}) & 0x02) >> 1; //       G
-		$MPEGrawHeader['private']       = (ord($Header4Bytes{2}) & 0x01);      //        H
-		$MPEGrawHeader['channelmode']   = (ord($Header4Bytes{3}) & 0xC0) >> 6; // II
-		$MPEGrawHeader['modeextension'] = (ord($Header4Bytes{3}) & 0x30) >> 4; //   JJ
-		$MPEGrawHeader['copyright']     = (ord($Header4Bytes{3}) & 0x08) >> 3; //     K
-		$MPEGrawHeader['original']      = (ord($Header4Bytes{3}) & 0x04) >> 2; //      L
-		$MPEGrawHeader['emphasis']      = (ord($Header4Bytes{3}) & 0x03);      //       MM
+		$MPEGrawHeader['version']       = (ord($Header4Bytes[1]) & 0x18) >> 3; //    BB
+		$MPEGrawHeader['layer']         = (ord($Header4Bytes[1]) & 0x06) >> 1; //      CC
+		$MPEGrawHeader['protection']    = (ord($Header4Bytes[1]) & 0x01);      //        D
+		$MPEGrawHeader['bitrate']       = (ord($Header4Bytes[2]) & 0xF0) >> 4; // EEEE
+		$MPEGrawHeader['sample_rate']   = (ord($Header4Bytes[2]) & 0x0C) >> 2; //     FF
+		$MPEGrawHeader['padding']       = (ord($Header4Bytes[2]) & 0x02) >> 1; //       G
+		$MPEGrawHeader['private']       = (ord($Header4Bytes[2]) & 0x01);      //        H
+		$MPEGrawHeader['channelmode']   = (ord($Header4Bytes[3]) & 0xC0) >> 6; // II
+		$MPEGrawHeader['modeextension'] = (ord($Header4Bytes[3]) & 0x30) >> 4; //   JJ
+		$MPEGrawHeader['copyright']     = (ord($Header4Bytes[3]) & 0x08) >> 3; //     K
+		$MPEGrawHeader['original']      = (ord($Header4Bytes[3]) & 0x04) >> 2; //      L
+		$MPEGrawHeader['emphasis']      = (ord($Header4Bytes[3]) & 0x03);      //       MM
 
 		return $MPEGrawHeader;
 	}

--- a/modules/getid3/lib/getid3/module.audio.ogg.inc
+++ b/modules/getid3/lib/getid3/module.audio.ogg.inc
@@ -18,7 +18,7 @@ getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.audio.flac.inc', __FILE
 class getid3_ogg
 {
 
-	function getid3_ogg(&$fd, &$ThisFileInfo) {
+	function __construct(&$fd, &$ThisFileInfo) {
 
 		$ThisFileInfo['fileformat'] = 'ogg';
 

--- a/modules/getid3/lib/getid3/module.misc.iso.inc
+++ b/modules/getid3/lib/getid3/module.misc.iso.inc
@@ -17,7 +17,7 @@
 class getid3_iso
 {
 
-	function getid3_iso($fd, &$ThisFileInfo) {
+	function __construct($fd, &$ThisFileInfo) {
 		$ThisFileInfo['fileformat'] = 'iso';
 
 		for ($i = 16; $i <= 19; $i++) {

--- a/modules/getid3/lib/getid3/module.misc.iso.inc
+++ b/modules/getid3/lib/getid3/module.misc.iso.inc
@@ -24,7 +24,7 @@ class getid3_iso
 			fseek($fd, 2048 * $i, SEEK_SET);
 			$ISOheader = fread($fd, 2048);
 			if (substr($ISOheader, 1, 5) == 'CD001') {
-				switch (ord($ISOheader{0})) {
+				switch (ord($ISOheader[0])) {
 					case 1:
 						$ThisFileInfo['iso']['primary_volume_descriptor']['offset'] = 2048 * $i;
 						$this->ParsePrimaryVolumeDescriptor($ISOheader, $ThisFileInfo);
@@ -275,9 +275,9 @@ class getid3_iso
 		fseek($fd, $directorydata['location_bytes'], SEEK_SET);
 		$DirectoryRecordData = fread($fd, 1);
 
-		while (ord($DirectoryRecordData{0}) > 33) {
+		while (ord($DirectoryRecordData[0]) > 33) {
 
-			$DirectoryRecordData .= fread($fd, ord($DirectoryRecordData{0}) - 1);
+			$DirectoryRecordData .= fread($fd, ord($DirectoryRecordData[0]) - 1);
 
 			$ThisDirectoryRecord['raw']['length']                    = getid3_lib::LittleEndian2Int(substr($DirectoryRecordData,  0, 1));
 			$ThisDirectoryRecord['raw']['extended_attribute_length'] = getid3_lib::LittleEndian2Int(substr($DirectoryRecordData,  1, 1));
@@ -351,13 +351,13 @@ class getid3_iso
 		// 6: second of the minute from 0 to 59
 		// 7: Offset from Greenwich Mean Time in number of 15 minute intervals from -48 (West) to +52 (East)
 
-		$UNIXyear   = ord($ISOtime{0}) + 1900;
-		$UNIXmonth  = ord($ISOtime{1});
-		$UNIXday    = ord($ISOtime{2});
-		$UNIXhour   = ord($ISOtime{3});
-		$UNIXminute = ord($ISOtime{4});
-		$UNIXsecond = ord($ISOtime{5});
-		$GMToffset  = $this->TwosCompliment2Decimal(ord($ISOtime{5}));
+		$UNIXyear   = ord($ISOtime[0]) + 1900;
+		$UNIXmonth  = ord($ISOtime[1]);
+		$UNIXday    = ord($ISOtime[2]);
+		$UNIXhour   = ord($ISOtime[3]);
+		$UNIXminute = ord($ISOtime[4]);
+		$UNIXsecond = ord($ISOtime[5]);
+		$GMToffset  = $this->TwosCompliment2Decimal(ord($ISOtime[5]));
 
 		return gmmktime($UNIXhour, $UNIXminute, $UNIXsecond, $UNIXmonth, $UNIXday, $UNIXyear);
 	}

--- a/modules/getid3/lib/getid3/module.tag.apetag.inc
+++ b/modules/getid3/lib/getid3/module.tag.apetag.inc
@@ -16,7 +16,7 @@
 class getid3_apetag
 {
 
-	function getid3_apetag(&$fd, &$ThisFileInfo, $overrideendoffset=0) {
+	function __construct(&$fd, &$ThisFileInfo, $overrideendoffset=0) {
 		$id3v1tagsize     = 128;
 		$apetagheadersize = 32;
 		$lyrics3tagsize   = 10;

--- a/modules/getid3/lib/getid3/module.tag.id3v1.inc
+++ b/modules/getid3/lib/getid3/module.tag.id3v1.inc
@@ -17,7 +17,7 @@
 class getid3_id3v1
 {
 
-	function getid3_id3v1(&$fd, &$ThisFileInfo) {
+	function __construct(&$fd, &$ThisFileInfo) {
 
 		fseek($fd, -256, SEEK_END);
 		$preid3v1 = fread($fd, 128);
@@ -105,7 +105,7 @@ class getid3_id3v1
 		return trim(substr($str, 0, strcspn($str, "\x00")));
 	}
 
-	function ArrayOfGenres($allowSCMPXextended=false) {
+	static function ArrayOfGenres($allowSCMPXextended=false) {
 		static $GenreLookup = array(
 			0    => 'Blues',
 			1    => 'Classic Rock',
@@ -302,7 +302,7 @@ class getid3_id3v1
 		return (isset($GenreLookup[$genreid]) ? $GenreLookup[$genreid] : false);
 	}
 
-	function LookupGenreID($genre, $allowSCMPXextended=false) {
+	static function LookupGenreID($genre, $allowSCMPXextended=false) {
 		$GenreLookup = getid3_id3v1::ArrayOfGenres($allowSCMPXextended);
 		$LowerCaseNoSpaceSearchTerm = strtolower(str_replace(' ', '', $genre));
 		foreach ($GenreLookup as $key => $value) {

--- a/modules/getid3/lib/getid3/module.tag.id3v2.inc
+++ b/modules/getid3/lib/getid3/module.tag.id3v2.inc
@@ -52,8 +52,8 @@ class getid3_id3v2
 		$header = fread($fd, 10);
 		if (substr($header, 0, 3) == 'ID3') {
 
-			$thisfile_id3v2['majorversion'] = ord($header{3});
-			$thisfile_id3v2['minorversion'] = ord($header{4});
+			$thisfile_id3v2['majorversion'] = ord($header[3]);
+			$thisfile_id3v2['minorversion'] = ord($header[4]);
 
 			// shortcut
 			$id3v2_majorversion = &$thisfile_id3v2['majorversion'];
@@ -72,7 +72,7 @@ class getid3_id3v2
 
 		}
 
-		$id3_flags = ord($header{5});
+		$id3_flags = ord($header[5]);
 		switch ($id3v2_majorversion) {
 			case 2:
 				// %ab000000 in v2.2
@@ -191,7 +191,7 @@ class getid3_id3v2
 					$thisfile_id3v2['padding']['length'] = strlen($framedata);
 					$thisfile_id3v2['padding']['valid']  = true;
 					for ($i = 0; $i < $thisfile_id3v2['padding']['length']; $i++) {
-						if ($framedata{$i} != "\x00") {
+						if ($framedata[$i] != "\x00") {
 							$thisfile_id3v2['padding']['valid'] = false;
 							$thisfile_id3v2['padding']['errorpos'] = $thisfile_id3v2['padding']['start'] + $i;
 							$ThisFileInfo['warning'][] = 'Invalid ID3v2 padding found at offset '.$thisfile_id3v2['padding']['errorpos'].' (the remaining '.($thisfile_id3v2['padding']['length'] - $i).' bytes are considered invalid)';
@@ -251,7 +251,7 @@ class getid3_id3v2
 					$thisfile_id3v2['padding']['length'] = strlen($framedata);
 					$thisfile_id3v2['padding']['valid']  = true;
 					for ($i = 0; $i < $thisfile_id3v2['padding']['length']; $i++) {
-						if ($framedata{$i} != "\x00") {
+						if ($framedata[$i] != "\x00") {
 							$thisfile_id3v2['padding']['valid'] = false;
 							$thisfile_id3v2['padding']['errorpos'] = $thisfile_id3v2['padding']['start'] + $i;
 							$ThisFileInfo['warning'][] = 'Invalid ID3v2 padding found at offset '.$thisfile_id3v2['padding']['errorpos'].' (the remaining '.($thisfile_id3v2['padding']['length'] - $i).' bytes are considered invalid)';
@@ -359,11 +359,11 @@ class getid3_id3v2
 			$footer = fread($fd, 10);
 			if (substr($footer, 0, 3) == '3DI') {
 				$thisfile_id3v2['footer'] = true;
-				$thisfile_id3v2['majorversion_footer'] = ord($footer{3});
-				$thisfile_id3v2['minorversion_footer'] = ord($footer{4});
+				$thisfile_id3v2['majorversion_footer'] = ord($footer[3]);
+				$thisfile_id3v2['minorversion_footer'] = ord($footer[4]);
 			}
 			if ($thisfile_id3v2['majorversion_footer'] <= 4) {
-				$id3_flags = ord(substr($footer{5}));
+				$id3_flags = ord(substr($footer[5]));
 				$thisfile_id3v2_flags['unsynch_footer']  = (bool) ($id3_flags & 0x80);
 				$thisfile_id3v2_flags['extfoot_footer']  = (bool) ($id3_flags & 0x40);
 				$thisfile_id3v2_flags['experim_footer']  = (bool) ($id3_flags & 0x20);
@@ -867,7 +867,7 @@ class getid3_id3v2
 					$parsedFrame['lyrics'][$timestampindex]['data'] = substr($frame_remainingdata, $frame_offset, $frame_terminatorpos - $frame_offset);
 
 					$frame_remainingdata = substr($frame_remainingdata, $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)));
-					if (($timestampindex == 0) && (ord($frame_remainingdata{0}) != 0)) {
+					if (($timestampindex == 0) && (ord($frame_remainingdata[0]) != 0)) {
 						// timestamp probably omitted for first data item
 					} else {
 						$parsedFrame['lyrics'][$timestampindex]['timestamp'] = getid3_lib::BigEndian2Int(substr($frame_remainingdata, 0, 4));
@@ -3080,10 +3080,10 @@ class getid3_id3v2
 
 	function IsANumber($numberstring, $allowdecimal=false, $allownegative=false) {
 		for ($i = 0; $i < strlen($numberstring); $i++) {
-			if ((chr($numberstring{$i}) < chr('0')) || (chr($numberstring{$i}) > chr('9'))) {
-				if (($numberstring{$i} == '.') && $allowdecimal) {
+			if ((chr($numberstring[$i]) < chr('0')) || (chr($numberstring[$i]) > chr('9'))) {
+				if (($numberstring[$i] == '.') && $allowdecimal) {
 					// allowed
-				} elseif (($numberstring{$i} == '-') && $allownegative && ($i == 0)) {
+				} elseif (($numberstring[$i] == '-') && $allownegative && ($i == 0)) {
 					// allowed
 				} else {
 					return false;

--- a/modules/getid3/lib/getid3/module.tag.id3v2.inc
+++ b/modules/getid3/lib/getid3/module.tag.id3v2.inc
@@ -18,7 +18,7 @@ getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.tag.id3v1.inc', __FILE_
 class getid3_id3v2
 {
 
-	function getid3_id3v2(&$fd, &$ThisFileInfo, $StartingOffset=0) {
+	function __construct(&$fd, &$ThisFileInfo, $StartingOffset=0) {
 		//    Overall tag structure:
 		//        +-----------------------------+
 		//        |      Header (10 bytes)      |

--- a/modules/getid3/lib/getid3/module.tag.lyrics3.inc
+++ b/modules/getid3/lib/getid3/module.tag.lyrics3.inc
@@ -17,7 +17,7 @@
 class getid3_lyrics3
 {
 
-	function getid3_lyrics3(&$fd, &$ThisFileInfo) {
+	function __construct(&$fd, &$ThisFileInfo) {
 		// http://www.volweb.cz/str/tags.htm
 
 		fseek($fd, (0 - 128 - 9 - 6), SEEK_END);          // end - ID3v1 - LYRICSEND - [Lyrics3size]

--- a/modules/getid3/module.inc
+++ b/modules/getid3/module.inc
@@ -29,7 +29,7 @@
  */
 class Getid3Module extends GalleryModule {
 
-    function Getid3Module() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('getid3');

--- a/modules/hidden/classes/HiddenHelper.class
+++ b/modules/hidden/classes/HiddenHelper.class
@@ -523,7 +523,7 @@ class HiddenHelper extends HiddenInterface_1_0 {
 	return array(null, $item->hasOnLoadHandler('Hidden'));
     }
 
-    function HiddenHelper() {
+    function __construct() {
 	$this->_notEmpty = true;
     }
 }

--- a/modules/hidden/module.inc
+++ b/modules/hidden/module.inc
@@ -31,7 +31,7 @@
  */
 class HiddenModule extends GalleryModule /* and GalleryEventListener */ {
 
-    function HiddenModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('hidden');

--- a/modules/httpauth/classes/HttpAuthHelper.class
+++ b/modules/httpauth/classes/HttpAuthHelper.class
@@ -40,7 +40,7 @@ class HttpAuthHelper /* extends HttpAuthInterface_1_0 */ {
      * @return array GalleryStatus a status code
      *               int HTTP auth status code
      */
-    function checkConfiguration() {
+    static function checkConfiguration() {
 	global $gallery;
 	$urlGenerator =& $gallery->getUrlGenerator();
 
@@ -108,7 +108,7 @@ class HttpAuthHelper /* extends HttpAuthInterface_1_0 */ {
      * @return array GalleryStatus a status code
      *               boolean true if Gallery can access HTTP usernames and passwords
      */
-    function checkHttpAuth() {
+    static function checkHttpAuth() {
 	global $gallery;
 	$urlGenerator =& $gallery->getUrlGenerator();
 
@@ -144,7 +144,7 @@ class HttpAuthHelper /* extends HttpAuthInterface_1_0 */ {
      *               string HTTP username
      *               string HTTP password
      */
-    function getHttpAuth() {
+    static function getHttpAuth() {
 	$authtype = GalleryUtilities::getServerVar('AUTH_TYPE');
 	$username = GalleryUtilities::getServerVar('PHP_AUTH_USER');
 	$password = GalleryUtilities::getServerVar('PHP_AUTH_PW');
@@ -178,7 +178,7 @@ class HttpAuthHelper /* extends HttpAuthInterface_1_0 */ {
      * @return array GalleryStatus a status code
      *               GalleryUser the active user or null
      */
-    function getUser($authtype, $username) {
+    static function getUser($authtype, $username) {
 	list ($ret, $params) = GalleryCoreApi::fetchAllPluginParameters('module', 'httpauth');
 	if ($ret) {
 	    return array($ret, null);
@@ -227,7 +227,7 @@ class HttpAuthHelper /* extends HttpAuthInterface_1_0 */ {
      * @param GalleryUser $authenticatedUser user authenticated for this request
      * @return GalleryStatus a status code
      */
-    function regenerateSessionIfNecessary($authenticatedUser) {
+    static function regenerateSessionIfNecessary($authenticatedUser) {
 	global $gallery;
 	$session =& $gallery->getSession();
 
@@ -249,7 +249,7 @@ class HttpAuthHelper /* extends HttpAuthInterface_1_0 */ {
      * @param string $username
      * @param string $password
      */
-    function addHttpAuthToUrl($url, $username, $password) {
+    static function addHttpAuthToUrl($url, $username, $password) {
 	$components = parse_url($url);
 	$components['user'] = $username;
 	$components['pass'] = $password;
@@ -260,7 +260,7 @@ class HttpAuthHelper /* extends HttpAuthInterface_1_0 */ {
      * Removes user:pass from the given URL.
      * @param string $url An absolute URL
      */
-    function stripHttpAuthFromUrl($url) {
+    static function stripHttpAuthFromUrl($url) {
 	$components = parse_url($url);
 	unset($components['user']);
 	unset($components['pass']);
@@ -270,7 +270,7 @@ class HttpAuthHelper /* extends HttpAuthInterface_1_0 */ {
     /**
      * @see HttpAuthInterface_1_0::getConfiguration
      */
-    function getConfiguration() {
+    static function getConfiguration() {
 	list ($ret, $params) = GalleryCoreApi::fetchAllPluginParameters('module', 'httpauth');
 	if ($ret) {
 	    return array($ret, null, null, null);
@@ -282,7 +282,7 @@ class HttpAuthHelper /* extends HttpAuthInterface_1_0 */ {
     /**
      * @see HttpAuthInterface_1_0::setConfiguration
      */
-    function setConfiguration($enableHttpAuth, $enableServerAuth=false, $useGlobally=false) {
+    static function setConfiguration($enableHttpAuth, $enableServerAuth=false, $useGlobally=false) {
 	list ($ret, $module) = GalleryCoreApi::loadPlugin('module', 'httpauth');
 	if ($ret) {
 	    return $ret;
@@ -312,7 +312,7 @@ class HttpAuthHelper /* extends HttpAuthInterface_1_0 */ {
     /**
      * @see HttpAuthInterface_1_0::requestAuthentication
      */
-    function requestAuthentication($ignoreUseGloballyFlag=true) {
+    static function requestAuthentication($ignoreUseGloballyFlag=true) {
 	list ($ret, $params) = GalleryCoreApi::fetchAllPluginParameters('module', 'httpauth');
 	if ($ret) {
 	    return $ret;
@@ -338,7 +338,7 @@ class HttpAuthHelper /* extends HttpAuthInterface_1_0 */ {
      * @param array $components URL components in the format of parse_url
      * @access private
      */
-    function _buildUrl($components) {
+    static function _buildUrl($components) {
 	$url = '';
 	if (!empty($components['scheme']) && !empty($components['host'])) {
 	    $auth = '';

--- a/modules/httpauth/module.inc
+++ b/modules/httpauth/module.inc
@@ -26,7 +26,7 @@
  */
 class HttpAuthModule extends GalleryModule /* and GalleryEventListener */ {
 
-    function HttpAuthModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('httpauth');

--- a/modules/icons/module.inc
+++ b/modules/icons/module.inc
@@ -27,7 +27,7 @@
  */
 class IconsModule extends GalleryModule {
 
-    function IconsModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('icons');
 	$this->setName($gallery->i18n('Icons'));

--- a/modules/imageblock/classes/ImageBlockHelper.class
+++ b/modules/imageblock/classes/ImageBlockHelper.class
@@ -35,7 +35,7 @@ class ImageBlockHelper /* extends GalleryEventListener */ {
      * @param array $params (optional) image block parameters (to override module settings)
      * @return GalleryStatus a status code
      */
-    function loadImageBlocks(&$template, $params) {
+    static function loadImageBlocks(&$template, $params) {
 	global $gallery;
 	list ($ret, $moduleParams) =
 	    GalleryCoreApi::fetchAllPluginParameters('module', 'imageblock');
@@ -206,7 +206,7 @@ class ImageBlockHelper /* extends GalleryEventListener */ {
     /**
      * @access private
      */
-    function _getBlockData($itemType, $order, $count, $parentId=null,
+    static function _getBlockData($itemType, $order, $count, $parentId=null,
 			   $fullSize=false, $userId=null, $maxSize=null, $biggerOnly=false) {
 	$blocks = $data = array();
 	switch ($order) {
@@ -493,7 +493,7 @@ class ImageBlockHelper /* extends GalleryEventListener */ {
      * @return array GalleryStatus a status code
      *               array of arrays containing id, viewCount of items (empty array if none found)
      */
-    function fetchViewableData($itemType, $order, $count, $parentId=null, $userId=null) {
+    static function fetchViewableData($itemType, $order, $count, $parentId=null, $userId=null) {
 	global $gallery;
 	$storage =& $gallery->getStorage();
 	$typeMap = array('Image' => 1, 'Album' => 2);
@@ -634,7 +634,7 @@ class ImageBlockHelper /* extends GalleryEventListener */ {
      * @return array GalleryStatus a status code
      *               string containing SQL ORDER BY statement
      */
-    function _buildOrderBy($order) {
+    static function _buildOrderBy($order) {
 	global $gallery;
 	$orderBy = null;
 
@@ -657,7 +657,7 @@ class ImageBlockHelper /* extends GalleryEventListener */ {
     /**
      * @access private
      */
-    function _runQuery($query, $data) {
+    static function _runQuery($query, $data) {
 	global $gallery;
 	list ($ret, $searchResults) = $gallery->search($query, $data);
 	if ($ret) {
@@ -677,7 +677,7 @@ class ImageBlockHelper /* extends GalleryEventListener */ {
     /**
      * @access private
      */
-    function _isCached($userId) {
+    static function _isCached($userId) {
 	global $gallery;
 	list ($ret, $searchResults) = $gallery->search(
 	    'SELECT COUNT(*) FROM [ImageBlockCacheMap] WHERE [ImageBlockCacheMap::userId] = ?',
@@ -695,7 +695,7 @@ class ImageBlockHelper /* extends GalleryEventListener */ {
      * @return GalleryStatus a status code
      * @todo Respect DisabledMap on INSERT such that we don't have to join the DisabledMap on SELECT
      */
-    function cacheViewableTree($userId) {
+    static function cacheViewableTree($userId) {
 	global $gallery;
 	$storage =& $gallery->getStorage();
 
@@ -883,7 +883,7 @@ class ImageBlockHelper /* extends GalleryEventListener */ {
      * @param boolean $useProgressBar (optional) use a progressbar during update? (default=false)
      * @return GalleryStatus a status code
      */
-    function setDisabledFlag($parentAlbum, $recursive, $disabled, $useProgressBar=false) {
+    static function setDisabledFlag($parentAlbum, $recursive, $disabled, $useProgressBar=false) {
 	global $gallery;
 
 	$parentAlbumId = $parentAlbum->getId();
@@ -975,7 +975,7 @@ class ImageBlockHelper /* extends GalleryEventListener */ {
      * @return array GalleryStatus a status code
      *               boolean disabledFlag for the GalleryDataItem
      */
-    function getDisabledFlag($itemId) {
+    static function getDisabledFlag($itemId) {
 	list ($ret, $searchResults) = GalleryCoreApi::getMapEntry('ImageBlockDisabledMap',
 	    array('itemId'), array('itemId' => (int)$itemId));
 	if ($ret) {
@@ -995,14 +995,14 @@ class ImageBlockHelper /* extends GalleryEventListener */ {
      * @param  int $max(optional) the maximim number to generate (default: 2147483647)
      * @return int a number between 0 and 2147483647.
      */
-    function getRandomKey($min=0, $max=2147483647) {
+    static function getRandomKey($min=0, $max=2147483647) {
     	global $gallery;
     	$phpVm = $gallery->getPhpVm();
 	static $initialized = false;
 
 	if (!$initialized) {
 	    list($usec, $sec) = explode(' ', microtime());
-	    srand($sec + $usec * 100000);
+	    srand($sec + intval($usec) * 100000);
 	    $initialized = true;
 	}
 	return $phpVm->rand($min, $max);
@@ -1018,7 +1018,7 @@ class ImageBlockHelper /* extends GalleryEventListener */ {
      *		     array int Minimum value of the random number to be genereated
      *			   int Maximum value of the random number to be generated
      */
-    function getRandomKeyRange($userId, $itemType, $parentSequence=null) {
+    static function getRandomKeyRange($userId, $itemType, $parentSequence=null) {
 	global $gallery;
 	$storage = $gallery->getStorage();
 

--- a/modules/imageblock/module.inc
+++ b/modules/imageblock/module.inc
@@ -27,7 +27,7 @@
  */
 class ImageBlockModule extends GalleryModule {
 
-    function ImageBlockModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('imageblock');
 	$this->setName($gallery->i18n('Image Block'));

--- a/modules/imageframe/module.inc
+++ b/modules/imageframe/module.inc
@@ -27,7 +27,7 @@
  */
 class ImageFrameModule extends GalleryModule {
 
-    function ImageFrameModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('imageframe');
 	$this->setName($gallery->i18n('ImageFrame'));

--- a/modules/imagemagick/module.inc
+++ b/modules/imagemagick/module.inc
@@ -30,7 +30,7 @@
  */
 class ImageMagickModule extends GalleryModule {
 
-    function ImageMagickModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('imagemagick');

--- a/modules/imagemagick/module.inc
+++ b/modules/imagemagick/module.inc
@@ -245,7 +245,7 @@ class ImageMagickModule extends GalleryModule {
 		if (empty($path)) {
 		    continue;
 		}
-		if ($path{strlen($path)-1} != $slash) {
+		if ($path[strlen($path)-1] != $slash) {
 		    $path .= $slash;
 		}
 		$paths[] = $path;
@@ -266,7 +266,7 @@ class ImageMagickModule extends GalleryModule {
 		if (empty($path)) {
 		    continue;
 		}
-		if ($path{strlen($path)-1} != $slash) {
+		if ($path[strlen($path)-1] != $slash) {
 		    $path .= $slash;
 		}
 		$paths[] = $path;

--- a/modules/itemadd/ItemAddFromServer.inc
+++ b/modules/itemadd/ItemAddFromServer.inc
@@ -91,7 +91,7 @@ class ItemAddFromServer extends ItemAddPlugin {
 		return array(GalleryCoreApi::error(ERROR_BAD_PARAMETER),
 			     null, null);
 	    }
-	    if ($dir{strlen($dir)-1} != $this->_dirSep) {
+	    if ($dir[strlen($dir)-1] != $this->_dirSep) {
 		$dir .= $this->_dirSep;
 	    }
 

--- a/modules/itemadd/module.inc
+++ b/modules/itemadd/module.inc
@@ -28,7 +28,7 @@
  */
 class ItemAddModule extends GalleryModule {
 
-    function ItemAddModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('itemadd');
 	$this->setName($gallery->i18n('Add Items'));

--- a/modules/jpegtran/module.inc
+++ b/modules/jpegtran/module.inc
@@ -177,7 +177,7 @@ class JpegtranModule extends GalleryModule {
 		if (empty($path)) {
 		    continue;
 		}
-		if ($path{strlen($path)-1} != $slash) {
+		if ($path[strlen($path)-1] != $slash) {
 		    $path .= $slash;
 		}
 		$paths[] = $path . 'jpegtran.exe';
@@ -199,7 +199,7 @@ class JpegtranModule extends GalleryModule {
 		if (empty($path)) {
 		    continue;
 		}
-		if ($path{strlen($path)-1} != $slash) {
+		if ($path[strlen($path)-1] != $slash) {
 		    $path .= $slash;
 		}
 		$paths[] = $path . 'jpegtran';

--- a/modules/jpegtran/module.inc
+++ b/modules/jpegtran/module.inc
@@ -30,7 +30,7 @@
  */
 class JpegtranModule extends GalleryModule {
 
-    function JpegtranModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('jpegtran');

--- a/modules/keyalbum/Callbacks.inc
+++ b/modules/keyalbum/Callbacks.inc
@@ -152,8 +152,9 @@ class KeyAlbumCallbacks {
 
 	if ($sizeLimit > 0 && count($keywords) > $sizeLimit) {
 	    /* Sort by frequency and drop least common */
-	    uasort($keywords, create_function('$a,$b', '$c = $a[\'count\']; $d = $b[\'count\']; '
-						    . 'return $c > $d ? -1 : ($c == $d ? 0 : 1);'));
+        uasort($keywords, function($a,$b) {
+            $c = $a[\'count\']; $d = $b[\'count\'];
+		    return $c > $d ? -1 : ($c == $d ? 0 : 1);});
 
 	    /* Avoid renumbering of numeric keys from array_splice */
 	    for ($newKeywords = array(), reset($keywords), $i = 0; $i < $sizeLimit; $i++) {

--- a/modules/keyalbum/KeywordAlbum.inc
+++ b/modules/keyalbum/KeywordAlbum.inc
@@ -50,7 +50,7 @@ class KeywordAlbumView extends GalleryView {
 	    return array($ret, null, null, null);
 	}
 	list ($keyword, $itemId) = GalleryUtilities::getRequestVariables('keyword', 'itemId');
-	$item->create(
+	$item->createDynamicAlbum(
 	    $module->translate(array('text' => 'Keyword Album: %s', 'arg1' => $keyword)),
 	    array(array('Keyword Album', 'keyword album'),
 		  array($module->translate('Keyword Album'), $module->translate('keyword album')))

--- a/modules/keyalbum/KeywordAlbumSiteAdmin.inc
+++ b/modules/keyalbum/KeywordAlbumSiteAdmin.inc
@@ -126,8 +126,8 @@ class KeywordAlbumSiteAdminView extends GalleryView {
 	    $split = $form['split'];
 	    $form['split'] = array();
 	    for ($i = 0; $i < strlen($split); $i++) {
-		if (isset($map[$split{$i}])) {
-		    $form['split'][$map[$split{$i}]] = 1;
+		if (isset($map[$split[$i]])) {
+		    $form['split'][$map[$split[$i]]] = 1;
 		}
 	    }
 	} else {

--- a/modules/keyalbum/module.inc
+++ b/modules/keyalbum/module.inc
@@ -27,7 +27,7 @@
  */
 class KeyAlbumModule extends GalleryModule {
 
-    function KeyAlbumModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('keyalbum');
 	$this->setName($gallery->i18n('Keyword Albums'));

--- a/modules/linkitem/module.inc
+++ b/modules/linkitem/module.inc
@@ -25,7 +25,7 @@
  */
 class LinkItemModule extends GalleryModule /* and GalleryEventListener */ {
 
-    function LinkItemModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('linkitem');
 	$this->setName($gallery->i18n('Link Items'));

--- a/modules/members/module.inc
+++ b/modules/members/module.inc
@@ -26,7 +26,7 @@
  */
 class MembersModule extends GalleryModule {
 
-    function MembersModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('members');

--- a/modules/migrate/module.inc
+++ b/modules/migrate/module.inc
@@ -28,7 +28,7 @@
  * @version $Revision: 20954 $
  */
 class MigrateModule extends GalleryModule /* and GalleryEventListener */ {
-    function MigrateModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('migrate');

--- a/modules/mime/module.inc
+++ b/modules/mime/module.inc
@@ -29,7 +29,7 @@
  */
 class MimeModule extends GalleryModule {
 
-    function MimeModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('mime');
 	$this->setName($gallery->i18n('MIME Maintenance'));

--- a/modules/mp3audio/module.inc
+++ b/modules/mp3audio/module.inc
@@ -27,7 +27,7 @@
  */
 class MP3AudioModule extends GalleryModule {
 
-    function MP3AudioModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('mp3audio');
 	$this->setName($gallery->i18n('MP3 Audio'));

--- a/modules/multilang/module.inc
+++ b/modules/multilang/module.inc
@@ -27,7 +27,7 @@
  */
 class MultiLangModule extends GalleryModule /* and GalleryEventListener */ {
 
-    function MultiLangModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('multilang');

--- a/modules/multiroot/module.inc
+++ b/modules/multiroot/module.inc
@@ -28,7 +28,7 @@
  */
 class MultirootModule extends GalleryModule {
 
-    function MultirootModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('multiroot');

--- a/modules/netpbm/module.inc
+++ b/modules/netpbm/module.inc
@@ -27,7 +27,7 @@
  */
 class NetPbmModule extends GalleryModule {
 
-    function NetPbmModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('netpbm');

--- a/modules/netpbm/module.inc
+++ b/modules/netpbm/module.inc
@@ -111,7 +111,7 @@ class NetPbmModule extends GalleryModule {
 		if (empty($path)) {
 		    continue;
 		}
-		if ($path{strlen($path)-1} != $slash) {
+		if ($path[strlen($path)-1] != $slash) {
 		    $path .= $slash;
 		}
 		$paths[] = $path;
@@ -133,7 +133,7 @@ class NetPbmModule extends GalleryModule {
 		if (empty($path)) {
 		    continue;
 		}
-		if ($path{strlen($path)-1} != $slash) {
+		if ($path[strlen($path)-1] != $slash) {
 		    $path .= $slash;
 		}
 		$paths[] = $path;

--- a/modules/newitems/module.inc
+++ b/modules/newitems/module.inc
@@ -29,7 +29,7 @@
  */
 class NewItemsModule extends GalleryModule {
 
-    function NewItemsModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('newitems');

--- a/modules/nokiaupload/module.inc
+++ b/modules/nokiaupload/module.inc
@@ -30,7 +30,7 @@
  */
 class NokiaUploadModule extends GalleryModule {
 
-    function NokiaUploadModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('nokiaupload');

--- a/modules/notification/classes/NotificationHelper.class
+++ b/modules/notification/classes/NotificationHelper.class
@@ -33,7 +33,7 @@ class NotificationHelper {
      * @return array GalleryStatus a status code
      *               integer UserId
      */
-    function getUserIdCheck() {
+    static function getUserIdCheck() {
 	global $gallery;
 
 	list ($ret, $isAnonymous) = GalleryCoreApi::isAnonymousUser();
@@ -55,7 +55,7 @@ class NotificationHelper {
      * 							     'enabled' => 0|1)
      * 		     int the lock id
      */
-    function getEnabledNotifications($forUpdate=false) {
+    static function getEnabledNotifications($forUpdate=false) {
 	$eventMapLockId = null;
 	if ($forUpdate) {
 	    list($ret, $eventMapLock) =
@@ -104,7 +104,7 @@ class NotificationHelper {
      * @return array GalleryStatus
      *  	     array (event id => event description)
      */
-    function getDefinedEvents($display=false) {
+    static function getDefinedEvents($display=false) {
 	$descriptions = $events = array();
 	list ($ret, $module) = GalleryCoreApi::loadPlugin('module', 'notification');
 	if ($ret) {
@@ -151,7 +151,7 @@ class NotificationHelper {
      * @return array GalleryStatus
      *  	     array (handler id => handler description)
      */
-    function getDefinedHandlers($display=false) {
+    static function getDefinedHandlers($display=false) {
 	list ($ret, $module) = GalleryCoreApi::loadPlugin('module', 'notification');
 	if ($ret) {
 	    return array($ret, null);
@@ -189,7 +189,7 @@ class NotificationHelper {
      * @return array GalleryStatus a status code
      *               array (event name => 1)
      */
-    function getSubscriptions($userId, $itemId=null) {
+    static function getSubscriptions($userId, $itemId=null) {
 	global $gallery;
 
 	$selection = array('userId' => $userId);
@@ -214,7 +214,7 @@ class NotificationHelper {
      * @return array GalleryStatus
      *               array An array suitable for use as hints. (i.e. array(gallery event, ...))
      */
-    function getActiveSubscriptionsEvents() {
+    static function getActiveSubscriptionsEvents() {
 	global $gallery;
 
 	$sql = 'SELECT DISTINCT [::notificationName] FROM [SubscriptionMap]';
@@ -247,7 +247,7 @@ class NotificationHelper {
      * @param array $notificationEvents Names of the Notification events to return.
      * @return array array('notificationName' => array('handlerId', ...)
      */
-    function getActiveNotificationsHandlers($notificationEvents) {
+    static function getActiveNotificationsHandlers($notificationEvents) {
 	global $gallery;
 
 	$markers = GalleryUtilities::makeMarkers(count($notificationEvents));
@@ -277,7 +277,7 @@ class NotificationHelper {
      * @return array GalleryStatus a status code
      *               array Array of userid that are subscribed to the event for the specfied item
      */
-    function getSubscribers($notificationName, $notification) {
+    static function getSubscribers($notificationName, $notification) {
 	$event = $notification->getEvent();
 	$itemId = $notification->getItemId();
 
@@ -328,7 +328,7 @@ class NotificationHelper {
      * @return array GalleryStatus a status code
      *               array Array of eventId => userid array
      */
-    function getSubscriberByEntityId($itemId) {
+    static function getSubscriberByEntityId($itemId) {
 	list ($ret, $searchResult) = GalleryCoreApi::getMapEntry('SubscriptionMap',
 			   array('notificationName', 'userId', 'handlerName'),
 			   array('itemId' => $itemId));
@@ -355,7 +355,7 @@ class NotificationHelper {
      * @param boolean $recursive If not empty apply subscription removal to descendent items
      * @return GalleryStatus
      */
-    function unsubscribe($userId, $itemId, $eventName, $notificationName, $handler, $recursive) {
+    static function unsubscribe($userId, $itemId, $eventName, $notificationName, $handler, $recursive) {
 	$ret = NotificationHelper::_applyUnsubscribe($userId, $itemId, $eventName,
 						     $notificationName, $handler, $recursive);
 	if ($ret) {
@@ -376,7 +376,7 @@ class NotificationHelper {
      * @param boolean $recursive If not empty apply subscription to child items
      * @return GalleryStatus
      */
-    function _applyUnsubscribe($userId, $itemId, $eventName, $name, $handler, $recursive) {
+    static function _applyUnsubscribe($userId, $itemId, $eventName, $name, $handler, $recursive) {
 	$ret = GalleryCoreApi::removeMapEntry('SubscriptionMap',
 			    array('userId' => $userId, 'itemId' => $itemId,
 				  'notificationName' => $name, 'handlerId' => $handler));
@@ -417,7 +417,7 @@ class NotificationHelper {
      * @param int $event The id of the event to be unsubscribed from
      * @return GalleryStatus
      */
-    function removeHintFromListener($event) {
+    static function removeHintFromListener($event) {
 	global $gallery;
 	$storage =& $gallery->getStorage();
 
@@ -477,7 +477,7 @@ class NotificationHelper {
      * @param boolean $recursive If not empty apply subscription to descendent items
      * @return GalleryStatus
      */
-    function subscribe($userId, $item, $eventName, $notificationName, $handler, $recursive) {
+    static function subscribe($userId, $item, $eventName, $notificationName, $handler, $recursive) {
 	global $gallery;
 	$storage =& $gallery->getStorage();
 
@@ -548,7 +548,7 @@ class NotificationHelper {
      * @param boolean $recursive If not empty apply subscription to descendent items
      * @return GalleryStatus
      */
-    function _applySubscription($userId, $item, $name, $notification, $handler, $recursive) {
+    static function _applySubscription($userId, $item, $name, $notification, $handler, $recursive) {
 	if (!empty($item)) {
 	    $itemId = $item->getId();
 	    $canContainChildren = $item->getCanContainChildren();
@@ -624,7 +624,7 @@ class NotificationHelper {
      * @return int the lock id
      * @private
      */
-    function _lockHints() {
+    static function _lockHints() {
 	list($ret, $hintsLock) =
 		GalleryCoreApi::getPluginParameter('module', 'notification', 'id.hintsLock');
 	if ($ret) {

--- a/modules/notification/module.inc
+++ b/modules/notification/module.inc
@@ -31,7 +31,7 @@ GalleryCoreApi::requireOnce('modules/notification/classes/GalleryCoreEventNotifi
  * @version $Revision: 18172 $
  */
 class NotificationModule extends GalleryModule {
-    function NotificationModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('notification');
 	$this->setName($gallery->i18n('Notification'));

--- a/modules/panorama/classes/PanoramaHelper.class
+++ b/modules/panorama/classes/PanoramaHelper.class
@@ -35,7 +35,7 @@ class PanoramaHelper {
      * @return array GalleryStatus a status code
      *               array of given-itemId=>GalleryDataItem-for-display
      */
-    function fetchViewableImages($items) {
+    static function fetchViewableImages($items) {
 	global $gallery;
 	foreach ($items as $item) {
 	    if (GalleryUtilities::isA($item, 'GalleryPhotoItem')) {

--- a/modules/panorama/module.inc
+++ b/modules/panorama/module.inc
@@ -30,7 +30,7 @@
  */
 class PanoramaModule extends GalleryModule {
 
-    function PanoramaModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('panorama');
 	$this->setName($gallery->i18n('Panorama'));

--- a/modules/password/PasswordOption.inc
+++ b/modules/password/PasswordOption.inc
@@ -44,7 +44,7 @@ class PasswordOption extends ItemEditOption {
 	 * Password protected items are not fully protected, but their descendants are. Only show
 	 * the option for non-album items that already are password protected.
 	 */
-	list ($ret, $hasPassword) = PasswordHelper::hasPassword($item);
+	list ($ret, $hasPassword) = PasswordHelper::hasPasswordStatic($item);
 	if ($ret) {
 	    return array($ret, null);
 	}
@@ -74,7 +74,7 @@ class PasswordOption extends ItemEditOption {
 	}
 
 	if (!empty($form['PasswordOption']['remove'])) {
-	    $ret = PasswordHelper::removePassword($item, $useProgressBar);
+	    $ret = PasswordHelper::removePasswordStatic($item, $useProgressBar);
 	    if ($ret) {
 		return array($ret, null, null);
 	    }
@@ -84,7 +84,7 @@ class PasswordOption extends ItemEditOption {
 		GalleryUtilities::unsanitizeInputValues($form['PasswordOption']['password1'],
 							false);
 		GalleryCoreApi::requireOnce('modules/password/classes/PasswordHelper.class');
-		$ret = PasswordHelper::setPassword($item, $form['PasswordOption']['password1'],
+		$ret = PasswordHelper::setPasswordStatic($item, $form['PasswordOption']['password1'],
 						   $useProgressBar);
 		if ($ret) {
 		    return array($ret, null, null);

--- a/modules/password/classes/PasswordHelper.class
+++ b/modules/password/classes/PasswordHelper.class
@@ -717,7 +717,7 @@ class PasswordHelper extends PasswordInterface_1_0 {
 	return array(null, $item->hasOnLoadHandler('Password'));
     }
 
-    function PasswordHelper() {
+    function __construct() {
 	$this->_notEmpty = true;
     }
 }

--- a/modules/password/classes/PasswordHelper.class
+++ b/modules/password/classes/PasswordHelper.class
@@ -668,7 +668,7 @@ class PasswordHelper extends PasswordInterface_1_0 {
      * @param GalleryItem $item new item
      * @return GalleryStatus a status code
      */
-    function handleNewItem($item) {
+    static function handleNewItem($item) {
 	list ($ret, $parent) =
 	    GalleryCoreApi::loadEntitiesById($item->getParentId(), 'GalleryItem');
 	if ($ret) {

--- a/modules/password/classes/PasswordHelper.class
+++ b/modules/password/classes/PasswordHelper.class
@@ -45,6 +45,9 @@ class PasswordHelper extends PasswordInterface_1_0 {
      * @static
      */
     function setPassword(&$item, $password, $useProgressBar=false) {
+        return PasswordHelper::setPasswordStatic(&$item, $password, $useProgressBar);
+    }
+    static function setPasswordStatic(&$item, $password, $useProgressBar=false) {
 	global $gallery;
 	$gallery->guaranteeTimeLimit(60);
 
@@ -133,7 +136,7 @@ class PasswordHelper extends PasswordInterface_1_0 {
      *               mixed id of nearest hidden ancestor or false
      * @access private
      */
-    function _checkAncestors($item) {
+    static function _checkAncestors($item) {
 	list ($ret, $hiddenInterface) = GalleryCoreApi::newFactoryInstance('HiddenInterface_1_0');
 	if ($ret) {
 	    return array($ret, null, null);
@@ -329,6 +332,9 @@ class PasswordHelper extends PasswordInterface_1_0 {
      * @static
      */
     function removePassword(&$item, $useProgressBar=false) {
+        return PasswordHelper::removePasswordStatic(&$item, $useProgressBar);
+    }
+    static function removePasswordStatic(&$item, $useProgressBar=false) {
 	global $gallery;
 	$gallery->guaranteeTimeLimit(60);
 
@@ -418,7 +424,7 @@ class PasswordHelper extends PasswordInterface_1_0 {
      * @return GalleryStatus a status code
      * @access private
      */
-    function _adjustPermissionsForRemove(&$item, $protectedBy,
+    static function _adjustPermissionsForRemove(&$item, $protectedBy,
 					 $protectedAncestor, $hiddenAncestor, &$progressBar) {
 	global $gallery;
 	static $coreParams;
@@ -714,6 +720,10 @@ class PasswordHelper extends PasswordInterface_1_0 {
      * @see PasswordInterface_1_0::hasPassword
      */
     function hasPassword($item) {
+	return PasswordHelper::hasPasswordStatic($item);
+    }
+
+    static function hasPasswordStatic($item) {
 	return array(null, $item->hasOnLoadHandler('Password'));
     }
 

--- a/modules/password/module.inc
+++ b/modules/password/module.inc
@@ -31,7 +31,7 @@
  */
 class PasswordModule extends GalleryModule /* and GalleryEventListener */ {
 
-    function PasswordModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('password');

--- a/modules/password/module.inc
+++ b/modules/password/module.inc
@@ -142,7 +142,7 @@ class PasswordModule extends GalleryModule /* and GalleryEventListener */ {
 		return $ret;
 	    }
 	    foreach ($items as $item) {
-		$ret = PasswordHelper::removePassword($item);
+		$ret = PasswordHelper::removePasswordStatic($item);
 		if ($ret) {
 		    return $ret;
 		}

--- a/modules/permalinks/classes/PermalinksMapHelper.class
+++ b/modules/permalinks/classes/PermalinksMapHelper.class
@@ -35,7 +35,7 @@ class PermalinksMapHelper {
      * @return array GalleryStatus a status code
      *         array of aliase names
      */
-    function fetchAliasesForItem($itemId=null) {
+    static function fetchAliasesForItem($itemId=null) {
 	$match = isset($itemId) ? array('destId' => (int)$itemId) : array();
 	list ($ret, $searchResults) = GalleryCoreApi::getMapEntry('PermalinksMap',
 	    array('aliasName'), $match);
@@ -57,7 +57,7 @@ class PermalinksMapHelper {
      * @return array GalleryStatus a status code
      *               int item id
      */
-    function fetchItemIdForAlias($aliasName) {
+    static function fetchItemIdForAlias($aliasName) {
 	list ($ret, $searchResults) = GalleryCoreApi::getMapEntry('PermalinksMap',
 	    array('destId'), array('aliasName' => $aliasName));
 	if ($ret) {
@@ -79,7 +79,7 @@ class PermalinksMapHelper {
      * @param int $itemId
      * @return GalleryStatus a status code
      */
-    function createAlias($aliasName, $itemId) {
+    static function createAlias($aliasName, $itemId) {
 	/* first, check for collision */
 	list ($ret, $collisionId) = PermalinksMapHelper::fetchItemIdForAlias($aliasName);
 	if ($ret) {
@@ -106,7 +106,7 @@ class PermalinksMapHelper {
      * @param int $aliasName
      * @return GalleryStatus a status code
      */
-    function deleteAlias($aliasName) {
+    static function deleteAlias($aliasName) {
 	/* Remove this alias from our groups table. */
 	$ret = GalleryCoreApi::removeMapEntry('PermalinksMap', array('aliasName' => $aliasName));
 	if ($ret) {

--- a/modules/permalinks/module.inc
+++ b/modules/permalinks/module.inc
@@ -30,7 +30,7 @@
  */
 class PermalinksModule extends GalleryModule /* and GalleryEventListener */ {
 
-    function PermalinksModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('permalinks');

--- a/modules/photoaccess/classes/PhotoAccessHelper.class
+++ b/modules/photoaccess/classes/PhotoAccessHelper.class
@@ -34,7 +34,7 @@ class PhotoAccessHelper {
      * @return array GalleryStatus a status code
      *               string the url to the photoworks.com cart
      */
-    function printPhotos($cartItemIds, $returnUrl) {
+    static function printPhotos($cartItemIds, $returnUrl) {
 	global $gallery;
 	$urlGenerator =& $gallery->getUrlGenerator();
 	$itemIds = array_keys($cartItemIds);

--- a/modules/photoaccess/module.inc
+++ b/modules/photoaccess/module.inc
@@ -27,7 +27,7 @@
  */
 class PhotoAccessModule extends GalleryModule {
 
-    function PhotoAccessModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('photoaccess');

--- a/modules/picasa/module.inc
+++ b/modules/picasa/module.inc
@@ -26,7 +26,7 @@
  */
 class PicasaModule extends GalleryModule {
 
-    function PicasaModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('picasa');
 	$this->setName($gallery->i18n('Picasa'));

--- a/modules/publishxp/module.inc
+++ b/modules/publishxp/module.inc
@@ -31,7 +31,7 @@
  */
 class PublishXpModule extends GalleryModule {
 
-    function PublishXpModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('publishxp');
 	$this->setName($gallery->i18n('Windows Publishing Wizard'));

--- a/modules/quotas/classes/GalleryQuotasHelper.class
+++ b/modules/quotas/classes/GalleryQuotasHelper.class
@@ -35,7 +35,7 @@ class GalleryQuotasHelper {
      * @return array GalleryStatus a status code
      *               integer user's disk usage in bytes
      */
-    function getUserDiskUsage($userId, $excludeIds=array()) {
+    static function getUserDiskUsage($userId, $excludeIds=array()) {
 	global $gallery;
 
 	$storage =& $gallery->getStorage();
@@ -85,7 +85,7 @@ class GalleryQuotasHelper {
      *               bool does a quota exists for this user
      *               integer user's disk quota in Kilobytes
      */
-    function getUserDiskQuota($userId) {
+    static function getUserDiskQuota($userId) {
 	global $gallery;
 	$userDiskQuota = null;
 	list ($ret, $userQuotaExists, $userQuotaInfo) =
@@ -120,7 +120,7 @@ class GalleryQuotasHelper {
      *               array('quota' => integer user's disk quota in Kilobytes,
      *                     'name' => string group's name)
      */
-    function fetchHighestGroupQuota($userId) {
+    static function fetchHighestGroupQuota($userId) {
 	global $gallery;
 
 	list ($ret, $groupQuotaIds) = GalleryCoreApi::fetchGroupsForUser($userId);
@@ -173,7 +173,7 @@ class GalleryQuotasHelper {
      *               string user's quota in human readable format
      *               string the unit of measurement for the user's quota (ie: KB, MB, GB)
      */
-    function humanReadableFromKilobytes($kilobytes) {
+    static function humanReadableFromKilobytes($kilobytes) {
 	global $gallery;
 	list ($ret, $module) = GalleryCoreApi::loadPlugin('module', 'quotas');
 	if ($ret) {
@@ -199,7 +199,7 @@ class GalleryQuotasHelper {
      *               array(groupId => array('quota' => group's disk quota,
      *                                      'name' => group's groupname))
      */
-    function fetchQuotaGroupIdList($count, $offset=0) {
+    static function fetchQuotaGroupIdList($count, $offset=0) {
 	global $gallery;
 
 	$storage =& $gallery->getStorage();
@@ -240,7 +240,7 @@ class GalleryQuotasHelper {
      * @return array GalleryStatus a status code
      *               integer the number of groups that have quotas assigned
      */
-    function fetchQuotaGroupCount() {
+    static function fetchQuotaGroupCount() {
 	global $gallery;
 	$storage =& $gallery->getStorage();
 
@@ -272,7 +272,7 @@ class GalleryQuotasHelper {
      *               array(groupId => array('quota' => user's disk quota,
      *                                      'name' => user's username))
      */
-    function fetchQuotaUserIdList($count, $offset=0) {
+    static function fetchQuotaUserIdList($count, $offset=0) {
 	global $gallery;
 	$storage =& $gallery->getStorage();
 
@@ -311,7 +311,7 @@ class GalleryQuotasHelper {
      * @return array GalleryStatus a status code
      *               integer the number of users that have quotas assigned
      */
-    function fetchQuotaUserCount() {
+    static function fetchQuotaUserCount() {
 	global $gallery;
 	$storage =& $gallery->getStorage();
 
@@ -345,7 +345,7 @@ class GalleryQuotasHelper {
      *                     'quota' => group's disk quota,
      *                     'name' => group's groupname)
      */
-    function fetchGroupQuota($groupId) {
+    static function fetchGroupQuota($groupId) {
 	global $gallery;
 	$storage =& $gallery->getStorage();
 	$query = '
@@ -390,7 +390,7 @@ class GalleryQuotasHelper {
      *                     'quota' => user's disk quota,
      *                     'name' => user's username)
      */
-    function fetchUserQuota($userId) {
+    static function fetchUserQuota($userId) {
 	global $gallery;
 	$storage =& $gallery->getStorage();
 

--- a/modules/quotas/module.inc
+++ b/modules/quotas/module.inc
@@ -27,7 +27,7 @@
  */
 class QuotasModule extends GalleryModule {
 
-    function QuotasModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('quotas');

--- a/modules/randomhighlight/module.inc
+++ b/modules/randomhighlight/module.inc
@@ -26,7 +26,7 @@
  */
 class RandomHighlightModule extends GalleryModule {
 
-    function RandomHighlightModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('randomhighlight');
 	$this->setName($gallery->i18n('Random Highlight'));

--- a/modules/rating/RatingAlbum.inc
+++ b/modules/rating/RatingAlbum.inc
@@ -50,7 +50,7 @@ class RatingAlbumView extends GalleryView {
 	    return array($ret, null, null, null);
 	}
 	list ($limit, $itemId) = GalleryUtilities::getRequestVariables('limit', 'itemId');
-	$item->create(
+	$item->createDynamicAlbum(
 	    $module->translate(array('text' => 'Rating Album: %s', 'arg1' => $limit)),
 	    array(array('Rating Album', 'rating album'),
 		  array($module->translate('Rating Album'), $module->translate('rating album')))

--- a/modules/rating/classes/RatingHelper.class
+++ b/modules/rating/classes/RatingHelper.class
@@ -37,7 +37,7 @@ class RatingHelper {
      *               array  double  latest average rating
      *                      int     count of total ratings
      */
-    function fetchRatings($itemIds, $userId) {
+    static function fetchRatings($itemIds, $userId) {
 	global $gallery;
 
 	list ($ret, $searchResults) = GalleryCoreApi::getMapEntry('RatingCacheMap',
@@ -123,7 +123,7 @@ class RatingHelper {
      *               array  double  new avg rating for itemId
      *                      int     total votes for itemId
      */
-    function rateItem($itemId, $rating, $userId) {
+    static function rateItem($itemId, $rating, $userId) {
 	global $gallery;
 
 	/* Make sure the user isn't a search engine crawler */

--- a/modules/rating/module.inc
+++ b/modules/rating/module.inc
@@ -26,7 +26,7 @@
  */
 class RatingModule extends GalleryModule {
 
-    function RatingModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('rating');

--- a/modules/rearrange/module.inc
+++ b/modules/rearrange/module.inc
@@ -27,7 +27,7 @@
  */
 class RearrangeModule extends GalleryModule {
 
-    function RearrangeModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('rearrange');
 	$this->setName($gallery->i18n('Rearrange'));

--- a/modules/register/module.inc
+++ b/modules/register/module.inc
@@ -27,7 +27,7 @@
  */
 class RegisterModule extends GalleryModule {
 
-    function RegisterModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('register');

--- a/modules/remote/classes/GalleryRemoteProperties.class
+++ b/modules/remote/classes/GalleryRemoteProperties.class
@@ -32,7 +32,7 @@ class GalleryRemoteProperties {
      */
     var $_map;
 
-    function GalleryRemoteProperties() {
+    function __construct() {
 	$this->_map = array();
     }
 

--- a/modules/remote/module.inc
+++ b/modules/remote/module.inc
@@ -25,7 +25,7 @@
  */
 class RemoteModule extends GalleryModule {
 
-    function RemoteModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('remote');
 	$this->setName($gallery->i18n('Remote'));

--- a/modules/replica/module.inc
+++ b/modules/replica/module.inc
@@ -28,7 +28,7 @@
  */
 class ReplicaModule extends GalleryModule {
 
-    function ReplicaModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('replica');
 	$this->setName($gallery->i18n('Replica'));

--- a/modules/reupload/module.inc
+++ b/modules/reupload/module.inc
@@ -27,7 +27,7 @@
  */
 class ReuploadModule extends GalleryModule {
 
-    function ReuploadModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('reupload');
 	$this->setName($gallery->i18n('Reupload'));

--- a/modules/rewrite/RewriteModuleExtras.inc
+++ b/modules/rewrite/RewriteModuleExtras.inc
@@ -32,7 +32,7 @@ class RewriteModuleExtras {
     /**
      * @see GalleryModule::upgrade
      */
-    function upgrade($module, $currentVersion) {
+    static function upgrade($module, $currentVersion) {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
 
@@ -389,7 +389,7 @@ class RewriteModuleExtras {
     /**
      * @see GalleryModule::handleEvent
      */
-    function handleDeactivatePlugin($module, $pluginId) {
+    static function handleDeactivatePlugin($module, $pluginId) {
 	list ($ret, $activeRules) = $module->getParameter('activeRules');
 	if ($ret) {
 	    return $ret;
@@ -423,7 +423,7 @@ class RewriteModuleExtras {
     /**
      * @see GalleryModule::handleEvent
      */
-    function handleUninstallPlugin($module, $pluginId) {
+    static function handleUninstallPlugin($module, $pluginId) {
 	$ret = RewriteHelper::setHistoryForModule($pluginId, array());
 	if ($ret) {
 	    return $ret;
@@ -435,7 +435,7 @@ class RewriteModuleExtras {
     /**
      * @see GalleryModule::handleEvent
      */
-    function handleActivatePlugin($module, $pluginId) {
+    static function handleActivatePlugin($module, $pluginId) {
 	/* Get saved patterns */
 	list ($ret, $plugin) = GalleryCoreApi::loadPlugin('module', $pluginId);
 	if ($ret) {

--- a/modules/rewrite/classes/RewriteApi.class
+++ b/modules/rewrite/classes/RewriteApi.class
@@ -41,7 +41,7 @@ class RewriteApi {
      */
     var $_parser;
 
-    function RewriteApi() {
+    function __construct() {
 	GalleryCoreApi::requireOnce('modules/rewrite/classes/RewriteHelper.class');
 	list ($ret, $this->_parser) = RewriteHelper::getRewriteParser();
 	if ($ret) {

--- a/modules/rewrite/classes/RewriteSimpleHelper.class
+++ b/modules/rewrite/classes/RewriteSimpleHelper.class
@@ -34,7 +34,7 @@ class RewriteSimpleHelper {
      *
      * @return GalleryStatus a status code
      */
-    function loadItemIdFromPath() {
+    static function loadItemIdFromPath() {
 	list ($path, $itemId) = GalleryUtilities::getRequestVariables('path', 'itemId');
 
 	if (!empty($path) && empty($itemId)) {
@@ -60,7 +60,7 @@ class RewriteSimpleHelper {
      * @param GalleryEntity $entity loaded entity with item id = $params['itemId'], or null
      * @return boolean true on success
      */
-    function parsePath(&$url, &$params, &$entity) {
+    static function parsePath(&$url, &$params, &$entity) {
 	global $gallery;
 	$urlGenerator =& $gallery->getUrlGenerator();
 
@@ -97,7 +97,7 @@ class RewriteSimpleHelper {
     /**
      * @see RewriteSimpleHelper::parsePath
      */
-    function parsePage(&$url, &$params, &$entity) {
+    static function parsePage(&$url, &$params, &$entity) {
 	$page = isset($params['page']) ? $params['page'] : '';
 	$url = str_replace('%page%', $page, $url);
 	unset($params['page']);
@@ -107,7 +107,7 @@ class RewriteSimpleHelper {
     /**
      * @see RewriteSimpleHelper::parsePath
      */
-    function parseLanguage(&$url, &$params, &$entity) {
+    static function parseLanguage(&$url, &$params, &$entity) {
 	global $gallery;
 	$urlGenerator =& $gallery->getUrlGenerator();
 
@@ -137,7 +137,7 @@ class RewriteSimpleHelper {
     /**
      * @see RewriteSimpleHelper::parsePath
      */
-    function parseSerialNumber(&$url, &$params, &$entity) {
+    static function parseSerialNumber(&$url, &$params, &$entity) {
 	global $gallery;
 	$urlGenerator =& $gallery->getUrlGenerator();
 
@@ -152,7 +152,7 @@ class RewriteSimpleHelper {
     /**
      * @see RewriteSimpleHelper::parsePath
      */
-    function parseFileName(&$url, &$params, &$entity)  {
+    static function parseFileName(&$url, &$params, &$entity)  {
 	global $gallery;
 	$urlGenerator =& $gallery->getUrlGenerator();
 

--- a/modules/rewrite/classes/parsers/isapirewrite/IsapiRewriteHelper.class
+++ b/modules/rewrite/classes/parsers/isapirewrite/IsapiRewriteHelper.class
@@ -631,7 +631,7 @@ class IsapiRewriteHelper {
 
 	if ($code == REWRITE_STATUS_OK) {
 	    $embeddedLocation = '/' . trim($param['embeddedLocation'], '/');
-	    if ($embeddedLocation{strlen($embeddedLocation)-1} != '/') {
+	    if ($embeddedLocation[strlen($embeddedLocation)-1] != '/') {
 		$embeddedLocation .= '/';
 	    }
 

--- a/modules/rewrite/classes/parsers/isapirewrite/parser.inc
+++ b/modules/rewrite/classes/parsers/isapirewrite/parser.inc
@@ -38,7 +38,7 @@ define('REWRITE_STATUS_HTTPDINI_CANT_WRITE', 34);
  */
 class IsapiRewriteParser extends RewriteParser {
 
-    function IsapiRewriteParser() {
+    function __construct() {
 	$this->_setParserId('isapirewrite');
 	$this->_setParserType('preGallery');
 	$this->_setUrlGeneratorId('IsapiRewriteUrlGenerator');

--- a/modules/rewrite/classes/parsers/modrewrite/ModRewriteHelper.class
+++ b/modules/rewrite/classes/parsers/modrewrite/ModRewriteHelper.class
@@ -663,7 +663,7 @@ class ModRewriteHelper {
 	}
 
 	$embeddedLocation = '/' . trim($param['embeddedLocation'], '/');
-	if ($embeddedLocation{strlen($embeddedLocation)-1} != '/') {
+	if ($embeddedLocation[strlen($embeddedLocation)-1] != '/') {
 	    $embeddedLocation .= '/';
 	}
 	$embeddedHtaccess = rtrim($param['embeddedHtaccess'], '/');

--- a/modules/rewrite/classes/parsers/modrewrite/parser.inc
+++ b/modules/rewrite/classes/parsers/modrewrite/parser.inc
@@ -42,7 +42,7 @@ define('REWRITE_STATUS_EMBED_HTACCESS_CANT_WRITE', 18);
  */
 class ModRewriteParser extends RewriteParser {
 
-    function ModRewriteParser() {
+    function __construct() {
 	$this->_setParserId('modrewrite');
 	$this->_setParserType('preGallery');
 	$this->_setUrlGeneratorId('ModRewriteUrlGenerator');

--- a/modules/rewrite/classes/parsers/pathinfo/parser.inc
+++ b/modules/rewrite/classes/parsers/pathinfo/parser.inc
@@ -33,7 +33,7 @@ define('REWRITE_STATUS_NO_PATH_INFO', 21);
  */
 class PathInfoParser extends RewriteParser {
 
-    function PathInfoParser() {
+    function __construct() {
 	$this->_setParserId('pathinfo');
 	$this->_setParserType('inGallery');
 	$this->_setUrlGeneratorId('PathInfoUrlGenerator');

--- a/modules/rss/module.inc
+++ b/modules/rss/module.inc
@@ -29,7 +29,7 @@
  */
 class RssModule extends GalleryModule /* and GalleryEventListener */ {
 
-    function RssModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('rss');

--- a/modules/search/module.inc
+++ b/modules/search/module.inc
@@ -29,7 +29,7 @@
  */
 class SearchModule extends GalleryModule {
 
-    function SearchModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('search');

--- a/modules/shutterfly/module.inc
+++ b/modules/shutterfly/module.inc
@@ -27,7 +27,7 @@
  */
 class ShutterflyModule extends GalleryModule {
 
-    function ShutterflyModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('shutterfly');

--- a/modules/sitemap/module.inc
+++ b/modules/sitemap/module.inc
@@ -26,7 +26,7 @@
  */
 class SitemapModule extends GalleryModule {
 
-    function SitemapModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('sitemap');
 	$this->setName($gallery->i18n('Sitemap'));

--- a/modules/sizelimit/module.inc
+++ b/modules/sizelimit/module.inc
@@ -27,7 +27,7 @@
  */
 class SizeLimitModule extends GalleryModule {
 
-    function SizeLimitModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('sizelimit');

--- a/modules/slideshow/classes/SlideshowHelper.class
+++ b/modules/slideshow/classes/SlideshowHelper.class
@@ -49,7 +49,7 @@ class SlideshowHelper {
      *               int the offset value for the previous page, null for no previous page
      *               int the offset value for the next page, null for no next page
      */
-    function buildAlbumSlideshow($item, $startId=null, $offset=0) {
+    static function buildAlbumSlideshow($item, $startId=null, $offset=0) {
 	list ($ret, $canView) = GalleryCoreApi::hasItemPermission($item->getId(), 'core.view');
 	if ($ret) {
 	    return array($ret, null, null, null, null);
@@ -107,7 +107,7 @@ class SlideshowHelper {
      *                     containing item, image and thumbnail entities
      *               int the index into the data array where the slideshow should start.
      */
-    function buildItemsSlideshow($childIds, $startId=null) {
+    static function buildItemsSlideshow($childIds, $startId=null) {
 	global $gallery;
 
 	if (empty($childIds)) {
@@ -220,7 +220,7 @@ class SlideshowHelper {
      *               int the offset value for the previous page, null for no previous page
      *               int the offset value for the next page, null for no next page
      */
-    function paginateItemSlideshow($itemId, $offset=0) {
+    static function paginateItemSlideshow($itemId, $offset=0) {
 	list ($ret, $itemCount) = GalleryCoreApi::fetchChildCounts(array($itemId));
 	if ($ret) {
 	    return array($ret, null, null);

--- a/modules/slideshow/module.inc
+++ b/modules/slideshow/module.inc
@@ -28,7 +28,7 @@
  */
 class SlideshowModule extends GalleryModule {
 
-    function SlideshowModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('slideshow');
 	$this->setName($gallery->i18n('Slideshow'));

--- a/modules/slideshowapplet/module.inc
+++ b/modules/slideshowapplet/module.inc
@@ -25,7 +25,7 @@
  */
 class SlideshowAppletModule extends GalleryModule {
 
-    function SlideshowAppletModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('slideshowapplet');
 	$this->setName($gallery->i18n('Slideshow Applet'));

--- a/modules/snapgalaxy/classes/SnapGalaxyHelper.class
+++ b/modules/snapgalaxy/classes/SnapGalaxyHelper.class
@@ -34,7 +34,7 @@ class SnapGalaxyHelper {
      * @return array GalleryStatus a status code
      *               string the url to the snapgalaxy.com cart
      */
-    function printPhotos($cartItemIds, $returnUrl) {
+    static function printPhotos($cartItemIds, $returnUrl) {
 	global $gallery;
 	$urlGenerator =& $gallery->getUrlGenerator();
 	$session =& $gallery->getSession();

--- a/modules/snapgalaxy/module.inc
+++ b/modules/snapgalaxy/module.inc
@@ -29,7 +29,7 @@
  */
 class SnapGalaxyModule extends GalleryModule {
 
-    function SnapGalaxyModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('snapgalaxy');

--- a/modules/squarethumb/module.inc
+++ b/modules/squarethumb/module.inc
@@ -30,7 +30,7 @@
  */
 class SquareThumbModule extends GalleryModule /* and GalleryEventListener */ {
 
-    function SquareThumbModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('squarethumb');

--- a/modules/thumbnail/classes/ThumbnailHelper.class
+++ b/modules/thumbnail/classes/ThumbnailHelper.class
@@ -41,7 +41,7 @@ class ThumbnailHelper {
      * @return array GalleryStatus a status code
      *               array of itemId=>fileName
      */
-    function fetchThumbnails($listAll=false, $count=null, $offset=null, $substring=null) {
+    static function fetchThumbnails($listAll=false, $count=null, $offset=null, $substring=null) {
 	global $gallery;
 
 	$where = $data = array();
@@ -85,7 +85,7 @@ class ThumbnailHelper {
      * @return array GalleryStatus a status code
      *               ThumbnailImage or null
      */
-    function fetchThumbnail($itemId) {
+    static function fetchThumbnail($itemId) {
 	global $gallery;
 
 	list ($ret, $searchResults) = $gallery->search(
@@ -114,7 +114,7 @@ class ThumbnailHelper {
      * @return array GalleryStatus a status code
      *               array of mimeType=>itemId
      */
-    function fetchMimeTypeMap() {
+    static function fetchMimeTypeMap() {
 	global $gallery;
 	list ($ret, $searchResults) = $gallery->search(
 	    'SELECT [ThumbnailImage::id], [ThumbnailImage::itemMimeTypes]
@@ -141,7 +141,7 @@ class ThumbnailHelper {
      *               :by-mimeType: null
      *                or by-toolkit: array of mimeType conflicts
      */
-    function fetchToolkitSupport($byMimeType=true) {
+    static function fetchToolkitSupport($byMimeType=true) {
 	list ($ret, $tList) = GalleryCoreApi::getToolkitOperationMimeTypes('thumbnail');
 	if ($ret) {
 	    return array($ret, null, null);
@@ -174,7 +174,7 @@ class ThumbnailHelper {
      * @param mixed $mimeTypes array or single string
      * @return GalleryStatus a status code
      */
-    function registerToolkitOperation($mimeTypes) {
+    static function registerToolkitOperation($mimeTypes) {
 	global $gallery;
 	if (!is_array($mimeTypes)) {
 	    $mimeTypes = array($mimeTypes);
@@ -211,7 +211,7 @@ class ThumbnailHelper {
      * @return array GalleryStatus a status code,
      *               int id of newly created object
      */
-    function addItem($mimeType, $parentId,
+    static function addItem($mimeType, $parentId,
 		     $filename, $tmpfile, $fileMimeType, $knownSize=array(), $item=null) {
 	/* Get the mime type. */
 	list ($ret, $fileMimeType) = GalleryCoreApi::getMimeType($filename, $fileMimeType);
@@ -282,7 +282,7 @@ class ThumbnailHelper {
      * @param boolean $isAdd (optional) true to add mime type, false to delete
      * @return GalleryStatus a status code
      */
-    function updateItem($itemId, $mimeType, $isAdd=true) {
+    static function updateItem($itemId, $mimeType, $isAdd=true) {
 	list ($ret, $item) = GalleryCoreApi::loadEntitiesById($itemId, 'ThumbnailImage');
 	if ($ret) {
 	    return $ret;
@@ -335,7 +335,7 @@ class ThumbnailHelper {
      * @param int $thumbnailId id of ThumbnailImage
      * @return GalleryStatus a status code
      */
-    function applyThumbnail(&$item, $thumbnailId) {
+    static function applyThumbnail(&$item, $thumbnailId) {
 	list ($ret, $derivative) = GalleryCoreApi::fetchThumbnailsByItemIds(array($item->getId()));
 	if ($ret) {
 	    return $ret;
@@ -417,7 +417,7 @@ class ThumbnailHelper {
      * @return array GalleryStatus a status code
      *               array (string mime type => string list of extensions)
      */
-    function getMimeTypeMap() {
+    static function getMimeTypeMap() {
 	global $gallery;
 
 	$query = '

--- a/modules/thumbnail/classes/ThumbnailImage.class
+++ b/modules/thumbnail/classes/ThumbnailImage.class
@@ -431,7 +431,7 @@ class ThumbnailImage extends GalleryFileSystemEntity {
 	if ($this->getParentId() != $thumbnailContainerId) {
 	    /* Custom thumbnails are stored in a decimal tree, e.g. 7/75.jpg. */
 	    $id = (string)$this->getId();
-	    $path = $id{0} . '/' . $id . '.jpg';
+	    $path = $id[0] . '/' . $id . '.jpg';
 	} else {
 	    /* Mime-type thumbnails are right under the plugin_data/modules/thumbnail/ folder. */
 	    $path = $this->getPathComponent();

--- a/modules/thumbnail/module.inc
+++ b/modules/thumbnail/module.inc
@@ -29,7 +29,7 @@
  */
 class ThumbnailModule extends GalleryModule {
 
-    function ThumbnailModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('thumbnail');

--- a/modules/thumbpage/module.inc
+++ b/modules/thumbpage/module.inc
@@ -27,7 +27,7 @@
  */
 class ThumbPageModule extends GalleryModule /* and GalleryEventListener */ {
 
-    function ThumbPageModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('thumbpage');

--- a/modules/uploadapplet/module.inc
+++ b/modules/uploadapplet/module.inc
@@ -25,7 +25,7 @@
  */
 class UploadAppletModule extends GalleryModule {
 
-    function UploadAppletModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('uploadapplet');
 	$this->setName($gallery->i18n('Upload Applet'));

--- a/modules/useralbum/module.inc
+++ b/modules/useralbum/module.inc
@@ -27,7 +27,7 @@
  */
 class UserAlbumModule extends GalleryModule /* and GalleryEventListener */ {
 
-    function UserAlbumModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('useralbum');
 	$this->setName($gallery->i18n('User Albums'));

--- a/modules/watermark/module.inc
+++ b/modules/watermark/module.inc
@@ -27,7 +27,7 @@
  */
 class WatermarkModule extends GalleryModule /* and GalleryEventListener */ {
 
-    function WatermarkModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('watermark');

--- a/modules/webcam/module.inc
+++ b/modules/webcam/module.inc
@@ -25,7 +25,7 @@
  */
 class WebCamModule extends GalleryModule {
 
-    function WebCamModule() {
+    function __construct() {
 	global $gallery;
 	$this->setId('webcam');
 	$this->setName($gallery->i18n('WebCam'));

--- a/modules/webdav/lib/HTTP/WebDAV/Server.php
+++ b/modules/webdav/lib/HTTP/WebDAV/Server.php
@@ -1633,7 +1633,7 @@ class HTTP_WebDAV_Server
         // set headers before we start printing
         $this->setResponseStatus($status);
 
-        if ($status{0} == 2) { // 2xx states are ok
+        if ($status[0] == 2) { // 2xx states are ok
             $this->setResponseHeader('Content-Type: text/xml; charset="utf-8"');
 
             // RFC2518 8.10.1: In order to indicate the lock token associated
@@ -2123,10 +2123,10 @@ class HTTP_WebDAV_Server
         $uuid = md5(microtime() . getmypid()); // this should be random enough for now
 
         // set variant and version fields for 'true' random uuid
-        $uuid{12} = '4';
-        $n = 8 + (ord($uuid{16}) & 3);
+        $uuid[12] = '4';
+        $n = 8 + (ord($uuid[16]) & 3);
         $hex = '0123456789abcdef';
-        $uuid{16} = $hex{$n};
+        $uuid{16} = $hex[$n];
 
         // return formated uuid
         return substr($uuid,  0, 8)
@@ -2161,7 +2161,7 @@ class HTTP_WebDAV_Server
     function _if_header_lexer($string, &$pos)
     {
         // skip whitespace
-        while (ctype_space($string{$pos})) {
+        while (ctype_space($string[$pos])) {
             ++$pos;
         }
 
@@ -2171,7 +2171,7 @@ class HTTP_WebDAV_Server
         }
 
         // get next character
-        $c = $string{$pos++};
+        $c = $string[$pos++];
 
         // now it depends on what we found
         switch ($c) {
@@ -2186,7 +2186,7 @@ class HTTP_WebDAV_Server
             // ETags are enclosed in [...]
             case '[':
                 $type = 'ETAG_STRONG';
-                if ($string{$pos} == 'W') {
+                if ($string[$pos] == 'W') {
                     $type = 'ETAG_WEAK';
                     $pos += 2;
                 }

--- a/modules/webdav/module.inc
+++ b/modules/webdav/module.inc
@@ -26,7 +26,7 @@
  */
 class WebDavModule extends GalleryModule /* and GalleryEventListener */ {
 
-    function WebDavModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('webdav');

--- a/modules/zipcart/module.inc
+++ b/modules/zipcart/module.inc
@@ -27,7 +27,7 @@
  */
 class ZipCartModule extends GalleryModule {
 
-    function ZipCartModule() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('zipcart');

--- a/modules/zipcart/module.inc
+++ b/modules/zipcart/module.inc
@@ -108,7 +108,7 @@ class ZipCartModule extends GalleryModule {
 		if (empty($path)) {
 		    continue;
 		}
-		if ($path{strlen($path)-1} != $slash) {
+		if ($path[strlen($path)-1] != $slash) {
 		    $path .= $slash;
 		}
 		$paths[] = $path . 'zip.exe';
@@ -124,7 +124,7 @@ class ZipCartModule extends GalleryModule {
 		if (empty($path)) {
 		    continue;
 		}
-		if ($path{strlen($path)-1} != $slash) {
+		if ($path[strlen($path)-1] != $slash) {
 		    $path .= $slash;
 		}
 		$paths[] = $path . 'zip';

--- a/themes/ajaxian/theme.inc
+++ b/themes/ajaxian/theme.inc
@@ -27,7 +27,7 @@
  */
 class AjaxianTheme extends GalleryTheme {
 
-    function AjaxianTheme() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('ajaxian');

--- a/themes/carbon/theme.inc
+++ b/themes/carbon/theme.inc
@@ -27,7 +27,7 @@
  */
 class CarbonTheme extends GalleryTheme {
 
-    function CarbonTheme() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('carbon');

--- a/themes/classic/theme.inc
+++ b/themes/classic/theme.inc
@@ -28,7 +28,7 @@
  */
 class ClassicTheme extends GalleryTheme {
 
-    function ClassicTheme() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('classic');

--- a/themes/floatrix/theme.inc
+++ b/themes/floatrix/theme.inc
@@ -27,7 +27,7 @@
  */
 class FloatrixTheme extends GalleryTheme {
 
-    function FloatrixTheme() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('floatrix');

--- a/themes/hybrid/theme.inc
+++ b/themes/hybrid/theme.inc
@@ -27,7 +27,7 @@
  */
 class HybridTheme extends GalleryTheme {
 
-    function HybridTheme() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('hybrid');

--- a/themes/matrix/theme.inc
+++ b/themes/matrix/theme.inc
@@ -27,7 +27,7 @@
  */
 class MatrixTheme extends GalleryTheme {
 
-    function MatrixTheme() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('matrix');

--- a/themes/siriux/theme.inc
+++ b/themes/siriux/theme.inc
@@ -27,7 +27,7 @@
  */
 class SiriuxTheme extends GalleryTheme {
 
-    function SiriuxTheme() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('siriux');

--- a/themes/slider/theme.inc
+++ b/themes/slider/theme.inc
@@ -28,7 +28,7 @@
  */
 class SliderTheme extends GalleryTheme {
 
-    function SliderTheme() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('slider');

--- a/themes/tile/theme.inc
+++ b/themes/tile/theme.inc
@@ -27,7 +27,7 @@
  */
 class TileTheme extends GalleryTheme {
 
-    function TileTheme() {
+    function __construct() {
 	global $gallery;
 
 	$this->setId('tile');

--- a/upgrade/steps/SystemChecksStep.class
+++ b/upgrade/steps/SystemChecksStep.class
@@ -33,7 +33,7 @@ class SystemChecksStep extends UpgradeStep {
      */
     function _getBytes($val) {
 	$val = trim($val);
-	$last = $val{strlen($val)-1};
+	$last = $val[strlen($val)-1];
 	switch ($last) {
 	case 'g':
 	case 'G':
@@ -540,7 +540,7 @@ class SystemChecksStep extends UpgradeStep {
 	if (empty($storagePath)) {
 	    return array(sprintf(_('The storage folder path is not defined in config.php (%s)'),
 				 'data.gallery.base'));
-	} else if ($storagePath{strlen($storagePath)-1} != $platform->getDirectorySeparator()) {
+	} else if ($storagePath[strlen($storagePath)-1] != $platform->getDirectorySeparator()) {
 	    $storagePath .= $platform->getDirectorySeparator();
 	}
 

--- a/upgrade/steps/UpgradeOtherModulesStep.class
+++ b/upgrade/steps/UpgradeOtherModulesStep.class
@@ -320,7 +320,7 @@ class UpgradeOtherModulesStep extends UpgradeStep {
 	/* Deactivate any plugins that need it */
 	eval('
 	    class MockTheme extends GalleryTheme {
-		function MockTheme($pluginId) {
+		function __construct($pluginId) {
 		  $this->_pluginId = $pluginId;
 		}
 
@@ -330,7 +330,7 @@ class UpgradeOtherModulesStep extends UpgradeStep {
 	    }
 
 	    class MockModule extends GalleryModule {
-		function MockModule($pluginId) {
+		function __construct($pluginId) {
 		  $this->_pluginId = $pluginId;
 		}
 


### PR DESCRIPTION
This updates the code to support PHP 8. Note that it's worked for everything I've tried on my local install, but it's definitely possible there are more problems lurking - feel free to open issues as you find them!

Categories of stuff fixed in this PR:
- Instance methods can no longer be called with a static syntax (i.e. `ClassName::instanceMethod()`) - this is [mentioned here](https://wiki.php.net/rfc/consistent_callables#instance_method_reported_as_callable) but I can't find the original deprecation notice. This has been deprecated for a while but now it returns an error. Made a bunch of methods static to fix this. In some cases a method was called with an instance syntax some places and a static syntax others, so I had to make two separate functions. (for example [commit 7e768be](https://github.com/gregstoll/gallery2/commit/7e768bea9dd8653ef2816904485f2acd52c23c8f))
- Curly braces can no longer be used to index into arrays and strings - see [deprecation notice](https://wiki.php.net/rfc/deprecate_curly_braces_array_access). Fix was simple but this was done in a ton of places. (for example [commit 5a584b5](https://github.com/gregstoll/gallery2/commit/5a584b532959185ce67e5129c1413c965a05cacd)
- Constructors used to be able to have the same name as the class but now have to be named `__construct()` - see [deprecation notice](https://wiki.php.net/rfc/remove_php4_constructors). Another simple fix needed in a ton of places. This one was scarier because constructing an object would still work, but the constructor wouldn't be called, which would lead to unpredictable problems later on. I search and tried to make sure to find all of these. (for example [commit c30f191](https://github.com/gregstoll/gallery2/commit/c30f191e55a946944de0ca55fd9e6b27be6b141a))
- Method prototypes of methods on a subclass have to match the prototype of the parent class's method. (can't find a reference to this) This was mostly a matter of adding an extra parameter (for example [commit f00650e](https://github.com/gregstoll/gallery2/commit/f00650e43a48c24c4714666fca312f356d7b622f), although there was one case where two unrelated methods had the same name and I changed one (`GalleryDynamicAlbum::createDynamicAlbum()` in [commit 5aac894](https://github.com/gregstoll/gallery2/commit/5aac89443d6ce7ab2666aaf0ad0c0f16ee7347f0).
- `create_function()` no longer works - see [deprecation notice](https://wiki.php.net/rfc/deprecations_php_7_2#create_function). Fix was to use anonymous functions instead. (for example [commit 368b772](https://github.com/gregstoll/gallery2/commit/368b772c1aacbaaa089b75c10ec9ee271c524802))
- `each()` no longer works - see [deprecation notice](https://wiki.php.net/rfc/deprecations_php_7_2#each). Fix was to use `foreach` construct instead. (for example [commit 6629937](https://github.com/gregstoll/gallery2/commit/6629937c8bd1aef0153eb08d8402dc108d4ca39e))
- Ternary operator (i.e. `a ? b : c`) used to be left-associative and you could nest them without parentheses; now parentheses are required - see [deprecation notice](https://wiki.php.net/rfc/ternary_associativity). Fix was to add parentheses.

I also fixed a few warnings that were cluttering up the debug output.