### PR TITLE
fix: revert strftime changes.

### DIFF
--- a/lib/smarty/plugins/function.html_select_date.php
+++ b/lib/smarty/plugins/function.html_select_date.php
@@ -42,14 +42,14 @@ function smarty_function_html_select_date($params, &$smarty)
     require_once $smarty->_get_plugin_filepath('function','html_options');
     /* Default values. */
     $prefix          = "Date_";
-    $start_year      = strftime("%Y");
+    $start_year      = date("Y");
     $end_year        = $start_year;
     $display_days    = true;
     $display_months  = true;
     $display_years   = true;
-    $month_format    = "%B";
+    $month_format    = "F";
     /* Write months as numbers by default  GL */
-    $month_value_format = "%m";
+    $month_value_format = "m";
     $day_format      = "%02d";
     /* Write day values using this format MB */
     $day_value_format = "%d";
@@ -142,8 +142,8 @@ function smarty_function_html_select_date($params, &$smarty)
         $time = $found[1];
     } else {
         // use smarty_make_timestamp to get an unix timestamp and
-        // strftime to make yyyy-mm-dd
-        $time = strftime('%Y-%m-%d', smarty_make_timestamp($time));
+        // date() to make yyyy-mm-dd
+        $time = date('Y\-m\-d', smarty_make_timestamp($time));
     }
     // Now split this in pieces, which later can be used to set the select
     $time = explode("-", $time);
@@ -151,16 +151,16 @@ function smarty_function_html_select_date($params, &$smarty)
     // make syntax "+N" or "-N" work with start_year and end_year
     if (preg_match('!^(\+|\-)\s*(\d+)$!', $end_year, $match)) {
         if ($match[1] == '+') {
-            $end_year = strftime('%Y') + $match[2];
+            $end_year = date('Y') + $match[2];
         } else {
-            $end_year = strftime('%Y') - $match[2];
+            $end_year = date('Y') - $match[2];
         }
     }
     if (preg_match('!^(\+|\-)\s*(\d+)$!', $start_year, $match)) {
         if ($match[1] == '+') {
-            $start_year = strftime('%Y') + $match[2];
+            $start_year = date('Y') + $match[2];
         } else {
-            $start_year = strftime('%Y') - $match[2];
+            $start_year = date('Y') - $match[2];
         }
     }
     if (strlen($time[0]) > 0) {
@@ -188,8 +188,8 @@ function smarty_function_html_select_date($params, &$smarty)
             $month_values[''] = '';
         }
         for ($i = 1; $i <= 12; $i++) {
-            $month_names[$i] = strftime($month_format, mktime(0, 0, 0, $i, 1, 2000));
-            $month_values[$i] = strftime($month_value_format, mktime(0, 0, 0, $i, 1, 2000));
+            $month_names[$i] = date($month_format, mktime(0, 0, 0, $i, 1, 2000));
+            $month_values[$i] = date($month_value_format, mktime(0, 0, 0, $i, 1, 2000));
         }
 
         $month_result .= '<select name=';
@@ -211,7 +211,7 @@ function smarty_function_html_select_date($params, &$smarty)
 
         $month_result .= smarty_function_html_options(array('output'     => $month_names,
                                                             'values'     => $month_values,
-                                                            'selected'   => (int)$time[1] ? strftime($month_value_format, mktime(0, 0, 0, (int)$time[1], 1, 2000)) : '',
+                                                            'selected'   => (int)$time[1] ? date($month_value_format, mktime(0, 0, 0, (int)$time[1], 1, 2000)) : '',
                                                             'print_result' => false),
                                                       $smarty);
         $month_result .= '</select>';

--- a/lib/smarty/plugins/function.html_select_time.php
+++ b/lib/smarty/plugins/function.html_select_time.php
@@ -83,7 +83,7 @@ function smarty_function_html_select_time($params, &$smarty)
 
     if ($display_hours) {
         $hours       = $use_24_hours ? range(0, 23) : range(1, 12);
-        $hour_fmt = $use_24_hours ? '%H' : '%I';
+        $hour_fmt = $use_24_hours ? 'H' : 'h';
         for ($i = 0, $for_max = count($hours); $i < $for_max; $i++)
             $hours[$i] = sprintf('%02d', $hours[$i]);
         $html_result .= '<select name=';
@@ -101,7 +101,7 @@ function smarty_function_html_select_time($params, &$smarty)
         $html_result .= '>'."\n";
         $html_result .= smarty_function_html_options(array('output'          => $hours,
                                                            'values'          => $hours,
-                                                           'selected'      => strftime($hour_fmt, $time),
+                                                           'selected'      => date($hour_fmt, $time),
                                                            'print_result' => false),
                                                      $smarty);
         $html_result .= "</select>\n";
@@ -111,7 +111,7 @@ function smarty_function_html_select_time($params, &$smarty)
         $all_minutes = range(0, 59);
         for ($i = 0, $for_max = count($all_minutes); $i < $for_max; $i+= $minute_interval)
             $minutes[] = sprintf('%02d', $all_minutes[$i]);
-        $selected = intval(floor(strftime('%M', $time) / $minute_interval) * $minute_interval);
+        $selected = intval(floor(date('i', $time) / $minute_interval) * $minute_interval);
         $html_result .= '<select name=';
         if (null !== $field_array) {
             $html_result .= '"' . $field_array . '[' . $prefix . 'Minute]"';
@@ -138,7 +138,7 @@ function smarty_function_html_select_time($params, &$smarty)
         $all_seconds = range(0, 59);
         for ($i = 0, $for_max = count($all_seconds); $i < $for_max; $i+= $second_interval)
             $seconds[] = sprintf('%02d', $all_seconds[$i]);
-        $selected = intval(floor(strftime('%S', $time) / $second_interval) * $second_interval);
+        $selected = intval(floor(date('s', $time) / $second_interval) * $second_interval);
         $html_result .= '<select name=';
         if (null !== $field_array) {
             $html_result .= '"' . $field_array . '[' . $prefix . 'Second]"';
@@ -180,7 +180,7 @@ function smarty_function_html_select_time($params, &$smarty)
         
         $html_result .= smarty_function_html_options(array('output'          => array('AM', 'PM'),
                                                            'values'          => array('am', 'pm'),
-                                                           'selected'      => strtolower(strftime('%p', $time)),
+                                                           'selected'      => date('a', $time),
                                                            'print_result' => false),
                                                      $smarty);
         $html_result .= "</select>\n";


### PR DESCRIPTION
More changes to Smarty code, to use `date` instead of `strftime` as introduced by @gregstoll .