### PR TITLE
Use fetch to avoid including debug output in the ajax response.

### DIFF
--- a/modules/core/ItemDeleteJs.inc
+++ b/modules/core/ItemDeleteJs.inc
@@ -99,7 +99,11 @@ class ItemDeleteJsView extends GalleryView {
 	header('Last-Modified: ' . GalleryUtilities::getHttpDate());
 	header('Expires: ' . GalleryUtilities::getHttpDate(time() + 2592000));
 
-	$ret = $template->display('modules/core/templates/ItemDeleteJs.tpl');
+	list($ret, $html) = $template->fetch('gallery:modules/core/templates/ItemDeleteJs.tpl');
+	if($ret){
+		return $ret;
+	}
+	echo $html;
 	return $ret;
     }
 }


### PR DESCRIPTION
Sometimes when you try to delete an item, there was no JS confirmation dialog.

Debugging revealed that it was an issue related to the way the itemdeletejs was generated: since it is an AJAX controller, it expected pure javascript content, but when debug was on, it returned addition content that was not javascript.

This patch uses `fetch` that do not include debugging output and it is safe to use when debugging is on.

Tests run successfully.