### PR TITLE
fix: undo changes on keyalbum from #798ee2e8

### DIFF
--- a/modules/keyalbum/KeywordAlbum.inc
+++ b/modules/keyalbum/KeywordAlbum.inc
@@ -50,17 +50,10 @@ class KeywordAlbumView extends GalleryView {
 	    return array($ret, null, null, null);
 	}
 	list ($keyword, $itemId) = GalleryUtilities::getRequestVariables('keyword', 'itemId');
-		$item->create(
-			$module->translate(
-				array(
-					'text' => 'Keyword Album: %s',
-					'arg1' => $keyword,
-				)
-			),
-			array(
-				array('Keyword Album', 'keyword album'),
-				array($module->translate('Keyword Album'), $module->translate('keyword album')),
-			)
+	$item->createDynamicAlbum(
+		$module->translate(array('text' => 'Keyword Album: %s', 'arg1' => $keyword)),
+		array(array('Keyword Album', 'keyword album'),
+		    array($module->translate('Keyword Album'), $module->translate('keyword album')))
 	);
 
 	list ($ret, $moduleParams) =


### PR DESCRIPTION
fix: undo changes from #798ee2e8

Previous changes broke keywords view with a missing object 0 error, due to bad initialisation of the Dynamic Album instance.
