### PR TITLE
Do not raise an error on non-legal path component, but legalize it.

### DIFF
--- a/modules/core/ItemAddAlbum.inc
+++ b/modules/core/ItemAddAlbum.inc
@@ -58,7 +58,7 @@ class ItemAddAlbumController extends GalleryController {
 	    if (empty($form['pathComponent'])) {
 		$error[] = 'form[error][pathComponent][missing]';
 	    } else if (!$platform->isLegalPathComponent($form['pathComponent'], true)) {
-		$error[] = 'form[error][pathComponent][invalid]';
+		    $form['pathComponent'] = $platform->legalizePathComponent($form['pathComponent'], true);
 	    }
 
 	    if (empty($error)) {

--- a/modules/core/ItemEditItem.inc
+++ b/modules/core/ItemEditItem.inc
@@ -65,7 +65,7 @@ class ItemEditItem extends ItemEditPlugin {
 		    $error[] = 'form[error][pathComponent][missing]';
 		    $form['pathComponent'] = '';
 		} else if (!$platform->isLegalPathComponent($form['pathComponent'])) {
-		    $error[] = 'form[error][pathComponent][invalid]';
+		    $form['pathComponent'] = $platform->legalizePathComponent($form['pathComponent']);
 		}
 	    }
 

--- a/modules/core/classes/GalleryPlatform.class
+++ b/modules/core/classes/GalleryPlatform.class
@@ -624,15 +624,7 @@ class GalleryPlatform {
 		    return $ret;
 	    }
 	    $slugMode = $slugMode ?? 'modern';
-	    switch ($slugMode) {
-		    case 'modern':
-			    return self::legalizePathComponentWithSlug($component, $forDirectory);
-		    case 'classic':
-			    return self::legalizePathComponentClassic($component, $forDirectory);
-		    default:
-			    return GalleryCoreApi::error(ERROR_BAD_PARAMETER, __FILE__, __LINE__,
-				"Unknown slug mode $slugMode.");
-	    }
+	    return $this->legalizePathComponentHelper($component, $forDirectory, $slugMode);
     }
     /**
      * Remove any illegal characters from the path component.
@@ -2221,6 +2213,25 @@ class GalleryPlatform {
 			$title = $fallback_title;
 
 		return $title;
+	}
+
+	/**
+	 * @param string $component
+	 * @param bool $forDirectory
+	 * @param mixed $slugMode
+	 * @return GalleryStatus|string
+	 */
+	public function legalizePathComponentHelper($component, $forDirectory=false, $slugMode='classic')
+	{
+		switch ($slugMode) {
+			case 'modern':
+				return self::legalizePathComponentWithSlug($component, $forDirectory);
+			case 'classic':
+				return self::legalizePathComponentClassic($component, $forDirectory);
+			default:
+				return GalleryCoreApi::error(ERROR_BAD_PARAMETER, __FILE__, __LINE__,
+				    "Unknown slug mode $slugMode.");
+		}
 	}
 }
 ?>

--- a/modules/core/test/phpunit/ItemAddAlbumControllerTest.class
+++ b/modules/core/test/phpunit/ItemAddAlbumControllerTest.class
@@ -179,15 +179,8 @@ class ItemAddAlbumControllerTest extends GalleryControllerTestCase {
 		$results = $this->handleRequest();
 
 		$this->assertEquals(
-			array(
-				'delegate' => array(
-					'view'    => 'core.ItemAdmin',
-					'subView' => 'core.ItemAddAlbum',
-				),
-				'status'   => array(),
-				'error'    => array('form[error][pathComponent][invalid]'),
-			),
-			$results
+			array(),
+			$results['error']
 		);
 	}
 

--- a/modules/core/test/phpunit/ItemEditItemPluginTest.class
+++ b/modules/core/test/phpunit/ItemEditItemPluginTest.class
@@ -240,16 +240,15 @@ class ItemEditItemPluginTest extends ItemEditPluginTestCase {
 	}
 
 	public function testInvalidPathComponent() {
-		$newPathComponent = $this->_item[0]->getPathComponent() . mt_rand();
-
 		GalleryUtilities::putRequestVariable('form[action][save]', 1);
-		GalleryUtilities::putRequestVariable('form[pathComponent]', '#$%W$%W?$%W%/');
+		GalleryUtilities::putRequestVariable('form[pathComponent]', '%W$%W?$%W%/');
+		GalleryUtilities::putRequestVariable('form[serialNumber]', $this->_item[0]->getSerialNumber());
 
 		// Perform the request and verify that we failed
 		$results = $this->handleRequest($this->_item[0], $this->_preferred);
 
 		$this->assertEquals(
-			array(array('form[error][pathComponent][invalid]'), null),
+		    array (0 => array (), 1 => 'Changes saved successfully',),
 			$results
 		);
 	}
@@ -257,19 +256,17 @@ class ItemEditItemPluginTest extends ItemEditPluginTestCase {
 	public function testInvalidPathComponentDisallowedFileExtension() {
 		GalleryUtilities::putRequestVariable('form[action][save]', 1);
 		GalleryUtilities::putRequestVariable('form[pathComponent]', 'test_new.php');
-
+		GalleryUtilities::putRequestVariable('form[serialNumber]', $this->_item[0]->getSerialNumber());
 		// Perform the request and verify that we fail
 		$results = $this->handleRequest($this->_item[0], $this->_preferred);
 
 		$this->assertEquals(
-			array(array('form[error][pathComponent][invalid]'), null),
+		    array (0 => array (), 1 => 'Changes saved successfully',),
 			$results
 		);
 	}
 
 	public function testMissingPathComponent() {
-		$newPathComponent = $this->_item[0]->getPathComponent() . mt_rand();
-
 		GalleryUtilities::putRequestVariable('form[action][save]', 1);
 		GalleryUtilities::removeRequestVariable('form[pathComponent]');
 


### PR DESCRIPTION
This issue arises when your gallery was created using the `classic` slug mode and all your items have component paths using the classic rules.

If you then switch the slug mode to `modern`, and you try to edit an item that had an space or any other non-legal chars on `modern` slug mode, the edit form will complain and ask you to manually update the path.

This patch fixes this issue and forces that all path components will be legalize on form submission.

I updated some tests to deal with this new behaviour.
