### PR TITLE
Do not use docker volumes but local mounted endpoints.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config.php
 login.txt
 *.swp
 gallery2-data
+mysqldata

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       PHP_IDE_CONFIG: "serverName=docker"
     volumes:
       - .:/app
-      - gallery2-data:/gallery2-data
+      - ./gallery2-data:/gallery2-data
       - ./php.ini:/usr/local/etc/php/conf.d/custom.ini
     links:
       - mysql
@@ -31,9 +31,6 @@ services:
       MYSQL_PASSWORD: 'secret'
       MYSQL_DATABASE: 'gallery2'
     volumes:
-      - mysqldata:/var/lib/mysql
+      - ./mysqldata:/var/lib/mysql
     ports:
       - "13306:3306"
-volumes:
-  mysqldata: {}
-  gallery2-data: {}


### PR DESCRIPTION
I had a very bad experience with docker and I had to reset it, so I lost all the /gallery2-data and the database content.

I decided to switch to use local mounted endpoints from now on, so it will be safer to keep the data in case of a docker crisis.