### PR TITLE
Add orientation on image rendering

### DIFF
--- a/modules/core/classes/GalleryDerivativeImage.class
+++ b/modules/core/classes/GalleryDerivativeImage.class
@@ -80,6 +80,16 @@ class GalleryDerivativeImage extends GalleryDerivative {
      */
     function create($parentId=null, $derivativeType=null) {
 	global $gallery;
+
+		if (is_null($parentId) || is_null($derivativeType)) {
+			return GalleryCoreApi::error(
+				ERROR_BAD_PARAMETER,
+				__FILE__,
+				__LINE__,
+				'Null parameter passed to GalleryDerivativeImage create function'
+			);
+		}
+
 	$parentId = (int)$parentId;
 
 	if ($derivativeType != DERIVATIVE_TYPE_IMAGE_THUMBNAIL &&
@@ -198,9 +208,17 @@ class GalleryDerivativeImage extends GalleryDerivative {
 		unset($params['maxSize']);
 	    }
 
+		/* Set a default value for class */
+		$params['class'] .= ' gcPhotoImage';
+
 	    $sizeStr = '';
 	    if ($width > 0 && $height > 0) {
-		$sizeStr = sprintf(' width="%s" height="%s"', $width, $height);
+		    if($height > $width){
+			    /* Image orientation is portrait */
+			    $params['class'] .= ' giPortrait';
+		    }
+
+		    $sizeStr = sprintf(' width="%s" height="%s"', $width, $height);
 	    }
 	    if (!isset($params['alt'])) {
 		$params['alt'] =

--- a/modules/core/classes/GalleryDerivativeImage.class
+++ b/modules/core/classes/GalleryDerivativeImage.class
@@ -209,6 +209,9 @@ class GalleryDerivativeImage extends GalleryDerivative {
 	    }
 
 		/* Set a default value for class */
+		if(!array_key_exists('class', $params)){
+			$params['class'] = "";
+		}
 		$params['class'] .= ' gcPhotoImage';
 
 	    $sizeStr = '';

--- a/modules/core/classes/GalleryDerivativeImage.class
+++ b/modules/core/classes/GalleryDerivativeImage.class
@@ -208,18 +208,10 @@ class GalleryDerivativeImage extends GalleryDerivative {
 		unset($params['maxSize']);
 	    }
 
-		/* Set a default value for class */
-		if(!array_key_exists('class', $params)){
-			$params['class'] = "";
-		}
-		$params['class'] .= ' gcPhotoImage';
+		$params['class'] = GalleryUtilities::getImageOrientationClasses($width, $height, $params['class'] ?? '');
 
 	    $sizeStr = '';
 	    if ($width > 0 && $height > 0) {
-		    if($height > $width){
-			    /* Image orientation is portrait */
-			    $params['class'] .= ' giPortrait';
-		    }
 
 		    $sizeStr = sprintf(' width="%s" height="%s"', $width, $height);
 	    }

--- a/modules/core/classes/GalleryPhotoItem.class
+++ b/modules/core/classes/GalleryPhotoItem.class
@@ -215,7 +215,7 @@ class GalleryPhotoItem extends GalleryDataItem {
 		array('forceFullUrl' => !empty($params['forceFullUrl'])));
 	    list ($width, $height) = array($this->getWidth(), $this->getHeight());
 
-		$params['class'] .= ' gcPhotoImage';
+	    $params['class'] = GalleryUtilities::getImageOrientationClasses($width, $height, $params['class'] ?? '');
 
 		/* Shrink our dimensions if necessary */
 	    if (isset($params['maxSize'])) {
@@ -226,10 +226,6 @@ class GalleryPhotoItem extends GalleryDataItem {
 
 	    $sizeStr = '';
 	    if ($width > 0 && $height > 0) {
-		    if($height > $width){
-						// Image orientation is portrait
-						$params['class'] .= ' giPortrait';
-		    }
 		$sizeStr = sprintf(' width="%s" height="%s"', $width, $height);
 	    }
 	    if (!isset($params['alt'])) {
@@ -242,10 +238,6 @@ class GalleryPhotoItem extends GalleryDataItem {
 	    unset($params['fallback']);
 	    unset($params['forceFullUrl']);
 	    unset($params['forceRawImage']);
-
-	    	$classes = " class=\"". $params['class'] . "\"";
-		$html .= $classes;
-		unset($params['class']);
 
 	    foreach ($params as $attr => $value) {
 		if (isset($value)) {

--- a/modules/core/classes/GalleryPhotoItem.class
+++ b/modules/core/classes/GalleryPhotoItem.class
@@ -127,6 +127,10 @@ class GalleryPhotoItem extends GalleryDataItem {
 	return null;
     }
 
+	public function getCanContainChildren() {
+		return false;
+	}
+
     /**
      * @see GalleryDataItem::rescan
      */
@@ -211,7 +215,9 @@ class GalleryPhotoItem extends GalleryDataItem {
 		array('forceFullUrl' => !empty($params['forceFullUrl'])));
 	    list ($width, $height) = array($this->getWidth(), $this->getHeight());
 
-	    /* Shrink our dimensions if necessary */
+		$params['class'] .= ' gcPhotoImage';
+
+		/* Shrink our dimensions if necessary */
 	    if (isset($params['maxSize'])) {
 		list ($width, $height) =
 		    GalleryUtilities::shrinkDimensionsToFit($width, $height, $params['maxSize']);
@@ -220,6 +226,10 @@ class GalleryPhotoItem extends GalleryDataItem {
 
 	    $sizeStr = '';
 	    if ($width > 0 && $height > 0) {
+		    if($height > $width){
+						// Image orientation is portrait
+						$params['class'] .= ' giPortrait';
+		    }
 		$sizeStr = sprintf(' width="%s" height="%s"', $width, $height);
 	    }
 	    if (!isset($params['alt'])) {
@@ -232,6 +242,11 @@ class GalleryPhotoItem extends GalleryDataItem {
 	    unset($params['fallback']);
 	    unset($params['forceFullUrl']);
 	    unset($params['forceRawImage']);
+
+	    	$classes = " class=\"". $params['class'] . "\"";
+		$html .= $classes;
+		unset($params['class']);
+
 	    foreach ($params as $attr => $value) {
 		if (isset($value)) {
 		    $html .= " $attr=\"$value\"";

--- a/modules/core/classes/GalleryUtilities.class
+++ b/modules/core/classes/GalleryUtilities.class
@@ -460,6 +460,19 @@ class GalleryUtilities {
 	}
 	return array($width, $height);
     }
+	/**
+	 * Return appropriate classes for the image orientation.
+	 * @return string
+	 */
+	static function getImageOrientationClasses($width, $height, $init_classes='')
+	{
+		$classes = $init_classes . ' gcPhotoImage';
+		if($height > $width){
+			/* Image orientation is portrait */
+			$classes .= ' giPortrait';
+		}
+		return $classes;
+	}
 
     /**
      * Scale the given width/height to a new target size, maintaining aspect ratio.

--- a/modules/core/test/phpunit/UtilitiesTest.class
+++ b/modules/core/test/phpunit/UtilitiesTest.class
@@ -651,6 +651,27 @@ class UtilitiesTest extends GalleryTestCase {
 		$this->assertEquals(array(1067, 800), $results);
 	}
 
+	public function testGetImageOrientationClassesPortrait() {
+		$results = GalleryUtilities::getImageOrientationClasses(768, 1024);
+		$this->assertTrue( str_contains($results, 'gcPhotoImage'));
+
+		$this->assertTrue( str_contains($results, 'giPortrait'));
+	}
+
+	public function testGetImageOrientationClassesNotPortrait() {
+		$results = GalleryUtilities::getImageOrientationClasses(1024, 768);
+		$this->assertTrue( str_contains($results, 'gcPhotoImage'));
+
+		$this->assertFalse( str_contains($results, 'giPortrait'));
+	}
+
+	public function testGetImageOrientationClassesWithInitialClasses() {
+		$results = GalleryUtilities::getImageOrientationClasses(1024, 768, 'initial');
+		$this->assertTrue( str_contains($results, 'gcPhotoImage'));
+
+		$this->assertTrue( str_contains($results, 'initial'));
+	}
+
 	public function testIsA() {
 		$this->assertTrue(GalleryUtilities::isA(new UtilitiesTest('x'), 'GalleryTestCase'));
 		$this->assertTrue(GalleryUtilities::isA(new UtilitiesTest('x'), 'UtilitiesTest'));


### PR DESCRIPTION
Add additional classes based on the orientation (width vs height) of an image.

It will enable themes to provide different styling to adjust the image to the screen.