### PR TITLE
fixing error #50 admin theme page not loading

### DIFF
--- a/modules/ffmpeg/module.inc
+++ b/modules/ffmpeg/module.inc
@@ -171,7 +171,7 @@ class FfmpegModule extends GalleryModule {
 
 	/* Now try each path in turn to see which ones work */
 	foreach ($paths as $path) {
-	    list ($ret, $testResults) = FfmpegToolkitHelper::testBinary($path);
+	    list ($ret, $testResults) = ($this->($path));
 	    if ($ret) {
 		/* Something went wrong with this path -- try the next path */
 		continue;


### PR DESCRIPTION
[replaced curly braces with square brackets for variables in a bunch of places.](https://github.com/gregstoll/gallery2/pull/51)