### PR TITLE
don't call explode() with null in modules/ffmpeg

### DIFF
--- a/modules/ffmpeg/classes/FfmpegToolkitHelper.class
+++ b/modules/ffmpeg/classes/FfmpegToolkitHelper.class
@@ -294,6 +294,7 @@ class FfmpegToolkitHelper {
 		    do {
 			list ($capabilities, $types) =
 			    preg_split('/\s+/', $resultLine, -1, PREG_SPLIT_NO_EMPTY);
+            if (!is_null($types)) {
 			foreach (explode(',', $types) as $type) {
 			    if (isset($relevantTypes[$type])) {
 				list ($ret, $mime) = GalleryCoreApi::convertExtensionToMime(
@@ -310,6 +311,7 @@ class FfmpegToolkitHelper {
 				}
 			    }
 			}
+            }
 
 			$resultLine = $results[$i++];
 		    } while (!empty($resultLine));


### PR DESCRIPTION
Fixes #45 