### PR TITLE
Remove usages of strftime() and gmstrftime()

### DIFF
--- a/lib/smarty/Smarty_Compiler.class.php
+++ b/lib/smarty/Smarty_Compiler.class.php
@@ -405,7 +405,7 @@ class Smarty_Compiler extends Smarty {
         }
 
         // put header at the top of the compiled template
-        $template_header = "<?php /* Smarty version ".$this->_version.", created on ".strftime("%Y-%m-%d %H:%M:%S")."\n";
+        $template_header = "<?php /* Smarty version ".$this->_version.", created on ".date("Y\-m\-d H\:i\:s")."\n";
         $template_header .= "         compiled from ".strtr(urlencode($resource_name), array('%2F'=>'/', '%3A'=>':'))." */ ?>\n";
 
         /* Emit code to load needed plugins. */

--- a/lib/smarty/internals/core.write_compiled_include.php
+++ b/lib/smarty/internals/core.write_compiled_include.php
@@ -25,7 +25,7 @@ function smarty_core_write_compiled_include($params, &$smarty)
     if (count($_match_source)==0) return;
 
     // convert the matched php-code to functions
-    $_include_compiled =  "<?php /* Smarty version ".$smarty->_version.", created on ".strftime("%Y-%m-%d %H:%M:%S")."\n";
+    $_include_compiled =  "<?php /* Smarty version ".$smarty->_version.", created on ".date("Y\-m\-d H\:i\:s")."\n";
     $_include_compiled .= "         compiled from " . strtr(urlencode($params['resource_name']), array('%2F'=>'/', '%3A'=>':')) . " */\n\n";
 
     $_compile_path = $params['include_file_path'];

--- a/lib/smarty/plugins/function.html_select_date.php
+++ b/lib/smarty/plugins/function.html_select_date.php
@@ -42,14 +42,14 @@ function smarty_function_html_select_date($params, &$smarty)
     require_once $smarty->_get_plugin_filepath('function','html_options');
     /* Default values. */
     $prefix          = "Date_";
-    $start_year      = strftime("%Y");
+    $start_year      = date("Y");
     $end_year        = $start_year;
     $display_days    = true;
     $display_months  = true;
     $display_years   = true;
-    $month_format    = "%B";
+    $month_format    = "F";
     /* Write months as numbers by default  GL */
-    $month_value_format = "%m";
+    $month_value_format = "m";
     $day_format      = "%02d";
     /* Write day values using this format MB */
     $day_value_format = "%d";
@@ -142,8 +142,8 @@ function smarty_function_html_select_date($params, &$smarty)
         $time = $found[1];
     } else {
         // use smarty_make_timestamp to get an unix timestamp and
-        // strftime to make yyyy-mm-dd
-        $time = strftime('%Y-%m-%d', smarty_make_timestamp($time));
+        // date() to make yyyy-mm-dd
+        $time = date('Y\-m\-d', smarty_make_timestamp($time));
     }
     // Now split this in pieces, which later can be used to set the select
     $time = explode("-", $time);
@@ -151,16 +151,16 @@ function smarty_function_html_select_date($params, &$smarty)
     // make syntax "+N" or "-N" work with start_year and end_year
     if (preg_match('!^(\+|\-)\s*(\d+)$!', $end_year, $match)) {
         if ($match[1] == '+') {
-            $end_year = strftime('%Y') + $match[2];
+            $end_year = date('Y') + $match[2];
         } else {
-            $end_year = strftime('%Y') - $match[2];
+            $end_year = date('Y') - $match[2];
         }
     }
     if (preg_match('!^(\+|\-)\s*(\d+)$!', $start_year, $match)) {
         if ($match[1] == '+') {
-            $start_year = strftime('%Y') + $match[2];
+            $start_year = date('Y') + $match[2];
         } else {
-            $start_year = strftime('%Y') - $match[2];
+            $start_year = date('Y') - $match[2];
         }
     }
     if (strlen($time[0]) > 0) {
@@ -188,8 +188,8 @@ function smarty_function_html_select_date($params, &$smarty)
             $month_values[''] = '';
         }
         for ($i = 1; $i <= 12; $i++) {
-            $month_names[$i] = strftime($month_format, mktime(0, 0, 0, $i, 1, 2000));
-            $month_values[$i] = strftime($month_value_format, mktime(0, 0, 0, $i, 1, 2000));
+            $month_names[$i] = date($month_format, mktime(0, 0, 0, $i, 1, 2000));
+            $month_values[$i] = date($month_value_format, mktime(0, 0, 0, $i, 1, 2000));
         }
 
         $month_result .= '<select name=';
@@ -211,7 +211,7 @@ function smarty_function_html_select_date($params, &$smarty)
 
         $month_result .= smarty_function_html_options(array('output'     => $month_names,
                                                             'values'     => $month_values,
-                                                            'selected'   => (int)$time[1] ? strftime($month_value_format, mktime(0, 0, 0, (int)$time[1], 1, 2000)) : '',
+                                                            'selected'   => (int)$time[1] ? date($month_value_format, mktime(0, 0, 0, (int)$time[1], 1, 2000)) : '',
                                                             'print_result' => false),
                                                       $smarty);
         $month_result .= '</select>';

--- a/lib/smarty/plugins/function.html_select_time.php
+++ b/lib/smarty/plugins/function.html_select_time.php
@@ -83,7 +83,7 @@ function smarty_function_html_select_time($params, &$smarty)
 
     if ($display_hours) {
         $hours       = $use_24_hours ? range(0, 23) : range(1, 12);
-        $hour_fmt = $use_24_hours ? '%H' : '%I';
+        $hour_fmt = $use_24_hours ? 'H' : 'h';
         for ($i = 0, $for_max = count($hours); $i < $for_max; $i++)
             $hours[$i] = sprintf('%02d', $hours[$i]);
         $html_result .= '<select name=';
@@ -101,7 +101,7 @@ function smarty_function_html_select_time($params, &$smarty)
         $html_result .= '>'."\n";
         $html_result .= smarty_function_html_options(array('output'          => $hours,
                                                            'values'          => $hours,
-                                                           'selected'      => strftime($hour_fmt, $time),
+                                                           'selected'      => date($hour_fmt, $time),
                                                            'print_result' => false),
                                                      $smarty);
         $html_result .= "</select>\n";
@@ -111,7 +111,7 @@ function smarty_function_html_select_time($params, &$smarty)
         $all_minutes = range(0, 59);
         for ($i = 0, $for_max = count($all_minutes); $i < $for_max; $i+= $minute_interval)
             $minutes[] = sprintf('%02d', $all_minutes[$i]);
-        $selected = intval(floor(strftime('%M', $time) / $minute_interval) * $minute_interval);
+        $selected = intval(floor(date('i', $time) / $minute_interval) * $minute_interval);
         $html_result .= '<select name=';
         if (null !== $field_array) {
             $html_result .= '"' . $field_array . '[' . $prefix . 'Minute]"';
@@ -138,7 +138,7 @@ function smarty_function_html_select_time($params, &$smarty)
         $all_seconds = range(0, 59);
         for ($i = 0, $for_max = count($all_seconds); $i < $for_max; $i+= $second_interval)
             $seconds[] = sprintf('%02d', $all_seconds[$i]);
-        $selected = intval(floor(strftime('%S', $time) / $second_interval) * $second_interval);
+        $selected = intval(floor(date('s', $time) / $second_interval) * $second_interval);
         $html_result .= '<select name=';
         if (null !== $field_array) {
             $html_result .= '"' . $field_array . '[' . $prefix . 'Second]"';
@@ -180,7 +180,7 @@ function smarty_function_html_select_time($params, &$smarty)
         
         $html_result .= smarty_function_html_options(array('output'          => array('AM', 'PM'),
                                                            'values'          => array('am', 'pm'),
-                                                           'selected'      => strtolower(strftime('%p', $time)),
+                                                           'selected'      => date('a', $time),
                                                            'print_result' => false),
                                                      $smarty);
         $html_result .= "</select>\n";

--- a/modules/core/ItemEditItem.inc
+++ b/modules/core/ItemEditItem.inc
@@ -368,12 +368,12 @@ class ItemEditItem extends ItemEditPlugin {
 	if ($originationTimestamp > 0) {
 	    $ItemEditItem['originationTimestamp'] = array(
 		'timestamp' => $originationTimestamp,
-		'Time_Hour' => $platform->strftime('%H', $originationTimestamp),
-		'Time_Minute' => $platform->strftime('%M', $originationTimestamp),
-		'Time_Second' => $platform->strftime('%S', $originationTimestamp),
-		'Date_Day' => ltrim($platform->strftime('%d', $originationTimestamp), '0'),
-		'Date_Month' => $platform->strftime('%m', $originationTimestamp),
-		'Date_Year' => $platform->strftime('%Y', $originationTimestamp),
+		'Time_Hour' => $platform->date('h', $originationTimestamp),
+		'Time_Minute' => $platform->date('i', $originationTimestamp),
+		'Time_Second' => $platform->date('s', $originationTimestamp),
+		'Date_Day' => $platform->date('j', $originationTimestamp),
+		'Date_Month' => $platform->date('m', $originationTimestamp),
+		'Date_Year' => $platform->date('Y', $originationTimestamp),
 	    );
 	}
 

--- a/modules/core/classes/Gallery.class
+++ b/modules/core/classes/Gallery.class
@@ -906,9 +906,9 @@ class Gallery {
 	$weekdays = array('1' => 'Mon', '2' => 'Tue', '3' => 'Wed',
 			  '4' => 'Thu', '5' => 'Fri', '6' => 'Sat',
 			  '0' => 'Sun');
-	$dow = $weekdays[gmstrftime('%w', $time)];
-	$month = $months[gmstrftime('%m', $time)];
-	$out = gmstrftime('%%s, %d %%s %Y %H:%M:%S GMT', $time);
+	$dow = $weekdays[gmdate('w', $time)];
+	$month = $months[gmdate('n', $time)];
+	$out = gmdate('\%\s\,\ d\ \%\s\ Y\ H\:i\:s\ \G\M\T', $time);
 	return sprintf($out, $dow, $month);
     }
 

--- a/modules/core/classes/GalleryPlatform.class
+++ b/modules/core/classes/GalleryPlatform.class
@@ -1228,6 +1228,21 @@ class GalleryPlatform {
      * @param int $timestamp (optional)
      * @return string
      */
+    function date($format, $timestamp=null) {
+	global $gallery;
+	if ($gallery->getDebug()) {
+	    $gallery->debug("date($format, $timestamp)");
+	}
+    return GalleryCoreApi::convertToUtf8(isset($timestamp) ? date($format, $timestamp) : date($format));
+    }
+
+    /**
+     * Format a local time/date according to locale settings.  Converts any text output from
+     * strftime tokens to UTF-8.
+     * @param string $format
+     * @param int $timestamp (optional)
+     * @return string
+     */
     function strftime($format, $timestamp=null) {
 	global $gallery;
 	if ($gallery->getDebug()) {

--- a/modules/core/classes/GalleryPlatform.class
+++ b/modules/core/classes/GalleryPlatform.class
@@ -1248,6 +1248,8 @@ class GalleryPlatform {
 	if ($gallery->getDebug()) {
 	    $gallery->debug("strftime($format, $timestamp)");
 	}
+    GalleryCoreApi::requireOnce(
+        'modules/core/classes/helpers/php-8.1-strftime-modified.class');
 
 	$i = 0;
 	$newFormat = '';
@@ -1264,7 +1266,8 @@ class GalleryPlatform {
 	/* Call strftime and convert to UTF-8; escape % characters before sprintf */
 	$newFormat = str_replace(array('%', '&%%&'), array('%%', '%'),
 	    GalleryCoreApi::convertToUtf8(
-		isset($timestamp) ? strftime($newFormat, $timestamp) : strftime($newFormat)));
+		isset($timestamp) ? PHP81_BC\strftime_modified($newFormat, $timestamp) : PHP81_BC\strftime_modified($newFormat)));
+		//isset($timestamp) ? strftime($newFormat, $timestamp) : strftime($newFormat)));
 	return vsprintf($newFormat, $textPieces);
     }
 

--- a/modules/core/classes/helpers/GalleryFileSystemEntityHelper_medium.class
+++ b/modules/core/classes/helpers/GalleryFileSystemEntityHelper_medium.class
@@ -96,7 +96,7 @@ class GalleryFileSystemEntityHelper_medium {
 	 * autogenerate a new filename.. we'll use today's date.
 	 */
 	if (rtrim($fileBase, '_') == '') {
-	    $fileBase = $platform->strftime('%Y%m%d');
+	    $fileBase = $platform->date('Ymd');
 	}
 
 	/*

--- a/modules/core/classes/helpers/php-8.1-strftime-modified.class
+++ b/modules/core/classes/helpers/php-8.1-strftime-modified.class
@@ -1,0 +1,218 @@
+<?php
+  namespace PHP81_BC;
+
+  use DateTime;
+  use DateTimeZone;
+  use DateTimeInterface;
+  use Exception;
+  use IntlGregorianCalendar;
+  use InvalidArgumentException;
+
+  /**
+   * Got from https://packagist.org/packages/php81_bc/strftime
+   * Locale-formatted strftime using IntlDateFormatter (PHP 8.1 compatible)
+   * This provides a cross-platform alternative to strftime() for when it will be removed from PHP.
+   * Note that output can be slightly different between libc sprintf and this function as it is using ICU.
+   *
+   * Usage:
+   * use function \PHP81_BC\strftime;
+   * echo strftime('%A %e %B %Y %X', new \DateTime('2021-09-28 00:00:00'), 'fr_FR');
+   *
+   * Original use:
+   * \setlocale(LC_TIME, 'fr_FR.UTF-8');
+   * echo \strftime('%A %e %B %Y %X', strtotime('2021-09-28 00:00:00'));
+   *
+   * @param  string $format Date format
+   * @param  integer|string|DateTime $timestamp Timestamp
+   * @return string
+   * @author BohwaZ <https://bohwaz.net/>
+   */
+  function strftime_modified (string $format, $timestamp = null, ?string $locale = null) : string {
+    /*if (!($timestamp instanceof DateTimeInterface)) {
+      $timestamp = is_int($timestamp) ? '@' . $timestamp : (string) $timestamp;
+
+      try {
+        $timestamp = new DateTime($timestamp);
+      } catch (Exception $e) {
+        throw new InvalidArgumentException('$timestamp argument is neither a valid UNIX timestamp, a valid date-time string or a DateTime object.', 0, $e);
+      }
+    }*/
+
+    /*$timestamp->setTimezone(new DateTimeZone(date_default_timezone_get()));
+
+    if (empty($locale)) {
+      // get current locale
+      $locale = setlocale(LC_TIME, '0');
+    }
+    // remove trailing part not supported by ext-intl locale
+    $locale = preg_replace('/[^\w-].*$/', '', $locale);*/
+
+    $intl_formats = [
+      '%a' => 'EEE',	// An abbreviated textual representation of the day	Sun through Sat
+      '%A' => 'EEEE',	// A full textual representation of the day	Sunday through Saturday
+      '%b' => 'MMM',	// Abbreviated month name, based on the locale	Jan through Dec
+      '%B' => 'MMMM',	// Full month name, based on the locale	January through December
+      '%h' => 'MMM',	// Abbreviated month name, based on the locale (an alias of %b)	Jan through Dec
+    ];
+
+    /*$intl_formatter = function (DateTimeInterface $timestamp, string $format) use ($intl_formats, $locale) {
+      $tz = $timestamp->getTimezone();
+      //$date_type = \IntlDateFormatter::FULL;
+      //$time_type = IntlDateFormatter::FULL;
+      $pattern = '';
+
+      switch ($format) {
+        // %c = Preferred date and time stamp based on locale
+        // Example: Tue Feb 5 00:45:10 2009 for February 5, 2009 at 12:45:10 AM
+        case '%c':
+          $date_type = IntlDateFormatter::LONG;
+          $time_type = IntlDateFormatter::SHORT;
+          break;
+
+        // %x = Preferred date representation based on locale, without the time
+        // Example: 02/05/09 for February 5, 2009
+        case '%x':
+          $date_type = IntlDateFormatter::SHORT;
+          $time_type = IntlDateFormatter::NONE;
+          break;
+
+        // Localized time format
+        case '%X':
+          $date_type = IntlDateFormatter::NONE;
+          $time_type = IntlDateFormatter::MEDIUM;
+          break;
+
+        default:
+          $pattern = $intl_formats[$format];
+      }
+
+      // In October 1582, the Gregorian calendar replaced the Julian in much of Europe, and
+      //  the 4th October was followed by the 15th October.
+      // ICU (including IntlDateFormattter) interprets and formats dates based on this cutover.
+      // Posix (including strftime) and timelib (including DateTimeImmutable) instead use
+      //  a "proleptic Gregorian calendar" - they pretend the Gregorian calendar has existed forever.
+      // This leads to the same instants in time, as expressed in Unix time, having different representations
+      //  in formatted strings.
+      // To adjust for this, a custom calendar can be supplied with a cutover date arbitrarily far in the past.
+      $calendar = IntlGregorianCalendar::createInstance();
+      $calendar->setGregorianChange(PHP_INT_MIN);
+
+      return (new IntlDateFormatter($locale, $date_type, $time_type, $tz, $calendar, $pattern))->format($timestamp);
+    };*/
+
+    // Same order as https://www.php.net/manual/en/function.strftime.php
+    $translation_table = [
+      // Day
+      '%a' => 'D',
+      '%A' => 'l',
+      '%d' => 'd',
+      '%e' => function ($timestamp) {
+        return sprintf('% 2u', $timestamp->format('j'));
+      },
+      '%j' => function ($timestamp) {
+        // Day number in year, 001 to 366
+        return sprintf('%03d', $timestamp->format('z')+1);
+      },
+      '%u' => 'N',
+      '%w' => 'w',
+
+      // Week
+      '%U' => function ($timestamp) {
+        // Number of weeks between date and first Sunday of year
+        $day = new DateTime(sprintf('%d-01 Sunday', date('Y', $timestamp)));
+        return sprintf('%02u', 1 + ($timestamp->format('z') - $day->format('z')) / 7);
+      },
+      '%V' => 'W',
+      '%W' => function ($timestamp) {
+        // Number of weeks between date and first Monday of year
+        $day = new DateTime(sprintf('%d-01 Monday', $timestamp->format('Y')));
+        return sprintf('%02u', 1 + ($timestamp->format('z') - $day->format('z')) / 7);
+      },
+
+      // Month
+      '%b' => 'M',
+      '%B' => 'F',
+      '%h' => 'M',
+      '%m' => 'm',
+
+      // Year
+      '%C' => function ($timestamp) {
+        // Century (-1): 19 for 20th century
+        return floor($timestamp->format('Y') / 100);
+      },
+      '%g' => function ($timestamp) {
+        return substr($timestamp->format('o'), -2);
+      },
+      '%G' => 'o',
+      '%y' => 'y',
+      '%Y' => 'Y',
+
+      // Time
+      '%H' => 'H',
+      '%k' => function ($timestamp) {
+        return sprintf('% 2u', date('G', $timestamp));
+      },
+      '%I' => 'h',
+      '%l' => function ($timestamp) {
+        return sprintf('% 2u', date('g', $timestamp));
+      },
+      '%M' => 'i',
+      '%p' => 'A', // AM PM (this is reversed on purpose!)
+      '%P' => 'a', // am pm
+      '%r' => 'h:i:s A', // %I:%M:%S %p
+      '%R' => 'H:i', // %H:%M
+      '%S' => 's',
+      '%T' => 'H:i:s', // %H:%M:%S
+      //'%X' => $intl_formatter, // Preferred time representation based on locale, without the date
+
+      // Timezone
+      '%z' => 'O',
+      '%Z' => 'T',
+
+      // Time and Date Stamps
+      '%c' => 'r',
+      '%D' => 'm/d/Y',
+      '%F' => 'Y-m-d',
+      '%s' => 'U',
+      '%x' => 'm/d/Y',
+    ];
+
+    $out = preg_replace_callback('/(?<!%)%([_#-]?)([a-zA-Z])/', function ($match) use ($translation_table, $timestamp) {
+      $prefix = $match[1];
+      $char = $match[2];
+      $pattern = '%'.$char;
+      if ($pattern == '%n') {
+        return "\n";
+      } elseif ($pattern == '%t') {
+        return "\t";
+      }
+
+      if (!isset($translation_table[$pattern])) {
+        throw new InvalidArgumentException(sprintf('Format "%s" is unknown in time format', $pattern));
+      }
+
+      $replace = $translation_table[$pattern];
+
+      if (is_string($replace)) {
+        $result = date($replace, $timestamp);
+      } else {
+        $result = $replace($timestamp, $pattern);
+      }
+
+      switch ($prefix) {
+        case '_':
+          // replace leading zeros with spaces but keep last char if also zero
+          return preg_replace('/\G0(?=.)/', ' ', $result);
+        case '#':
+        case '-':
+          // remove leading zeros but keep last char if also zero
+          return preg_replace('/^0+(?=.)/', '', $result);
+      }
+
+      return $result;
+    }, $format);
+
+    $out = str_replace('%%', '%', $out);
+    return $out;
+  }
+?>

--- a/modules/core/classes/helpers/php-8.1-strftime-modified.class
+++ b/modules/core/classes/helpers/php-8.1-strftime-modified.class
@@ -10,6 +10,12 @@
 
   /**
    * Got from https://packagist.org/packages/php81_bc/strftime
+   * This is pretty heavily modified from the original because using IntlDateFormatter requires
+   * the php_intl extension which I didn't want to require for Gallery.
+   * (see https://stackoverflow.com/questions/6242378/fatal-error-class-intldateformatter-not-found )
+   * So I commented out a bunch of stuff and replaced necessary things that should be good enough for
+   * Gallery's uses.
+   *
    * Locale-formatted strftime using IntlDateFormatter (PHP 8.1 compatible)
    * This provides a cross-platform alternative to strftime() for when it will be removed from PHP.
    * Note that output can be slightly different between libc sprintf and this function as it is using ICU.

--- a/modules/core/classes/helpers/php-8.1-strftime.class
+++ b/modules/core/classes/helpers/php-8.1-strftime.class
@@ -1,0 +1,219 @@
+<?php
+  namespace PHP81_BC;
+
+  use DateTime;
+  use DateTimeZone;
+  use DateTimeInterface;
+  use Exception;
+  use IntlDateFormatter;
+  use IntlGregorianCalendar;
+  use InvalidArgumentException;
+
+  /**
+   * Got from https://packagist.org/packages/php81_bc/strftime
+   * Locale-formatted strftime using IntlDateFormatter (PHP 8.1 compatible)
+   * This provides a cross-platform alternative to strftime() for when it will be removed from PHP.
+   * Note that output can be slightly different between libc sprintf and this function as it is using ICU.
+   *
+   * Usage:
+   * use function \PHP81_BC\strftime;
+   * echo strftime('%A %e %B %Y %X', new \DateTime('2021-09-28 00:00:00'), 'fr_FR');
+   *
+   * Original use:
+   * \setlocale(LC_TIME, 'fr_FR.UTF-8');
+   * echo \strftime('%A %e %B %Y %X', strtotime('2021-09-28 00:00:00'));
+   *
+   * @param  string $format Date format
+   * @param  integer|string|DateTime $timestamp Timestamp
+   * @return string
+   * @author BohwaZ <https://bohwaz.net/>
+   */
+  function strftime_new (string $format, $timestamp = null, ?string $locale = null) : string {
+    if (!($timestamp instanceof DateTimeInterface)) {
+      $timestamp = is_int($timestamp) ? '@' . $timestamp : (string) $timestamp;
+
+      try {
+        $timestamp = new DateTime($timestamp);
+      } catch (Exception $e) {
+        throw new InvalidArgumentException('$timestamp argument is neither a valid UNIX timestamp, a valid date-time string or a DateTime object.', 0, $e);
+      }
+    }
+
+    $timestamp->setTimezone(new DateTimeZone(date_default_timezone_get()));
+
+    if (empty($locale)) {
+      // get current locale
+      $locale = setlocale(LC_TIME, '0');
+    }
+    // remove trailing part not supported by ext-intl locale
+    $locale = preg_replace('/[^\w-].*$/', '', $locale);
+
+    $intl_formats = [
+      '%a' => 'EEE',	// An abbreviated textual representation of the day	Sun through Sat
+      '%A' => 'EEEE',	// A full textual representation of the day	Sunday through Saturday
+      '%b' => 'MMM',	// Abbreviated month name, based on the locale	Jan through Dec
+      '%B' => 'MMMM',	// Full month name, based on the locale	January through December
+      '%h' => 'MMM',	// Abbreviated month name, based on the locale (an alias of %b)	Jan through Dec
+    ];
+
+    $intl_formatter = function (DateTimeInterface $timestamp, string $format) use ($intl_formats, $locale) {
+      $tz = $timestamp->getTimezone();
+      $date_type = IntlDateFormatter::FULL;
+      $time_type = IntlDateFormatter::FULL;
+      $pattern = '';
+
+      switch ($format) {
+        // %c = Preferred date and time stamp based on locale
+        // Example: Tue Feb 5 00:45:10 2009 for February 5, 2009 at 12:45:10 AM
+        case '%c':
+          $date_type = IntlDateFormatter::LONG;
+          $time_type = IntlDateFormatter::SHORT;
+          break;
+
+        // %x = Preferred date representation based on locale, without the time
+        // Example: 02/05/09 for February 5, 2009
+        case '%x':
+          $date_type = IntlDateFormatter::SHORT;
+          $time_type = IntlDateFormatter::NONE;
+          break;
+
+        // Localized time format
+        case '%X':
+          $date_type = IntlDateFormatter::NONE;
+          $time_type = IntlDateFormatter::MEDIUM;
+          break;
+
+        default:
+          $pattern = $intl_formats[$format];
+      }
+
+      // In October 1582, the Gregorian calendar replaced the Julian in much of Europe, and
+      //  the 4th October was followed by the 15th October.
+      // ICU (including IntlDateFormattter) interprets and formats dates based on this cutover.
+      // Posix (including strftime) and timelib (including DateTimeImmutable) instead use
+      //  a "proleptic Gregorian calendar" - they pretend the Gregorian calendar has existed forever.
+      // This leads to the same instants in time, as expressed in Unix time, having different representations
+      //  in formatted strings.
+      // To adjust for this, a custom calendar can be supplied with a cutover date arbitrarily far in the past.
+      $calendar = IntlGregorianCalendar::createInstance();
+      $calendar->setGregorianChange(PHP_INT_MIN);
+
+      return (new IntlDateFormatter($locale, $date_type, $time_type, $tz, $calendar, $pattern))->format($timestamp);
+    };
+
+    // Same order as https://www.php.net/manual/en/function.strftime.php
+    $translation_table = [
+      // Day
+      '%a' => $intl_formatter,
+      '%A' => $intl_formatter,
+      '%d' => 'd',
+      '%e' => function ($timestamp) {
+        return sprintf('% 2u', $timestamp->format('j'));
+      },
+      '%j' => function ($timestamp) {
+        // Day number in year, 001 to 366
+        return sprintf('%03d', $timestamp->format('z')+1);
+      },
+      '%u' => 'N',
+      '%w' => 'w',
+
+      // Week
+      '%U' => function ($timestamp) {
+        // Number of weeks between date and first Sunday of year
+        $day = new DateTime(sprintf('%d-01 Sunday', $timestamp->format('Y')));
+        return sprintf('%02u', 1 + ($timestamp->format('z') - $day->format('z')) / 7);
+      },
+      '%V' => 'W',
+      '%W' => function ($timestamp) {
+        // Number of weeks between date and first Monday of year
+        $day = new DateTime(sprintf('%d-01 Monday', $timestamp->format('Y')));
+        return sprintf('%02u', 1 + ($timestamp->format('z') - $day->format('z')) / 7);
+      },
+
+      // Month
+      '%b' => $intl_formatter,
+      '%B' => $intl_formatter,
+      '%h' => $intl_formatter,
+      '%m' => 'm',
+
+      // Year
+      '%C' => function ($timestamp) {
+        // Century (-1): 19 for 20th century
+        return floor($timestamp->format('Y') / 100);
+      },
+      '%g' => function ($timestamp) {
+        return substr($timestamp->format('o'), -2);
+      },
+      '%G' => 'o',
+      '%y' => 'y',
+      '%Y' => 'Y',
+
+      // Time
+      '%H' => 'H',
+      '%k' => function ($timestamp) {
+        return sprintf('% 2u', $timestamp->format('G'));
+      },
+      '%I' => 'h',
+      '%l' => function ($timestamp) {
+        return sprintf('% 2u', $timestamp->format('g'));
+      },
+      '%M' => 'i',
+      '%p' => 'A', // AM PM (this is reversed on purpose!)
+      '%P' => 'a', // am pm
+      '%r' => 'h:i:s A', // %I:%M:%S %p
+      '%R' => 'H:i', // %H:%M
+      '%S' => 's',
+      '%T' => 'H:i:s', // %H:%M:%S
+      '%X' => $intl_formatter, // Preferred time representation based on locale, without the date
+
+      // Timezone
+      '%z' => 'O',
+      '%Z' => 'T',
+
+      // Time and Date Stamps
+      '%c' => $intl_formatter,
+      '%D' => 'm/d/Y',
+      '%F' => 'Y-m-d',
+      '%s' => 'U',
+      '%x' => $intl_formatter,
+    ];
+
+    $out = preg_replace_callback('/(?<!%)%([_#-]?)([a-zA-Z])/', function ($match) use ($translation_table, $timestamp) {
+      $prefix = $match[1];
+      $char = $match[2];
+      $pattern = '%'.$char;
+      if ($pattern == '%n') {
+        return "\n";
+      } elseif ($pattern == '%t') {
+        return "\t";
+      }
+
+      if (!isset($translation_table[$pattern])) {
+        throw new InvalidArgumentException(sprintf('Format "%s" is unknown in time format', $pattern));
+      }
+
+      $replace = $translation_table[$pattern];
+
+      if (is_string($replace)) {
+        $result = $timestamp->format($replace);
+      } else {
+        $result = $replace($timestamp, $pattern);
+      }
+
+      switch ($prefix) {
+        case '_':
+          // replace leading zeros with spaces but keep last char if also zero
+          return preg_replace('/\G0(?=.)/', ' ', $result);
+        case '#':
+        case '-':
+          // remove leading zeros but keep last char if also zero
+          return preg_replace('/^0+(?=.)/', '', $result);
+      }
+
+      return $result;
+    }, $format);
+
+    $out = str_replace('%%', '%', $out);
+    return $out;
+  }
+?>

--- a/modules/core/classes/helpers/php-8.1-strftime.class
+++ b/modules/core/classes/helpers/php-8.1-strftime.class
@@ -10,6 +10,9 @@
   use InvalidArgumentException;
 
   /**
+   * NOTE: not actually using this, see php-8.1-strftime-modified.class for the code we're using
+   * along with an explanation.
+   *
    * Got from https://packagist.org/packages/php81_bc/strftime
    * Locale-formatted strftime using IntlDateFormatter (PHP 8.1 compatible)
    * This provides a cross-platform alternative to strftime() for when it will be removed from PHP.

--- a/modules/nokiaupload/classes/ImageUploadHelper.class
+++ b/modules/nokiaupload/classes/ImageUploadHelper.class
@@ -626,7 +626,7 @@ class ImageUploadHelper {
     function logRequest($message='') {
 	global $gallery;
 	if ($gallery->getDebug()) {
-	    $gallery->debug("##### $message ### " . strftime('%Y-%m-%d %T') . ' #####');
+	    $gallery->debug("##### $message ### " . date('Y\-m\-d H\:i\:s') . ' #####');
 	    $gallery->debug('POST is: ');
 	    $gallery->debug_r($_POST);
 	    $gallery->debug('GET is: ');

--- a/modules/sitemap/Sitemap.inc
+++ b/modules/sitemap/Sitemap.inc
@@ -147,7 +147,7 @@ class SitemapView extends GalleryView {
 		$loc = $urlGenerator->generateUrl(
 		    array('view' => 'core.ShowItem', 'itemId' => $result[0]),
 		    array('forceSessionId' => false, 'forceFullUrl' => true));
-		$lastmod = gmstrftime('%Y-%m-%dT%H:%M:%S+00:00', $result[1]);
+		$lastmod = gmdate('Y\-m\-d\TH\:i\:s\+\0\0\:\0\0', $result[1]);
 		$changefreq = 'never';
 		foreach ($frequencyTable as $comparison => $value) {
 		    if ($result[2] <= $comparison) {


### PR DESCRIPTION
Some of these I replaced with `date()` and `gmdate()`. The rest I replaced with a compatibility layer to keep user-facing formats the same.

Fixes #25 