### PR TITLE
PHP deprecation warnings fixed

### DIFF
--- a/lib/JSON/JSON.php
+++ b/lib/JSON/JSON.php
@@ -139,6 +139,10 @@ class Services_JSON
     *                                   strings or numbers, if you return an object, make sure it does
     *                                   not have a toJSON method, otherwise an error will occur.
     */
+
+    /* deprecated dynamic properties in php 8.2 */
+    var $use;
+
     function __construct($use = 0)
     {
         $this->use = $use;

--- a/lib/bbcode/stringparser_bbcode.class.php
+++ b/lib/bbcode/stringparser_bbcode.class.php
@@ -146,6 +146,13 @@ class StringParser_BBCode extends StringParser {
 	 * @var bool
 	 */
 	var $_validateAgain = false;
+
+	/* deprecated dynamic properties in php 8.2 */
+	var $_output;
+	var $_savedName;
+	var $_savedCloseCount;
+	var $_savedValue;
+	var $_quoting;
 	
 	/**
 	 * Add a code
@@ -1522,6 +1529,9 @@ class StringParser_BBCode_Node_Element extends StringParser_Node {
 	 * @var bool
 	 */
 	var $_paragraphHandled = false;
+
+	/* deprecated dynamic properties in php 8.2 */
+	var $_codeInfo;
 	
 	//////////////////////////////////////////////////
 	

--- a/lib/pear/HTMLSax3.php
+++ b/lib/pear/HTMLSax3.php
@@ -826,6 +826,10 @@ class XML_HTMLSax3_OpeningTagState {
     * @access protected
     * @see XML_HTMLSax3_AttributeStartState
     */
+
+    /* deprecated dynamic properties in php 8.2 */
+    private array $attrs;
+
     function parseAttributes(&$context) {
         $Attributes = array();
     

--- a/lib/smarty/Smarty_Compiler.class.php
+++ b/lib/smarty/Smarty_Compiler.class.php
@@ -73,6 +73,14 @@ class Smarty_Compiler extends Smarty {
     var $_strip_depth           =   0;
     var $_additional_newline    =   "\n";
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $_dvar_math_regexp;
+    var $_dvar_math_var_regexp;
+    var $_obj_restricted_param_regexp;
+    var $_obj_single_param_regexp;
+    var $_param_regexp;
+    var $_plugins_code;
+
     /**#@-*/
     /**
      * The class constructor.

--- a/lib/tools/phpunit/CodeAuditTestCase.class
+++ b/lib/tools/phpunit/CodeAuditTestCase.class
@@ -26,6 +26,9 @@
  * @version $Revision: 17580 $
  */
 class CodeAuditTestCase extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_checkTime;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 

--- a/lib/tools/phpunit/GalleryTestCase.class
+++ b/lib/tools/phpunit/GalleryTestCase.class
@@ -27,6 +27,58 @@
 class GalleryTestCase extends TestCase {
 	public $_cleanup;
 
+	/* deprecated dynamic properties in php 8.2 */
+	protected $_activeUserBackup;
+	protected $_album;
+	protected $_albums;
+	protected $_callback;
+	protected $_callbacks;
+	protected $_child;
+	protected $_comment;
+	protected $_derivative;
+	protected $_entity;
+	protected $_item;
+	protected $_items;
+	protected $_languageCode;
+	protected $_mockSession;
+	protected $_module;
+	protected $_noErrors;
+	protected $_noWarnings;
+	protected $_origSession;
+	protected $_originalSession;
+	protected $_parentAlbum;
+	protected $_parser;
+	protected $_phpVm;
+	protected $_platform;
+	protected $_preferred;
+	protected $_randomKey;
+	protected $_root;
+	protected $_rootAlbumId;
+	protected $_savePlatform;
+	protected $_saveSID;
+	protected $_saveSession;
+	protected $_saveUser;
+	protected $_saveVars;
+	protected $_savedSession;
+	protected $_saveSessionPerms;
+	protected $_session;
+	protected $_siteAdminGroupId;
+	protected $_smarty;
+	protected $_storage;
+	protected $_targetAlbum;
+	protected $_task;
+	protected $_template;
+	protected $_testRepository;
+	protected $_testStorage;
+	protected $_toolkit;
+	protected $_urlGenerator;
+	protected $_user;
+	protected $_user1;
+	protected $_user2;
+	protected $_userId;
+	protected $_view;
+	protected $_watermark;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 
@@ -1506,6 +1558,10 @@ class GalleryTestCase extends TestCase {
  * Extends GalleryEventListener
  */
 class EntityCounterEventListener {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_count;
+	public $_ids;
+
 	public function __construct() {
 		$this->_count = 0;
 		$this->_ids   = array();

--- a/lib/tools/phpunit/MockObject.class
+++ b/lib/tools/phpunit/MockObject.class
@@ -38,6 +38,10 @@
  * @version $Revision: 17580 $
  */
 class MockObject {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_called;
+	public $_className;
+
 	public function __construct() {
 		$this->_className        = get_class($this);
 		$_GET[$this->_className] = array(

--- a/lib/tools/phpunit/MockTemplateAdapter.class
+++ b/lib/tools/phpunit/MockTemplateAdapter.class
@@ -23,6 +23,12 @@
  * @subpackage PHPUnit
  */
 class MockTemplateAdapter {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_useProgressBar;
+	public $_callbacks;
+	public $_completeProgressBar;
+	public $_progress;
+
 	public function __construct($useProgressBar = true) {
 		$this->_useProgressBar      = $useProgressBar;
 		$this->_callbacks           = array();

--- a/lib/tools/phpunit/UnitTestStorage.class
+++ b/lib/tools/phpunit/UnitTestStorage.class
@@ -50,6 +50,10 @@ class UnitTestStorage extends MockObject {
 	public $_extras;
 	public $_lockSystem;
 
+	/* deprecated dynamic properties in php 8.2 */
+	public $_tablePrefix;
+	public $_columnPrefix;
+
 	public function __construct() {
 		parent::__construct();
 

--- a/lib/tools/phpunit/index.php
+++ b/lib/tools/phpunit/index.php
@@ -31,7 +31,7 @@ require_once '../../../init.inc';
 @date_default_timezone_set(date_default_timezone_get());
 $testReportDir = $gallery->getConfig('data.gallery.base') . 'test/';
 $priorRuns     = array();
-$glob          = glob("${testReportDir}*");
+$glob          = glob("{$testReportDir}*");
 
 if ($glob) {
 	foreach ($glob as $filename) {
@@ -49,7 +49,7 @@ if (!empty($_GET['run'])) {
 	list($action, $run) = explode(':', $_GET['run']);
 
 	$run     = substr($run, 0, strspn($run, '0123456789'));
-	$runFile = "${testReportDir}run-$run.html";
+	$runFile = "{$testReportDir}run-$run.html";
 
 	switch ($action) {
 		case 'frame':
@@ -68,7 +68,7 @@ if (!empty($_GET['run'])) {
 
 		case 'deleteall':
 			foreach ($priorRuns as $pr) {
-				unlink("${testReportDir}run-$pr[key].html");
+				unlink("{$testReportDir}run-$pr[key].html");
 			}
 
 			header('Location: index.php');
@@ -118,7 +118,7 @@ function PhpUnitOutputInterceptor($message) {
 		static $fd;
 
 		if (!isset($fd)) {
-			$fd = fopen("${testReportDir}run-" . date('YmdHis') . '.html', 'wb+');
+			$fd = fopen("{$testReportDir}run-" . date('YmdHis') . '.html', 'wb+');
 		}
 
 		static $replaced;

--- a/lib/tools/phpunit/phpunit.inc
+++ b/lib/tools/phpunit/phpunit.inc
@@ -1016,6 +1016,9 @@ class TestSuite {
 	public $fClassname;
 	public $fModuleId;
 
+	/* deprecated dynamic properties in php 8.2 */
+	public $fFilter;
+
 	public function __construct($classname = false, $moduleid = false, $filter = null) {
 		// Find all methods of the given class whose name starts with
 		// "test" and add them to the test suite.

--- a/lib/tools/repository/test/phpunit/RepositoryDescriptorTest.class
+++ b/lib/tools/repository/test/phpunit/RepositoryDescriptorTest.class
@@ -38,6 +38,9 @@ GalleryCoreApi::requireOnce(
 class RepositoryDescriptorTest extends GalleryTestCase {
 	public $_testModule;
 
+	/* deprecated dynamic properties in php 8.2 */
+	public $_canonicalFileMetaData;
+
 	public function setUp($x1 = null) {
 		$ret = parent::setUp($x1);
 
@@ -548,6 +551,9 @@ class RepositoryDescriptorTest extends GalleryTestCase {
 }
 
 class RepositoryDescriptorTestPhpVm extends GalleryPhpVm {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_crc32;
+
 	public function setCrc32($contents, $crc32) {
 		$this->_crc32[$contents] = $crc32;
 	}
@@ -558,6 +564,9 @@ class RepositoryDescriptorTestPhpVm extends GalleryPhpVm {
 }
 
 class RepositoryDescriptor_FakeFileMetaDataTest extends RepositoryDescriptor {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_metaData;
+
 	public function __construct($metaData) {
 		$this->_metaData = $metaData;
 	}
@@ -639,6 +648,9 @@ class RepositoryDescriptorTestTranslator {
 }
 
 class RepositoryDescriptorTestUtilities {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_matches;
+
 	public function setGetFileRevision($expected, $reply) {
 		$this->_matches[$expected] = $reply;
 	}

--- a/lib/tools/repository/test/phpunit/RepositoryPackageTest.class
+++ b/lib/tools/repository/test/phpunit/RepositoryPackageTest.class
@@ -291,6 +291,10 @@ class RepositoryPackageTestDescriptor {
 	public $_pluginDir;
 	public $_pluginVersion;
 
+	/* deprecated dynamic properties in php 8.2 */
+	public $_pluginBuildTimestamp;
+	public $_pluginStringsRevision;
+
 	public function __construct() {
 		$this->_packages    = array('package1', 'package2');
 		$this->_directories = array(

--- a/modules/archiveupload/test/phpunit/ArchiveExtractToolkitTest.class
+++ b/modules/archiveupload/test/phpunit/ArchiveExtractToolkitTest.class
@@ -28,6 +28,9 @@ GalleryCoreApi::requireOnce('modules/archiveupload/classes/ArchiveExtractToolkit
  * @version $Revision: 17999 $
  */
 class ArchiveExtractToolkitTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_unzipPath;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/captcha/test/phpunit/CaptchaHelperTest.class
+++ b/modules/captcha/test/phpunit/CaptchaHelperTest.class
@@ -121,6 +121,9 @@ class CaptchaHelperTest extends GalleryTestCase {
 }
 
 class CaptchaHelperTestPhpVm {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_function_exists;
+
 	public function setFunctionExists($functionName, $bool) {
 		$this->_function_exists[$functionName] = $bool;
 	}

--- a/modules/captcha/test/phpunit/CaptchaValidationPluginTest.class
+++ b/modules/captcha/test/phpunit/CaptchaValidationPluginTest.class
@@ -27,6 +27,11 @@
  * @version $Revision: 17580 $
  */
 class CaptchaValidationPluginTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_plugin;
+	public $_saveSessionCount;
+	public $_form;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/cart/test/phpunit/AddToCartControllerTest.class
+++ b/modules/cart/test/phpunit/AddToCartControllerTest.class
@@ -26,6 +26,9 @@
  * @version $Revision: 17580 $
  */
 class AddToCartControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_saveCartItemCounts;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'cart.AddToCart');
 	}

--- a/modules/cart/test/phpunit/CartHelperTest.class
+++ b/modules/cart/test/phpunit/CartHelperTest.class
@@ -28,6 +28,9 @@ GalleryCoreApi::requireOnce('modules/cart/classes/CartHelper.class');
  * @version $Revision: 17580 $
  */
 class CartHelperTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_saveCartItemCounts;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/cart/test/phpunit/ModifyCartControllerTest.class
+++ b/modules/cart/test/phpunit/ModifyCartControllerTest.class
@@ -28,6 +28,9 @@ GalleryCoreApi::requireOnce('modules/cart/classes/CartHelper.class');
  * @version $Revision: 17923 $
  */
 class ModifyCartControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_saveCartItemCounts;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'cart.ModifyCart');
 	}

--- a/modules/cart/test/phpunit/ViewCartViewTest.class
+++ b/modules/cart/test/phpunit/ViewCartViewTest.class
@@ -26,6 +26,11 @@
  * @version $Revision: 17580 $
  */
 class ViewCartViewTest extends GalleryViewTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_photoItem;
+	public $_movieItem;
+	public $_saveCartItemCounts;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'cart.ViewCart');
 	}

--- a/modules/comment/test/phpunit/AddCommentControllerTest.class
+++ b/modules/comment/test/phpunit/AddCommentControllerTest.class
@@ -28,6 +28,10 @@ GalleryCoreApi::requireOnce('modules/comment/classes/GalleryCommentHelper.class'
  * @version $Revision: 17580 $
  */
 class AddCommentControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_saveMarkup;
+	public $_startTime;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'comment.AddComment');
 	}

--- a/modules/comment/test/phpunit/AkismetApiTest.class
+++ b/modules/comment/test/phpunit/AkismetApiTest.class
@@ -30,6 +30,9 @@ GalleryCoreApi::requireOnce('modules/comment/classes/AkismetApi.class');
  * @version $Revision: 17989 $
  */
 class AkismetApiTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_akismet;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/comment/test/phpunit/CommentSearchTest.class
+++ b/modules/comment/test/phpunit/CommentSearchTest.class
@@ -27,6 +27,9 @@
  * @version $Revision: 17580 $
  */
 class CommentSearchTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_commentSearch;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/comment/test/phpunit/CommentSiteAdminControllerTest.class
+++ b/modules/comment/test/phpunit/CommentSiteAdminControllerTest.class
@@ -352,6 +352,9 @@ class CommentSiteAdminControllerTest extends GalleryControllerTestCase {
 }
 
 class CommentSiteAdminControllerTest_FakeAkismetApi {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_legal;
+
 	public function __construct($legal = false) {
 		$this->_legal = $legal;
 	}

--- a/modules/comment/test/phpunit/EditCommentControllerTest.class
+++ b/modules/comment/test/phpunit/EditCommentControllerTest.class
@@ -26,6 +26,11 @@
  * @version $Revision: 17580 $
  */
 class EditCommentControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_anonymousUserId;
+	public $_anonymousUser;
+	public $_saveMarkup;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'comment.EditComment');
 	}

--- a/modules/comment/test/phpunit/ShowAllCommentsViewTest.class
+++ b/modules/comment/test/phpunit/ShowAllCommentsViewTest.class
@@ -27,6 +27,9 @@
  * @version $Revision: 17679 $
  */
 class ShowAllCommentsViewTest extends GalleryViewTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_item2;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'comment.ShowAllComments');
 	}

--- a/modules/core/AdminMaintenance.inc
+++ b/modules/core/AdminMaintenance.inc
@@ -29,6 +29,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/helpers/MaintenanceHelper_simp
  */
 class AdminMaintenanceController extends GalleryController {
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $_module;
+
     /**
      * @see GalleryController::handleRequest
      */

--- a/modules/core/AdminRepository.inc
+++ b/modules/core/AdminRepository.inc
@@ -31,6 +31,9 @@ GalleryCoreApi::requireOnce(
  */
 class AdminRepositoryController extends AdminRepositoryDownloadAndInstallController {
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $_repositories;
+
     /**
      * Get the repositories, but allow tests to inject their own version.
      * @see GalleryRepository::getRepositories

--- a/modules/core/Callbacks.inc
+++ b/modules/core/Callbacks.inc
@@ -24,6 +24,9 @@
  * @version $Revision: 17580 $
  */
 class CoreCallbacks {
+    /* deprecated dynamic properties in php 8.2 */
+    var $_tpl_vars;
+
     function callback($params, &$smarty, $callback, $userId=null) {
 	global $gallery;
 	$block =& $smarty->_tpl_vars['block'];

--- a/modules/core/ItemAdd.inc
+++ b/modules/core/ItemAdd.inc
@@ -34,6 +34,16 @@ class ItemAddController extends GalleryController {
      */
     var $_optionInstances;
 
+    /* Deprecated dynamic properties in php 8.2 */
+    var $_coreModule;
+    var $_templateAdapter;
+    var $_storage;
+    var $_processingItemsMessage;
+    var $_extractionToolkitMap;
+    var $_processedItems;
+    var $_platform;
+    var $_extractingArchiveMessage;
+
     /**
      * Tests can use this method to hardwire a specific set of option instances to use.
      * This avoids situations where some of the option instances will do unpredictable

--- a/modules/core/classes/Gallery.class
+++ b/modules/core/classes/Gallery.class
@@ -167,6 +167,9 @@ class Gallery {
      */
     var $_phpVm = null;
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $_squareQueue;
+
 
     function __construct() {
 	$this->_activeUser = null;

--- a/modules/core/classes/GalleryDynamicAlbum.class
+++ b/modules/core/classes/GalleryDynamicAlbum.class
@@ -37,6 +37,9 @@ class GalleryDynamicAlbum extends GalleryItem {
      */
     var $_itemTypeName;
 
+    /* deprecate dynamic properties in php 8.2 */
+    var $urlParams;
+    var $getChildrenFunction;
 
     /**
      * Initialize dynamic album

--- a/modules/core/classes/GalleryPlatform.class
+++ b/modules/core/classes/GalleryPlatform.class
@@ -39,6 +39,11 @@ class GalleryPlatform {
 	'html', 'js', 'htm', 'shtml', 'vbs', 'dll', 'jsp' , 'cfm', 'reg', 'shtm', 'phtm', 'exe',
 	'bat', 'sh', 'cmd', 'install', 'pl', 'tcl', 'py', 'com', 'rb', 'asp', 'aspx', 'ascx');
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $_filePerms;
+    var $_dirPerms;
+    var $_umask;
+
     /**
      * Copy a file.
      * @param string $source the source file

--- a/modules/core/classes/GalleryPlatform/UnixPlatform.class
+++ b/modules/core/classes/GalleryPlatform/UnixPlatform.class
@@ -29,6 +29,10 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryPlatform.class');
  */
 class UnixPlatform extends GalleryPlatform {
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $_beNice;
+    var $_execExpectedStatus;
+
     /**
      * @see GalleryPlatform::exec
      */

--- a/modules/core/classes/GalleryRepositoryIndex.class
+++ b/modules/core/classes/GalleryRepositoryIndex.class
@@ -57,6 +57,9 @@ class GalleryRepositoryIndex {
      */
     var $_utilities;
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $utilities;
+
 
     function __construct($source) {
 	$this->_utilities = new GalleryRepositoryUtilities();

--- a/modules/core/classes/GallerySmarty.class
+++ b/modules/core/classes/GallerySmarty.class
@@ -42,6 +42,9 @@ class GallerySmarty extends Smarty {
      */
     var $_firstGalleryStatus;
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $_cache_include_info;
+
 
     /**
      * Fetch should also return a GalleryStatus object

--- a/modules/core/classes/GalleryStatus.class
+++ b/modules/core/classes/GalleryStatus.class
@@ -48,6 +48,8 @@ class GalleryStatus {
      */
     var $_errorMessage;
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $_stackTrace;
 
     /**
      * Constructor

--- a/modules/core/classes/GalleryStorage.class
+++ b/modules/core/classes/GalleryStorage.class
@@ -1138,14 +1138,14 @@ class GalleryStorage {
 	    $class = $regs[1];
 	    list ($table, $alias) = $this->_translateTableName($class);
 	    if ($alias == null) {
-		$query = str_replace("[${class}]", "$table", $query);
+		$query = str_replace("[{$class}]", "$table", $query);
 	    } else {
 		list ($ret, $as) = $this->getFunctionSql('AS', array());
 		if ($ret) {
 		    /* XXX TODO: propagate this back up as a GalleryStatus */
 		    return 'QUERY ERROR';
 		}
-		$query = str_replace("[${class}]", "$table $as $alias", $query);
+		$query = str_replace("[{$class}]", "$table $as $alias", $query);
 	    }
 	}
 

--- a/modules/core/classes/GalleryStorage.class
+++ b/modules/core/classes/GalleryStorage.class
@@ -1668,6 +1668,8 @@ function GalleryAdodbErrorHandler($dbms, $fn, $errno, $errmsg, $p1=false, $p2=fa
  * @subpackage Storage
  */
 class MySqlStorage extends GalleryStorage {
+    /* deprecated dynamic properties in php 8.2 */
+    var $_serverInfo;
 
     function __construct($config) {
 	parent::__construct($config);

--- a/modules/core/classes/GalleryStorage.class
+++ b/modules/core/classes/GalleryStorage.class
@@ -1125,11 +1125,11 @@ class GalleryStorage {
 
 	    $column = $this->_translateColumnName($member);
 	    if ($alias) {
-		$query = str_replace("[${class}::${member}]", "$alias.$column", $query);
+		$query = str_replace("[{$class}::{$member}]", "$alias.$column", $query);
 	    } else if ($class) {
-		$query = str_replace("[${class}::${member}]", "$table.$column", $query);
+		$query = str_replace("[{$class}::{$member}]", "$table.$column", $query);
 	    } else {
-		$query = str_replace("[::${member}]", "$column", $query);
+		$query = str_replace("[::{$member}]", "$column", $query);
 	    }
 	}
 

--- a/modules/core/classes/GalleryStorage/GalleryDatabaseImport.class
+++ b/modules/core/classes/GalleryStorage/GalleryDatabaseImport.class
@@ -137,6 +137,11 @@ class GalleryDatabaseImport extends GalleryImportElement {
      */
     var $_fileReadChunkSize = 8192;
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $_installedModuleVersion;
+    var $_installedCoreVersion;
+    var $_installedThemeVersion;
+
     function __construct() {
 	parent::__construct();
     }
@@ -743,6 +748,10 @@ class _GalleryRowTag extends GalleryImportElement {
 
     /** Holds the generated insert for this table */
     var $_currentSql;
+
+    /* deprecated dynamic properties in php 8.2 */
+    var $_fields;
+    var $_fieldNames;
 
     function __construct($parent, $tableName, $fields, $attributes) {
 	parent::__construct($parent);

--- a/modules/core/classes/GalleryStorage/GalleryStorageExtras.class
+++ b/modules/core/classes/GalleryStorage/GalleryStorageExtras.class
@@ -27,6 +27,9 @@
  * @version $Revision: 17988 $
  */
 class GalleryStorageExtras /* the other half of GalleryStorage */ {
+    /* deprecated dynamic properties in php 8.2 */
+    var $_gs;
+
     /**
      * @param GalleryStorage $galleryStorage the database storage instance
      */

--- a/modules/core/classes/GalleryStorage/PostgreSqlStorage.class
+++ b/modules/core/classes/GalleryStorage/PostgreSqlStorage.class
@@ -31,6 +31,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryStorage.class');
  */
 class PostgreSqlStorage extends GalleryStorage {
 
+    /* deprecated dynamic properties in php 8.2 */
+    public $_serverInfo;
+
     function __construct($config) {
     parent::__construct($config);
 	$this->_isTransactional = true;

--- a/modules/core/classes/GalleryTemplateAdapter.class
+++ b/modules/core/classes/GalleryTemplateAdapter.class
@@ -1050,7 +1050,7 @@ class GalleryTemplateAdapter {
 	    GalleryCoreApi::requireOnce("modules/$module/Callbacks.inc");
 
 	    $userId = $smarty->_tpl_vars['theme']['actingUserId'];
-	    $className = "${module}Callbacks";
+	    $className = "{$module}Callbacks";
 	    $class = new $className;
 	    $ret = $class->callback($params, $smarty, $file, $userId);
 	    if ($ret) {

--- a/modules/core/classes/GalleryTranslator.class
+++ b/modules/core/classes/GalleryTranslator.class
@@ -315,8 +315,8 @@ class GalleryTranslator {
 	if (function_exists('dgettext')) {
 	    $this->_isRightToLeft = isset($data['right-to-left']);
 	    /* Some systems only require LANG, some (like Mandrake) seem to require LANGUAGE also */
-	    putenv("LANG=${languageCode}");
-	    putenv("LANGUAGE=${languageCode}");
+	    putenv("LANG={$languageCode}");
+	    putenv("LANGUAGE={$languageCode}");
 
 	    GalleryTranslator::_setlocale(LC_ALL, $languageCode);
 	}
@@ -426,7 +426,7 @@ class GalleryTranslator {
 	    list ($supportedLanguages, $defaultCountry) = GalleryTranslator::getLanguageData();
 	}
 
-	list ($language, $country) = preg_split('/[-_]/', "${languageCode}_");
+	list ($language, $country) = preg_split('/[-_]/', "{$languageCode}_");
 	$country = GalleryUtilities::strToUpper($country);
 	if ((empty($country) || !isset($supportedLanguages[$language][$country]))
 		&& isset($defaultCountry[$language])) {
@@ -434,7 +434,7 @@ class GalleryTranslator {
 	    $country = $defaultCountry[$language];
 	}
 	if (isset($supportedLanguages[$language][$country])) {
-	    return array("${language}_${country}", $supportedLanguages[$language][$country]);
+	    return array("{$language}_{$country}", $supportedLanguages[$language][$country]);
 	}
 
 	if ($fallback) {

--- a/modules/core/classes/GalleryUnknownItem.class
+++ b/modules/core/classes/GalleryUnknownItem.class
@@ -40,6 +40,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryDataItem.class');
  */
 class GalleryUnknownItem extends GalleryDataItem {
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $parent;
+
     /**
      * Create a new GalleryUnknownItem from an image file
      *

--- a/modules/core/classes/GalleryUrlGenerator.class
+++ b/modules/core/classes/GalleryUrlGenerator.class
@@ -62,6 +62,13 @@ class GalleryUrlGenerator {
      */
     var $_path;
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $_hasRequestUriShortUrlPrefix;
+    var $_cookiePath;
+    var $_localUrlMap;
+    var $_localUrlMapDirty;
+    var $_rootItemId;
+
     /**
      * The host string of generated URLs (including optional port) eg. 'www.example.com'.
      *
@@ -129,6 +136,9 @@ class GalleryUrlGenerator {
      * @access private
      */
     var $_isCookiePathConfigured;
+
+    /* deprecated dynamic properties in php 8.2 */
+    var $_returnUrlData;
 
     /*
      * ****************************************

--- a/modules/core/classes/helpers/GalleryTranslatorHelper_medium.class
+++ b/modules/core/classes/helpers/GalleryTranslatorHelper_medium.class
@@ -37,13 +37,13 @@ class GalleryTranslatorHelper_medium {
 	$codeBase = GalleryCoreApi::getCodeBasePath();
 
 	$gallery->guaranteeTimeLimit(30);  /* the glob may take a long time */
-	$pluginPath = "$codeBase${pluginType}s/$pluginId/";
-	$moFilesInPoDir = $platform->glob("${pluginPath}po/*.mo");
+	$pluginPath = "$codeBase{$pluginType}s/$pluginId/";
+	$moFilesInPoDir = $platform->glob("{$pluginPath}po/*.mo");
 	if (!empty($moFilesInPoDir)) {
 	    $moFiles = $moFilesInPoDir;
 	    $codePattern = '#(\w+).mo$#';
 	} else {
-	    $moFiles = $platform->glob("${pluginPath}locale/*/LC_MESSAGES/*.mo");
+	    $moFiles = $platform->glob("{$pluginPath}locale/*/LC_MESSAGES/*.mo");
 	    $codePattern = '#locale/(\w+)/LC_MESSAGES#';
 	}
 
@@ -64,7 +64,7 @@ class GalleryTranslatorHelper_medium {
 		    return GalleryCoreApi::error(ERROR_PLATFORM_FAILURE);
 		}
 
-		$destinationPath = $destinationDir . "${pluginType}s_$pluginId.mo";
+		$destinationPath = $destinationDir . "{$pluginType}s_$pluginId.mo";
 		$success = $platform->copy($moPath, $destinationPath);
 		if (!$success) {
 		    return GalleryCoreApi::error(ERROR_PLATFORM_FAILURE);
@@ -83,7 +83,7 @@ class GalleryTranslatorHelper_medium {
 
 	$gallery->guaranteeTimeLimit(30);  /* the glob may take a long time */
 	$moFiles = $platform->glob($gallery->getConfig('data.gallery.locale')
-				   . "*/LC_MESSAGES/${pluginType}s_$pluginId.mo");
+				   . "*/LC_MESSAGES/{$pluginType}s_$pluginId.mo");
 	$success = true;
 	if (!empty($moFiles)) {
 	    foreach ($moFiles as $moPath) {

--- a/modules/core/module.inc
+++ b/modules/core/module.inc
@@ -26,6 +26,9 @@
  */
 class CoreModule extends GalleryModule {
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $_galleryVersion;
+
     function __construct() {
 	global $gallery;
 

--- a/modules/core/test/phpunit/AdminCoreControllerTest.class
+++ b/modules/core/test/phpunit/AdminCoreControllerTest.class
@@ -25,6 +25,9 @@
  * @version $Revision: 17630 $
  */
 class AdminCoreControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_valueMap;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.AdminCore');
 	}
@@ -690,6 +693,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryPlatform/UnixPlatform.c
 GalleryCoreApi::requireOnce('modules/core/classes/GalleryPlatform/WinNtPlatform.class');
 
 class AdminCoreControllerTestUnixPlatform extends UnixPlatform {
+        /* deprecated dynamic properties in php 8.2 */
+	public $_succeed;
+
 	public function __construct($succeed) {
 		$this->_succeed = $succeed;
 	}

--- a/modules/core/test/phpunit/AdminDeleteUserControllerTest.class
+++ b/modules/core/test/phpunit/AdminDeleteUserControllerTest.class
@@ -26,6 +26,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryDataCache.class');
  * @version $Revision: 17580 $
  */
 class AdminDeleteUserControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_userIds;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.AdminDeleteUser');
 	}

--- a/modules/core/test/phpunit/AdminEditGroupUsersControllerTest.class
+++ b/modules/core/test/phpunit/AdminEditGroupUsersControllerTest.class
@@ -25,6 +25,9 @@
  * @version $Revision: 17580 $
  */
 class AdminEditGroupUsersControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_group;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.AdminEditGroupUsers');
 	}

--- a/modules/core/test/phpunit/AdminLanguageManagerControllerTest.class
+++ b/modules/core/test/phpunit/AdminLanguageManagerControllerTest.class
@@ -28,6 +28,10 @@ GalleryCoreApi::requireOnce('modules/core/AdminLanguageManager.inc');
 class AdminLanguageManagerControllerTest extends GalleryControllerTestCase {
 	public $_galleryTemplateAdapter;
 
+	/* deprecated dynamic properties in php 8.2 */
+	public $_useBrowserPref;
+	public $_defaultLanguage;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.AdminLanguageManager');
 	}

--- a/modules/core/test/phpunit/AdminMaintenanceControllerModeTest.class
+++ b/modules/core/test/phpunit/AdminMaintenanceControllerModeTest.class
@@ -25,6 +25,11 @@
  * @version $Revision: 17580 $
  */
 class AdminMaintenanceControllerModeTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_versionFileContents;
+	public $_versionFile;
+	public $_versionContentsBase;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.AdminMaintenance');
 	}

--- a/modules/core/test/phpunit/AdminRepositoryDownloadAndInstallControllerTest.class
+++ b/modules/core/test/phpunit/AdminRepositoryDownloadAndInstallControllerTest.class
@@ -30,6 +30,9 @@ GalleryCoreApi::requireOnce(
 class AdminRepositoryDownloadAndInstallControllerTest extends GalleryControllerTestCase {
 	public $_galleryTemplateAdapter;
 
+	/* deprecated dynamic properties in php 8.2 */
+	public $_coreModule;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.AdminRepositoryDownloadAndInstall');
 	}
@@ -992,6 +995,9 @@ class AdminRepositoryDownloadAndInstallControllerTestWrapper extends AdminReposi
 }
 
 class AdminRepositoryDownloadAndInstallControllerTestPhpVm {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_class_exists;
+
 	public function __construct() {
 		$this->_class_exists = false;
 	}

--- a/modules/core/test/phpunit/AdminRepositoryDownloadControllerTest.class
+++ b/modules/core/test/phpunit/AdminRepositoryDownloadControllerTest.class
@@ -266,6 +266,9 @@ class AdminRepositoryDownloadControllerTestWrapper extends AdminRepositoryDownlo
 }
 
 class AdminRepositoryDownloadControllerTestPhpVm {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_class_exists;
+
 	public function __construct() {
 		$this->_class_exists = false;
 	}

--- a/modules/core/test/phpunit/AdminThemesControllerTest.class
+++ b/modules/core/test/phpunit/AdminThemesControllerTest.class
@@ -26,6 +26,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryTheme.class');
  * @version $Revision: 17580 $
  */
 class AdminThemesControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_testTheme;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.AdminThemes');
 	}
@@ -492,6 +495,9 @@ class TestThemeId2Theme extends GalleryTheme {
  * Test theme
  */
 class AdminThemesControllerTestTheme {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_callMap;
+
 	public static function getMe() {
 		static $instance;
 

--- a/modules/core/test/phpunit/AlbumTest.class
+++ b/modules/core/test/phpunit/AlbumTest.class
@@ -24,7 +24,9 @@
  * @author Bharat Mediratta <bharat@menalto.com>
  * @version $Revision: 17589 $
  */
-class AlbumTest extends GalleryTestCase{
+class AlbumTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $previousValueSlugMode;
 
 	public function setUpSlug($slugMode)
 	{

--- a/modules/core/test/phpunit/BuildDerivativesTaskTest.class
+++ b/modules/core/test/phpunit/BuildDerivativesTaskTest.class
@@ -134,6 +134,10 @@ class BuildDerivativesTaskTest extends GalleryTestCase {
 }
 
 class BuildDerivativesTaskTestStorage {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_storage;
+	public $_searches;
+
 	public function __construct($storage) {
 		$this->_storage  = $storage;
 		$this->_searches = array();

--- a/modules/core/test/phpunit/CharsetTest.class
+++ b/modules/core/test/phpunit/CharsetTest.class
@@ -816,6 +816,10 @@ class CharsetTest extends GalleryTestCase {
 }
 
 class CharsetTestPhpVm {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_function_exists;
+	public $_returns;
+
 	public function setFunctionExists($functionName, $bool) {
 		$this->_function_exists[$functionName] = $bool;
 	}

--- a/modules/core/test/phpunit/ChildTest.class
+++ b/modules/core/test/phpunit/ChildTest.class
@@ -25,6 +25,9 @@
  * @version $Revision: 17580 $
  */
 class ChildTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_rootHighlight;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/core/test/phpunit/CodeAuditTest.class
+++ b/modules/core/test/phpunit/CodeAuditTest.class
@@ -27,6 +27,18 @@
  * @version $Revision: 20940 $
  */
 class CodeAuditTest extends CodeAuditTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_shouldHalt;
+	public $_baseDir;
+	public $_checkTime;
+	public $_exception;
+	public $_longLineFiles;
+	public $_errorCount;
+	public $_lineEnding;
+	public $_phpEndFile;
+	public $_preamble;
+	public $_preamblePattern;
+
 	public function __construct($methodName) {
 		global $gallery;
 

--- a/modules/core/test/phpunit/ControllerTest.class
+++ b/modules/core/test/phpunit/ControllerTest.class
@@ -26,6 +26,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryController.class');
  * @version $Revision: 17788 $
  */
 class ControllerTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_originalIsPersistentSession;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/core/test/phpunit/CoreSearchTest.class
+++ b/modules/core/test/phpunit/CoreSearchTest.class
@@ -25,6 +25,9 @@
  * @version $Revision: 17580 $
  */
 class CoreSearchTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_coreSearch;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/core/test/phpunit/CreateThumbnailOptionTest.class
+++ b/modules/core/test/phpunit/CreateThumbnailOptionTest.class
@@ -26,6 +26,9 @@ GalleryCoreApi::requireOnce('lib/tools/phpunit/ItemAddOptionTestCase.class');
  * @version $Revision: 17580 $
  */
 class CreateThumbnailOptionTest extends ItemAddOptionTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_itemThumbnail;
+ 
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core', 'CreateThumbnailOption');
 	}

--- a/modules/core/test/phpunit/DataCacheTest.class
+++ b/modules/core/test/phpunit/DataCacheTest.class
@@ -1173,6 +1173,10 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryPhpVm.class');
  * Mock VM
  */
 class DataCacheTestMockVm extends GalleryPhpVm {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_time;
+	public $_randValue;
+
 	public function setTime($time) {
 		$this->_time = $time;
 	}

--- a/modules/core/test/phpunit/DatabaseExportTest.class
+++ b/modules/core/test/phpunit/DatabaseExportTest.class
@@ -27,6 +27,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryStorage.class');
  * @version $Revision: 17580 $
  */
 class DatabaseExportTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_export;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/core/test/phpunit/DatabaseImportTest.class
+++ b/modules/core/test/phpunit/DatabaseImportTest.class
@@ -27,6 +27,10 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryStorage.class');
  * @version $Revision: 20957 $
  */
 class DatabaseImportTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_testObj;
+	public $_xmlParser;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/core/test/phpunit/DatabaseStorageTest.class
+++ b/modules/core/test/phpunit/DatabaseStorageTest.class
@@ -26,6 +26,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryStorage/GalleryStorageE
  * @version $Revision: 17580 $
  */
 class DatabaseStorageTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_data;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/core/test/phpunit/DeleteSessionsTaskTest.class
+++ b/modules/core/test/phpunit/DeleteSessionsTaskTest.class
@@ -26,6 +26,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/DeleteSessionsTask.class');
  * @version $Revision: 17580 $
  */
 class DeleteSessionsTaskTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_core;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/core/test/phpunit/DerivativeTest.class
+++ b/modules/core/test/phpunit/DerivativeTest.class
@@ -1413,6 +1413,9 @@ class DerivativeTestToolkit extends GalleryToolkit {
  * Test item
  */
 class DerivativeTestItem extends GalleryDataItem {
+	/* deprecated dynamic properties in php 8.2 */
+	public $parent;
+
 	/**
 	 * @see GalleryEntity::getClassName
 	 */

--- a/modules/core/test/phpunit/EmbedTest.class
+++ b/modules/core/test/phpunit/EmbedTest.class
@@ -27,6 +27,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryEmbed.class');
  * @version $Revision: 17775 $
  */
 class EmbedTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_origGallery;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/core/test/phpunit/EventLogHelperTest.class
+++ b/modules/core/test/phpunit/EventLogHelperTest.class
@@ -25,6 +25,9 @@
  * @version $Revision: 17580 $
  */
 class EventLogHelperTest extends GalleryTestCase {
+	/* deprecated dynamic properties in ph 8.2 */
+	public $_location;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/core/test/phpunit/EventTest.class
+++ b/modules/core/test/phpunit/EventTest.class
@@ -293,6 +293,9 @@ class EventTestEventListener {
  * Mock platform.
  */
 class EventTestPlatform extends GalleryPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_list;
+
 	public function opendir($path) {
 		if (substr($path, -8) == 'modules/') {
 			$this->_list = array();

--- a/modules/core/test/phpunit/FastDownloadTest.class
+++ b/modules/core/test/phpunit/FastDownloadTest.class
@@ -25,6 +25,9 @@
  * @version $Revision: 17580 $
  */
 class FastDownloadTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_derivatives;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -412,6 +415,9 @@ class FastDownloadTest extends GalleryTestCase {
  * Fake platform that simulates writing to a file and captures the output
  */
 class FastDownloadTestCreateFastDownloadPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_buf;
+
 	public $_stat;
 
 	public function __construct(&$buf) {
@@ -460,6 +466,9 @@ class FastDownloadTestCreateFastDownloadPlatform {
  * Test platform to verify that we are deleting cache files
  */
 class FastDownloadTestRemovePermissionPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_buf;
+
 	public $_stat;
 
 	public function __construct(&$buf) {

--- a/modules/core/test/phpunit/FileSystemTest.class
+++ b/modules/core/test/phpunit/FileSystemTest.class
@@ -616,6 +616,9 @@ class FileSystemTest extends GalleryTestCase {
  * @subpackage PHPUnit
  */
 class FileSystemTestPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_separator;
+
 	public function __construct($separator) {
 		$this->_separator = $separator;
 	}
@@ -634,6 +637,9 @@ class FileSystemTestPlatform {
  * @subpackage PHPUnit
  */
 class FileSystemTestPlatformForRename extends GalleryPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_separator;
+
 	public function __construct($separator) {
 		$this->_separator = $separator;
 	}

--- a/modules/core/test/phpunit/FlushDatabaseCacheTaskTest.class
+++ b/modules/core/test/phpunit/FlushDatabaseCacheTaskTest.class
@@ -138,6 +138,9 @@ class FlushDatabaseCacheTaskTest extends GalleryTestCase {
 }
 
 class FlushDatabaseCacheTaskTestPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_failedCalls;
+
 	public function __construct($failedCalls) {
 		GalleryUtilities::putRequestVariable('calls', array());
 

--- a/modules/core/test/phpunit/FlushTemplatesTaskTest.class
+++ b/modules/core/test/phpunit/FlushTemplatesTaskTest.class
@@ -116,6 +116,9 @@ class FlushTemplatesTaskTest extends GalleryTestCase {
 }
 
 class FlushTemplatesTaskTestPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_failedCalls;
+
 	public function __construct($failedCalls) {
 		GalleryUtilities::putRequestVariable('calls', array());
 

--- a/modules/core/test/phpunit/ItemAddControllerTest.class
+++ b/modules/core/test/phpunit/ItemAddControllerTest.class
@@ -25,6 +25,9 @@
  * @version $Revision: 17580 $
  */
 class ItemAddControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamci properties in php 8.2 */
+	public $_templateAdapter;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.ItemAdd');
 	}
@@ -1152,6 +1155,9 @@ class ItemAddControllerTestPluginFail {
  * Test ItemAddOption
  */
 class ItemAddTestOption extends ItemAddOption {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_withError;
+
 	public function __construct($withError = false) {
 		$this->_withError                                = $withError;
 		$_SERVER['ItemAddControllerTest']['optionCalls'] = array();

--- a/modules/core/test/phpunit/ItemAddFromBrowserTest.class
+++ b/modules/core/test/phpunit/ItemAddFromBrowserTest.class
@@ -25,6 +25,11 @@
  * @version $Revision: 17580 $
  */
 class ItemAddFromBrowserTest extends ItemAddPluginTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_addController;
+	public $_rootAlbum;
+	public $_lockIds;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core', 'ItemAddFromBrowser');
 	}

--- a/modules/core/test/phpunit/ItemAttributesTest.class
+++ b/modules/core/test/phpunit/ItemAttributesTest.class
@@ -917,6 +917,11 @@ class ItemAttributesTestSession {
 	public $_userId;
 	public $_creationTime;
 
+	/* deprecated dynamic properties in php 8.2 */
+	public $_isPersistent;
+	public $_isSearchEngineSession;
+	public $_data;
+
 	public function __construct($isPersistent = true, $isSearchEngineSession = false) {
 		$this->_creationTime          = time();
 		$this->_isPersistent          = $isPersistent;
@@ -965,6 +970,11 @@ class ItemAttributesTestSession {
 }
 
 class ItemAttributesTestPhpVm extends GalleryPhpVm {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_getAllHeadersExists;
+	public $_headers;
+	public $_time;
+
 	public function __construct($getAllHeadersExists = false, $headers = array(), $time = null) {
 		$this->_getAllHeadersExists = $getAllHeadersExists;
 		$this->_headers             = $headers;

--- a/modules/core/test/phpunit/ItemEditAlbumPluginTest.class
+++ b/modules/core/test/phpunit/ItemEditAlbumPluginTest.class
@@ -27,6 +27,7 @@
 class ItemEditAlbumPluginTest extends ItemEditPluginTestCase {
 	/* deprecated dynamic properties in php 8.2 */
 	public $_childAlbum;
+	public $_grandchildAlbum;
 
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core', 'ItemEditAlbum');

--- a/modules/core/test/phpunit/ItemEditAlbumPluginTest.class
+++ b/modules/core/test/phpunit/ItemEditAlbumPluginTest.class
@@ -25,6 +25,9 @@
  * @version $Revision: 17580 $
  */
 class ItemEditAlbumPluginTest extends ItemEditPluginTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_childAlbum;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core', 'ItemEditAlbum');
 	}

--- a/modules/core/test/phpunit/ItemEditItemPluginTest.class
+++ b/modules/core/test/phpunit/ItemEditItemPluginTest.class
@@ -25,6 +25,9 @@
  * @version $Revision: 17580 $
  */
 class ItemEditItemPluginTest extends ItemEditPluginTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_thumbnail;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core', 'ItemEditItem');
 	}

--- a/modules/core/test/phpunit/ItemEditMoviePluginTest.class
+++ b/modules/core/test/phpunit/ItemEditMoviePluginTest.class
@@ -161,6 +161,9 @@ class ItemEditMoviePluginTest extends ItemEditPluginTestCase {
  * @subpackage PHPUnit
  */
 class ItemEditMoviePluginTestPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_platform;
+
 	public function __construct($originalPlatform) {
 		$this->_platform = $originalPlatform;
 	}

--- a/modules/core/test/phpunit/ItemEditPhotoPluginTest.class
+++ b/modules/core/test/phpunit/ItemEditPhotoPluginTest.class
@@ -25,6 +25,10 @@
  * @version $Revision: 17580 $
  */
 class ItemEditPhotoPluginTest extends ItemEditPluginTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_blob;
+	public $_unused;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core', 'ItemEditPhoto');
 	}

--- a/modules/core/test/phpunit/ItemEditPhotoThumbnailPluginTest.class
+++ b/modules/core/test/phpunit/ItemEditPhotoThumbnailPluginTest.class
@@ -25,6 +25,9 @@
  * @version $Revision: 17580 $
  */
 class ItemEditPhotoThumbnailPluginTest extends ItemEditPluginTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_item2;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core', 'ItemEditPhotoThumbnail');
 	}

--- a/modules/core/test/phpunit/ItemEditRotateAndScalePhotoPluginTest.class
+++ b/modules/core/test/phpunit/ItemEditRotateAndScalePhotoPluginTest.class
@@ -25,6 +25,10 @@
  * @version $Revision: 17580 $
  */
 class ItemEditRotateAndScalePhotoPluginTest extends ItemEditPluginTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_blob;
+	public $_blobDerivative;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core', 'ItemEditRotateAndScalePhoto');
 	}

--- a/modules/core/test/phpunit/ItemEditThemePluginTest.class
+++ b/modules/core/test/phpunit/ItemEditThemePluginTest.class
@@ -25,6 +25,11 @@
  * @version $Revision: 17580 $
  */
 class ItemEditThemePluginTest extends ItemEditPluginTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_childAlbum;
+	public $_grandchildAlbum;
+	public $_savedPlatform;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core', 'ItemEditTheme');
 	}
@@ -488,6 +493,9 @@ class ItemEditThemeControllerTestTheme {
  * Test platform
  */
 class ItemEditThemeTestPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_savedPlatform;
+
 	public function __construct($originalPlatform) {
 		$this->_savedPlatform = $originalPlatform;
 	}

--- a/modules/core/test/phpunit/ItemMakeHighlightControllerTest.class
+++ b/modules/core/test/phpunit/ItemMakeHighlightControllerTest.class
@@ -27,6 +27,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryToolkit.class');
  * @version $Revision: 17580 $
  */
 class ItemMakeHighlightControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_subalbum;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.ItemMakeHighlight');
 	}

--- a/modules/core/test/phpunit/ItemMoveSingleControllerTest.class
+++ b/modules/core/test/phpunit/ItemMoveSingleControllerTest.class
@@ -26,6 +26,11 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryToolkit.class');
  * @version $Revision: 17580 $
  */
 class ItemMoveSingleControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_childAlbum;
+	public $_rootAlbum;
+	public $_destinationAlbum;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.ItemMoveSingle');
 	}

--- a/modules/core/test/phpunit/ItemOrderTest.class
+++ b/modules/core/test/phpunit/ItemOrderTest.class
@@ -25,6 +25,10 @@
  * @version $Revision: 17580 $
  */
 class ItemOrderTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_parentItem;
+	public $_childItems;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/core/test/phpunit/ItemPermissionsControllerTest.class
+++ b/modules/core/test/phpunit/ItemPermissionsControllerTest.class
@@ -25,6 +25,11 @@
  * @version $Revision: 17580 $
  */
 class ItemPermissionsControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_albumParent;
+	public $_albumChild;
+	public $_group;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.ItemPermissions');
 	}

--- a/modules/core/test/phpunit/ItemTest.class
+++ b/modules/core/test/phpunit/ItemTest.class
@@ -25,6 +25,9 @@
  * @version $Revision: 17580 $
  */
 class ItemTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_groupId;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/core/test/phpunit/LanguageTest.class
+++ b/modules/core/test/phpunit/LanguageTest.class
@@ -25,6 +25,9 @@
  * @version $Revision: 17580 $
  */
 class LanguageTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_siteLanguage;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.ChangeLanguage');
 	}

--- a/modules/core/test/phpunit/LocalizationAuditTest.class
+++ b/modules/core/test/phpunit/LocalizationAuditTest.class
@@ -27,6 +27,11 @@
 class LocalizationAuditTest extends CodeAuditTestCase {
 	public $_idMap = array();
 
+	/* deprecated dynamic properties in php 8.2 */
+	public $_shouldHalt;
+	public $_baseDir;
+	public $_errorCount;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 

--- a/modules/core/test/phpunit/LockTest.class
+++ b/modules/core/test/phpunit/LockTest.class
@@ -27,6 +27,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/FlockLockSystem.class');
  * @version $Revision: 17580 $
  */
 class LockTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_subAlbums;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/core/test/phpunit/LogoutControllerTest.class
+++ b/modules/core/test/phpunit/LogoutControllerTest.class
@@ -25,6 +25,9 @@
  * @version $Revision: 18040 $
  */
 class LogoutControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_anonymousId;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.Logout');
 	}

--- a/modules/core/test/phpunit/MailHelperTest.class
+++ b/modules/core/test/phpunit/MailHelperTest.class
@@ -25,6 +25,12 @@
  * @version $Revision: 20940 $
  */
 class MailHelperTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $templateFile;
+	public $_originalPlatform;
+	public $_dummyPlatform;
+	public $_emailData;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -281,6 +287,9 @@ class MailHelperTest extends GalleryTestCase {
  * @subpackage PHPUnit
  */
 class MailHelperDummyPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_platform;
+
 	public function __construct($platform) {
 		$this->_platform         = $platform;
 		$_REQUEST['mailedCount'] = 0;

--- a/modules/core/test/phpunit/MarkupTest.class
+++ b/modules/core/test/phpunit/MarkupTest.class
@@ -27,6 +27,11 @@ GalleryCoreApi::requireOnce('lib/smarty_plugins/modifier.markup.php');
  * @version $Revision: 17580 $
  */
 class MarkupTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_bbcode;
+	public $_html;
+	public $_none;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/core/test/phpunit/ModuleTest.class
+++ b/modules/core/test/phpunit/ModuleTest.class
@@ -25,6 +25,10 @@
  * @version $Revision: 17580 $
  */
 class ModuleTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_removedDir;
+	public $_rootAlbum;
+
 	public function setUp($x1 = null) {
 		global $gallery;
 
@@ -933,6 +937,10 @@ class ModuleTestEntity extends GalleryEntity {
  * @subpackage PHPUnit
  */
 class ModuleTestPlatform extends GalleryPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_list;
+	public $_test;
+
 	public function __construct(&$test) {
 		$this->_test =& $test;
 	}

--- a/modules/core/test/phpunit/MovieTest.class
+++ b/modules/core/test/phpunit/MovieTest.class
@@ -25,6 +25,9 @@
  * @version $Revision: 17580 $
  */
 class MovieTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_movie;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/core/test/phpunit/OptimizeDatabaseTaskTest.class
+++ b/modules/core/test/phpunit/OptimizeDatabaseTaskTest.class
@@ -67,6 +67,9 @@ class OptimizeDatabaseTaskTest extends GalleryTestCase {
 }
 
 class OptimizeDatabaseTaskTestStorage {
+	/* deprecated dynanic properties in php 8.2 */
+	public $_optimizeWasCalled;
+
 	public function __construct() {
 		$this->_optimizeWasCalled = false;
 	}

--- a/modules/core/test/phpunit/Php43CompatibilityTest.class
+++ b/modules/core/test/phpunit/Php43CompatibilityTest.class
@@ -26,6 +26,12 @@
  * @version $Revision: 17580 $
  */
 class Php43CompatibilityTest extends CodeAuditTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_shouldHalt;
+	public $_baseDir;
+	public $_illegalRegexp;
+	public $_exceptions;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 

--- a/modules/core/test/phpunit/PhpDocAuditTest.class
+++ b/modules/core/test/phpunit/PhpDocAuditTest.class
@@ -25,6 +25,11 @@
  * @version $Revision: 17580 $
  */
 class PhpDocAuditTest extends CodeAuditTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_shouldHalt;
+	public $_baseDir;
+	public $_errorCount;
+
 	public $_packageMap = array();
 
 	public function __construct($methodName) {

--- a/modules/core/test/phpunit/PlatformTest.class
+++ b/modules/core/test/phpunit/PlatformTest.class
@@ -32,6 +32,14 @@ class PlatformTest extends GalleryTestCase {
 	 */
 	var $_platform = null;
 
+	/* deprecated dynamic properties in php 8.2 */
+	var $_saveVars;
+	var $_saveSID;
+	var $_rootAlbumId;
+	var $_sourceFile;
+	var $_destFile;
+	var $_mail;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -816,63 +824,63 @@ class PlatformTest extends GalleryTestCase {
 
 		$platform->setRealpathData(
 			array(
-				"${s}test${s}" => "${s}test",
-				"${s}testing"  => "${s}testing",
+				"{$s}test{$s}" => "{$s}test",
+				"{$s}testing"  => "{$s}testing",
 			)
 		);
 
-		$gallery->_phpVm = new PlatformTestPhpVm("${s}test${s}", $this);
+		$gallery->_phpVm = new PlatformTestPhpVm("{$s}test{$s}", $this);
 
-		$this->assertFalse($platform->isRestrictedByOpenBaseDir("${s}test"), 'no trailing slash');
+		$this->assertFalse($platform->isRestrictedByOpenBaseDir("{$s}test"), 'no trailing slash');
 		$this->assertTrue(
-			$platform->isRestrictedByOpenBaseDir("${s}testing"),
+			$platform->isRestrictedByOpenBaseDir("{$s}testing"),
 			'should not match basedir with trailing slash'
 		);
 
 		// Invalid paths (realpath returns false, our code does relative path and .. handling)
 		$platform->setRealpathData(
 			array(
-				"${s}test" => "${s}test",
+				"{$s}test" => "{$s}test",
 			)
 		);
 
-		$gallery->_phpVm = new PlatformTestPhpVm("${s}test", $this);
+		$gallery->_phpVm = new PlatformTestPhpVm("{$s}test", $this);
 
 		$this->assertTrue(
-			!$platform->isRestrictedByOpenBaseDir("${s}test${s}bogus"),
+			!$platform->isRestrictedByOpenBaseDir("{$s}test{$s}bogus"),
 			'valid bogus path'
 		);
 		$this->assertTrue(
-			!$platform->isRestrictedByOpenBaseDir("${s}test${s}bogus${s}..${s}path"),
+			!$platform->isRestrictedByOpenBaseDir("{$s}test{$s}bogus{$s}..{$s}path"),
 			'single dotdot'
 		);
 		$this->assertTrue(
-			$platform->isRestrictedByOpenBaseDir("${s}test${s}bogus${s}..${s}..${s}path"),
+			$platform->isRestrictedByOpenBaseDir("{$s}test{$s}bogus{$s}..{$s}..{$s}path"),
 			'multiple dotdots'
 		);
 		$this->assertTrue(
-			$platform->isRestrictedByOpenBaseDir("${s}test${s}.."),
+			$platform->isRestrictedByOpenBaseDir("{$s}test{$s}.."),
 			'dotdot at end'
 		);
 		$this->assertTrue(
-			!$platform->isRestrictedByOpenBaseDir("${s}.${s}test${s}bogus"),
+			!$platform->isRestrictedByOpenBaseDir("{$s}.{$s}test{$s}bogus"),
 			'dot in valid bogus path'
 		);
 		$this->assertTrue(
-			!$platform->isRestrictedByOpenBaseDir("${s}.${s}test${s}.${s}bogus"),
+			!$platform->isRestrictedByOpenBaseDir("{$s}.{$s}test{$s}.{$s}bogus"),
 			'two dots in valid bogus path'
 		);
-		$platform->setCwd("${s}test");
+		$platform->setCwd("{$s}test");
 		$this->assertTrue(
 			!$platform->isRestrictedByOpenBaseDir('bogus'),
 			'valid relative path'
 		);
 		$this->assertTrue(
-			$platform->isRestrictedByOpenBaseDir("..${s}bogus"),
+			$platform->isRestrictedByOpenBaseDir("..{$s}bogus"),
 			'invalid relative path'
 		);
 		$this->assertTrue(
-			!$platform->isRestrictedByOpenBaseDir("bogus${s}path${s}..${s}..${s}test"),
+			!$platform->isRestrictedByOpenBaseDir("bogus{$s}path{$s}..{$s}..{$s}test"),
 			'valid relative path with two dotdots'
 		);
 	}
@@ -914,7 +922,7 @@ class PlatformTest extends GalleryTestCase {
 		@$this->_platform->fclose($fd);
 	}
 
-	public function ignore_error_handler($errno, $errstr) {
+	public static function ignore_error_handler($errno, $errstr) {
 		return true;
 	}
 
@@ -1122,6 +1130,10 @@ class PlatformTest extends GalleryTestCase {
 }
 
 class PlatformTestPhpVm extends GalleryPhpVm {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_iniVal;
+	public $_test;
+
 	public function __construct($iniVal, &$test) {
 		$this->_iniVal = $iniVal;
 		$this->_test   =& $test;
@@ -1151,6 +1163,10 @@ class PlatformTestPhpVm extends GalleryPhpVm {
 GalleryCoreApi::requireOnce('modules/core/classes/GalleryPlatform/UnixPlatform.class');
 
 class PlatformTestOpenBaseDirUnixPlatform extends UnixPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_realpathData;
+	public $_cwd;
+
 	public function setRealpathData($realpathData) {
 		$this->_realpathData = $realpathData;
 	}

--- a/modules/core/test/phpunit/PluginCallbackTest.class
+++ b/modules/core/test/phpunit/PluginCallbackTest.class
@@ -26,6 +26,9 @@ GalleryCoreApi::requireOnce('modules/core/PluginCallback.inc');
  * @version $Revision: 17580 $
  */
 class PluginCallbackTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_testPlugin;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -1114,6 +1117,9 @@ class PluginCallbackTest extends GalleryTestCase {
 }
 
 class MockGalleryStatus {
+	/* deprecated dynamic properties in php 8.2 */
+	public $something;
+
 	public function __construct() {
 		// Put something in here so that empty($this) would not return true
 		$this->something = 1;
@@ -1142,6 +1148,10 @@ class MockGalleryStatus {
 }
 
 class PluginCallbackMockStorage {
+	/* deprecated dynamic properties in php 8.2 */
+	public $rolledBack;
+	public $checkPointed;
+
 	public function rollbackTransaction() {
 		$this->rolledBack = 1;
 
@@ -1156,6 +1166,9 @@ class PluginCallbackMockStorage {
 }
 
 class PluginCallbackWithFakeHandler extends PluginCallbackView {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_replies;
+
 	/**
 	 * Class Loader
 	 */

--- a/modules/core/test/phpunit/PluginParameterTest.class
+++ b/modules/core/test/phpunit/PluginParameterTest.class
@@ -104,7 +104,7 @@ class PluginParameterTest extends GalleryTestCase {
 				'module',
 				'unitTestModule',
 				$key,
-				"${value}-$i"
+				"{$value}-$i"
 			);
 
 			if ($ret) {
@@ -118,7 +118,7 @@ class PluginParameterTest extends GalleryTestCase {
 			return $ret;
 		}
 
-		$this->assertEquals("${value}-2", $newValue);
+		$this->assertEquals("{$value}-2", $newValue);
 	}
 
 	public function testFetchAllParameters() {
@@ -131,8 +131,8 @@ class PluginParameterTest extends GalleryTestCase {
 			$ret = GalleryCoreApi::setPluginParameter(
 				'module',
 				'unitTestModule',
-				"${key}-$i",
-				"${value}-$i"
+				"{$key}-$i",
+				"{$value}-$i"
 			);
 
 			if ($ret) {
@@ -147,7 +147,7 @@ class PluginParameterTest extends GalleryTestCase {
 		}
 
 		for ($i = 0; $i < 3; $i++) {
-			$this->assertEquals("${value}-$i", $newValues["${key}-$i"]);
+			$this->assertEquals("{$value}-$i", $newValues["{$key}-$i"]);
 		}
 	}
 
@@ -162,7 +162,7 @@ class PluginParameterTest extends GalleryTestCase {
 				'module',
 				'unitTestModule',
 				$key,
-				"${value}-$i",
+				"{$value}-$i",
 				$i
 			);
 
@@ -178,7 +178,7 @@ class PluginParameterTest extends GalleryTestCase {
 				return $ret;
 			}
 
-			$this->assertEquals("${value}-$i", $newValue);
+			$this->assertEquals("{$value}-$i", $newValue);
 		}
 	}
 

--- a/modules/core/test/phpunit/PluginTest.class
+++ b/modules/core/test/phpunit/PluginTest.class
@@ -329,6 +329,11 @@ class PluginTest extends GalleryTestCase {
 class PluginTestCompatibleModule extends GalleryModule {}
 
 class PluginTestPlugin extends GalleryPlugin {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_type;
+	public $_requiredThemeApi;
+	public $_requiredModuleApi;
+
 	public function setPluginType($type) {
 		$this->_type = $type;
 	}

--- a/modules/core/test/phpunit/RepositoryDownloadPackagesTest.class
+++ b/modules/core/test/phpunit/RepositoryDownloadPackagesTest.class
@@ -26,6 +26,12 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryRepositoryUtilities.cla
  * @version $Revision: 17580 $
  */
 class RepositoryDownloadPackagesTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_repository;
+	public $_descriptor;
+	public $_templateAdapter;
+	public $_versions;
+
 	public function setUp($x1 = null) {
 		$ret = parent::setUp();
 

--- a/modules/core/test/phpunit/RepositoryUtilitiesTest.class
+++ b/modules/core/test/phpunit/RepositoryUtilitiesTest.class
@@ -29,6 +29,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryTheme.class');
  * @version $Revision: 17666 $
  */
 class RepositoryUtilitiesTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_apis;
+
 	public function setUp($x1 = null) {
 		$ret = parent::setUp();
 
@@ -1454,6 +1457,9 @@ class RepositoryUtilitiesTest extends GalleryTestCase {
 }
 
 class RepositoryUtilitiesTestPhpVm extends GalleryPhpVm {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_gzinflateExists;
+
 	public function __construct($gzinflateExists) {
 		$this->_gzinflateExists = $gzinflateExists;
 	}

--- a/modules/core/test/phpunit/SessionTest.class
+++ b/modules/core/test/phpunit/SessionTest.class
@@ -28,6 +28,12 @@ GalleryCoreApi::requireOnce('modules/core/classes/GallerySession.class');
  * @version $Revision: 18136 $
  */
 class SessionTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_saveStorage;
+	public $_saveServerVars;
+	public $_anonymousUserId;
+	public $_sessionIds;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -4459,6 +4465,10 @@ class SessionTest extends GalleryTestCase {
 }
 
 class SessionTestPhpVm extends GalleryPhpVm {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_randValue;
+	public $_timeValue;
+
 	public function __construct($md5Override = array(), $timeValue = null, $randValue = null) {
 		$_REQUEST['md5Override'] = $md5Override;
 		$this->_randValue        = $randValue;
@@ -4499,6 +4509,17 @@ class SessionTestPhpVm extends GalleryPhpVm {
 }
 
 class SessionTestStorage {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_query;
+	public $_data;
+	public $_options;
+	public $_addMapEntry;
+	public $_updateMapEntry;
+	public $_collisions;
+	public $_execute;
+	public $_type;
+	public $_searchResults;
+
 	public function __construct($collisions = 0, $results = array(), $type = 'foo') {
 		$this->_query          = array();
 		$this->_data           = array();
@@ -4551,6 +4572,10 @@ class SessionTestStorage {
 }
 
 class SessionTestRecordSet {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_results;
+	public $_i;
+
 	public function __construct($results = array()) {
 		$this->_results = $results;
 		$this->_i       = 0;

--- a/modules/core/test/phpunit/SimpleCallbackTest.class
+++ b/modules/core/test/phpunit/SimpleCallbackTest.class
@@ -25,6 +25,12 @@
  * @version $Revision: 18157 $
  */
 class SimpleCallbackTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_users;
+	public $_tag;
+	public $_groupNames;
+	public $_userNames;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/core/test/phpunit/StorageTest.class
+++ b/modules/core/test/phpunit/StorageTest.class
@@ -35,6 +35,11 @@ class StorageTest extends GalleryTestCase {
 	// results on the non transactional db connection
 	public $_resultsNonTransactional;
 
+	/* deprecated dynamic properties in php 8.2 */
+	public $_isEmptyAllowedForNotNullColumn;
+	public $_serverInfo;
+	public $_nonTransactionalDb;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -1798,6 +1803,9 @@ class StorageTestDB {
 	public $transCnt = 1;
 	public $_recordSets;
 
+	/* deprecated dynamic properties in php 8.2 */
+	public $_results;
+
 	public function __construct(&$testCase, $resultsType) {
 		$this->_testCase   =& $testCase;
 		$this->_results    =& $testCase->$resultsType;
@@ -1835,6 +1843,9 @@ class StorageTestDB {
 
 class StorageTestRecordSet {
 	public $_rows;
+
+	/* deprecated dynamic properties in php 8.2 */
+	public $_recordCount;
 
 	public function __construct($rows = array()) {
 		$this->_rows        = $rows;

--- a/modules/core/test/phpunit/SvnAuditTest.class
+++ b/modules/core/test/phpunit/SvnAuditTest.class
@@ -25,6 +25,12 @@
  * @version $Revision: 17580 $
  */
 class SvnAuditTest extends CodeAuditTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_exceptions;
+	public $_shouldHalt;
+	public $_baseDir;
+	public $_errorCount;
+
 	public function __construct($methodName) {
 		global $gallery;
 
@@ -107,11 +113,11 @@ class SvnAuditTest extends CodeAuditTestCase {
 	public function checkFile($fileName, $buffer) {
 		$slash     = $this->_platform->getDirectorySeparator();
 		$base      = basename($fileName);
-		$propsFile = dirname($fileName) . "${slash}.svn${slash}props${slash}${base}.svn-work";
+		$propsFile = dirname($fileName) . "{$slash}.svn{$slash}props{$slash}{$base}.svn-work";
 
 		if (!$this->_platform->file_exists($propsFile)) {
 			// svn 1.4.x does not write .svn-work unless local prop changes are made
-			$propsFile = dirname($fileName) . "${slash}.svn${slash}prop-base${slash}${base}.svn-base";
+			$propsFile = dirname($fileName) . "{$slash}.svn{$slash}prop-base{$slash}{$base}.svn-base";
 		}
 
 		$g2Path = str_replace($this->_baseDir . '/', '', $fileName);

--- a/modules/core/test/phpunit/TemplateAdapterTest.class
+++ b/modules/core/test/phpunit/TemplateAdapterTest.class
@@ -32,6 +32,11 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryTemplateAdapter.class')
  * @version $Revision: 20957 $
  */
 class TemplateAdapterTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_mockUrlGenerator;
+	public $_mockSmarty;
+	public $_templateAdapter;
+
 	public function GalleryTemplateAdapterTest($methodName) {
 		parent::__construct($methodName);
 	}
@@ -1033,6 +1038,9 @@ class TemplateAdapterMockTheme {
 
 class TemplateAdapterMockSmarty {
 	public $_includes = array();
+
+	/* deprecated dynamic properties in php 8.2 */
+	public $_tpl_vars;
 
 	public function _smarty_include($params) {
 		$this->_includes[] = $params;

--- a/modules/core/test/phpunit/TemplateAuditTest.class
+++ b/modules/core/test/phpunit/TemplateAuditTest.class
@@ -26,6 +26,19 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryTemplate.class');
  * @version $Revision: 20940 $
  */
 class TemplateAuditTest extends CodeAuditTestCase {
+	/* deprecated dynamic properties */
+	public $_shouldHalt;
+	public $_baseDir;
+	public $_lineEnding;
+	public $_revisionPattern;
+	public $_revisionPlaceHolder;
+	public $_headerPattern;
+	public $_headerLines;
+	public $_expectedHeaderLines;
+	public $_exceptions;
+	public $_exception;
+	public $_errorCount;
+
 	public function __construct($methodName) {
 		global $gallery;
 

--- a/modules/core/test/phpunit/TemplateTest.class
+++ b/modules/core/test/phpunit/TemplateTest.class
@@ -26,6 +26,12 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryTemplate.class');
  * @version $Revision: 17950 $
  */
 class TemplateTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_mockSmarty;
+	public $_baseDirOverride;
+	public $_origPlatform;
+	public $_mockPlatform;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -564,6 +570,9 @@ class TemplateTest extends GalleryTestCase {
 }
 
 class TemplateTestMockPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_returns;
+
 	public function set($func, $filename, $return) {
 		$this->_returns[$func][$filename] = $return;
 	}
@@ -582,6 +591,10 @@ class TemplateTestMockPlatform {
 }
 
 class TemplateTestMockSmarty {
+	/* deprecated dynamic properties in php 8.2 */
+	public $template_dir;
+	public $_tpl_vars;
+
 	public function __construct() {
 		$this->template_dir = '/legal/path';
 		$this->_tpl_vars    = array(

--- a/modules/core/test/phpunit/ThemeTest.class
+++ b/modules/core/test/phpunit/ThemeTest.class
@@ -27,6 +27,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryTemplate.class');
  * @version $Revision: 17580 $
  */
 class ThemeTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_theme;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -661,6 +664,9 @@ class ThemeTest extends GalleryTestCase {
  * Test theme
  */
 class ThemeTestTheme extends GalleryTheme {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_preloadedBlocks;
+
 	public function __construct() {
 		global $gallery;
 
@@ -690,6 +696,9 @@ class ThemeTestView extends GalleryView {}
  * Test platform for this test
  */
 class ThemeTestPlatform extends GalleryPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_list;
+
 	public function opendir($path) {
 		if (strpos($path, 'themes/') !== false) {
 			$this->_list = array();

--- a/modules/core/test/phpunit/TranslatorTest.class
+++ b/modules/core/test/phpunit/TranslatorTest.class
@@ -512,14 +512,14 @@ class TranslatorTest extends GalleryTestCase {
 		$gallery->setConfig('data.gallery.locale', '/g2data/locale/');
 
 		$modulePath = GalleryCoreApi::getCodeBasePath('modules/TranslatorTest/');
-		$poPath     = "${modulePath}po/";
+		$poPath     = "{$modulePath}po/";
 
-		$platform->setReply('glob', array("${poPath}*.mo", null), array("${poPath}aa.mo"));
+		$platform->setReply('glob', array("{$poPath}*.mo", null), array("{$poPath}aa.mo"));
 		$platform->setReply('file_exists', array('/g2data/locale/aa/LC_MESSAGES/'), true);
 		$platform->setReply('is_dir', array('/g2data/locale/aa/LC_MESSAGES/'), true);
 		$platform->setReply(
 			'copy',
-			array("${poPath}aa.mo", '/g2data/locale/aa/LC_MESSAGES/modules_TranslatorTest.mo'),
+			array("{$poPath}aa.mo", '/g2data/locale/aa/LC_MESSAGES/modules_TranslatorTest.mo'),
 			true
 	);
 		$gallery->setPlatform($platform);
@@ -541,19 +541,19 @@ class TranslatorTest extends GalleryTestCase {
 		$gallery->setConfig('data.gallery.locale', '/g2data/locale/');
 
 		$modulePath = GalleryCoreApi::getCodeBasePath('modules/TranslatorTest/');
-		$poPath     = "${modulePath}po/";
+		$poPath     = "{$modulePath}po/";
 
-		$platform->setReply('glob', array("${poPath}*.mo", null), array());
+		$platform->setReply('glob', array("{$poPath}*.mo", null), array());
 		$platform->setReply(
 			'glob',
-			array("${modulePath}locale/*/LC_MESSAGES/*.mo", null),
-			array("${modulePath}locale/aa/LC_MESSAGES/aa.mo")
+			array("{$modulePath}locale/*/LC_MESSAGES/*.mo", null),
+			array("{$modulePath}locale/aa/LC_MESSAGES/aa.mo")
 	);
 		$platform->setReply('file_exists', array('/g2data/locale/aa/LC_MESSAGES/'), true);
 		$platform->setReply('is_dir', array('/g2data/locale/aa/LC_MESSAGES/'), true);
 		$platform->setReply(
 			'copy',
-			array("${modulePath}locale/aa/LC_MESSAGES/aa.mo",
+			array("{$modulePath}locale/aa/LC_MESSAGES/aa.mo",
 		  '/g2data/locale/aa/LC_MESSAGES/modules_TranslatorTest.mo', ),
 			true
 	);
@@ -576,9 +576,9 @@ class TranslatorTest extends GalleryTestCase {
 		$gallery->setConfig('data.gallery.locale', '/g2data/locale/');
 
 		$modulePath = GalleryCoreApi::getCodeBasePath('modules/TranslatorTest/');
-		$poPath     = "${modulePath}po/";
+		$poPath     = "{$modulePath}po/";
 
-		$platform->setReply('glob', array("${poPath}*.mo", null), array("${poPath}aa.mo"));
+		$platform->setReply('glob', array("{$poPath}*.mo", null), array("{$poPath}aa.mo"));
 
 		// This next block is what GalleryUtilities::guaranteeDirExists requires
 		$platform->setReply('file_exists', array('/g2data/locale/aa/LC_MESSAGES/'), false);
@@ -647,8 +647,8 @@ class TranslatorTest extends GalleryTestCase {
 
 		$platform->setReply(
 			'glob',
-			array("${codeBase}modules/*/po", null),
-			array("${codeBase}modules/test/po")
+			array("{$codeBase}modules/*/po", null),
+			array("{$codeBase}modules/test/po")
 	);
 		$platform->setReply(
 			'file_exists',
@@ -657,7 +657,7 @@ class TranslatorTest extends GalleryTestCase {
 	);
 		$platform->setReply(
 			'file_exists',
-			array("${codeBase}modules/test/po/wx_YZ.mo"),
+			array("{$codeBase}modules/test/po/wx_YZ.mo"),
 			false
 	);
 		$platform->setReply(
@@ -667,7 +667,7 @@ class TranslatorTest extends GalleryTestCase {
 	);
 		$platform->setReply(
 			'file_exists',
-			array("${codeBase}modules/test/po/wx.mo"),
+			array("{$codeBase}modules/test/po/wx.mo"),
 			true
 	);
 
@@ -681,14 +681,14 @@ class TranslatorTest extends GalleryTestCase {
 		$platform->setReply('mkdir', array('/g2data/locale/wx/LC_MESSAGES/', 755), true);
 		$platform->setReply(
 			'copy',
-			array("${codeBase}modules/test/po/wx.mo",
+			array("{$codeBase}modules/test/po/wx.mo",
 			  '/g2data/locale/wx/LC_MESSAGES/modules_test.mo', ),
 			true
 	);
 		$platform->setReply(
 			'glob',
-			array("${codeBase}themes/*/po", null),
-			array("${codeBase}themes/matrix/po")
+			array("{$codeBase}themes/*/po", null),
+			array("{$codeBase}themes/matrix/po")
 	);
 		$platform->setReply(
 			'file_exists',
@@ -697,7 +697,7 @@ class TranslatorTest extends GalleryTestCase {
 	);
 		$platform->setReply(
 			'file_exists',
-			array("${codeBase}themes/matrix/po/wx_YZ.mo"),
+			array("{$codeBase}themes/matrix/po/wx_YZ.mo"),
 			false
 	);
 		$platform->setReply(
@@ -732,8 +732,8 @@ class TranslatorTest extends GalleryTestCase {
 
 			$platform->setReply(
 				'glob',
-				array("${codeBase}modules/*/po", null),
-				array("${codeBase}modules/test/po")
+				array("{$codeBase}modules/*/po", null),
+				array("{$codeBase}modules/test/po")
 		);
 			$platform->setReply(
 				'file_exists',
@@ -745,7 +745,7 @@ class TranslatorTest extends GalleryTestCase {
 				array("/g2data/locale/$language/LC_MESSAGES/modules_test.mo"),
 				true
 		);
-			$platform->setReply('glob', array("${codeBase}themes/*/po", null), array());
+			$platform->setReply('glob', array("{$codeBase}themes/*/po", null), array());
 		}
 
 		$gallery->setPlatform($platform);

--- a/modules/core/test/phpunit/UrlGeneratorTest.class
+++ b/modules/core/test/phpunit/UrlGeneratorTest.class
@@ -28,6 +28,9 @@ class UrlGeneratorTest extends GalleryTestCase {
 	public $_urlGenerator;
 	public $_savedGet;
 
+	/* deprecated dynamic properties in php 8.2 */
+	public $_origEmbed;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/core/test/phpunit/UserHelperTest.class
+++ b/modules/core/test/phpunit/UserHelperTest.class
@@ -27,6 +27,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/helpers/GalleryUserHelper_medi
  * @version $Revision: 17608 $
  */
 class UserHelperTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_originalStorage;
+
 	public function setUp($x1 = null) {
 		global $gallery;
 
@@ -484,6 +487,10 @@ class UserHelperTestMockStorage {
  * Fake search results class, pretends to extend GallerySearchResults
  */
 class UserHelperTestMockStorageFakeResults {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_count;
+	public $_lastAttempt;
+
 	public function __construct($count, $lastAttempt = null) {
 		$this->_count       = $count;
 		$this->_lastAttempt = $lastAttempt;
@@ -532,6 +539,10 @@ class UserHelperTestPhpVm {
  * Mock Session
  */
 class UserHelperTestSession {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_regenerateWasCalled;
+	public $_sessionData;
+
 	public function __construct() {
 		$this->_regenerateWasCalled = false;
 	}

--- a/modules/core/test/phpunit/UserLoginControllerTest.class
+++ b/modules/core/test/phpunit/UserLoginControllerTest.class
@@ -28,6 +28,12 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryTemplate.class');
  * @version $Revision: 17924 $
  */
 class UserLoginControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_exitCalls;
+	public $_headers;
+	public $_validationLevel;
+	public $_originalLoginRedirect;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.UserLogin');
 	}
@@ -673,6 +679,10 @@ class UserLoginControllerTest extends GalleryControllerTestCase {
  * Mock ValidationPlugin
  */
 class UserLoginControllerTestPlugin extends GalleryValidationPlugin {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_errors;
+	public $_continue;
+
 	public function setContinue($continue) {
 		$this->_continue = $continue;
 	}
@@ -690,6 +700,11 @@ class UserLoginControllerTestPlugin extends GalleryValidationPlugin {
  * Mock session
  */
 class UserLoginControllerTestSession {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_sessionData;
+	public $_regenerateWasCalled;
+	public $_hash;
+
 	public function __construct() {
 		$this->_regenerateWasCalled = false;
 		$this->_hash                = array();
@@ -740,6 +755,10 @@ class UserLoginControllerTestSession {
  * Mock PHP VM
  */
 class UserLoginTestPhpVm {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_test;
+	public $_headersSent;
+
 	public function __construct(&$test, $headersSent = false) {
 		$this->_test             =& $test;
 		$this->_headersSent      = $headersSent;

--- a/modules/core/test/phpunit/UserPreferencesControllerTest.class
+++ b/modules/core/test/phpunit/UserPreferencesControllerTest.class
@@ -25,6 +25,9 @@
  * @version $Revision: 17627 $
  */
 class UserPreferencesControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_currentLanguage;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.UserPreferences');
 	}

--- a/modules/core/test/phpunit/UserRecoverPasswordAdminControllerTest.class
+++ b/modules/core/test/phpunit/UserRecoverPasswordAdminControllerTest.class
@@ -25,6 +25,10 @@
  * @version $Revision: 17580 $
  */
 class UserRecoverPasswordAdminControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_admin;
+	public $_savedAdminPassword;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.UserRecoverPasswordAdmin');
 	}
@@ -431,6 +435,10 @@ class UserRecoverPasswordAdminControllerTest extends GalleryControllerTestCase {
 }
 
 class UserRecoverPasswordAdminDummyPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_authFileValue;
+	public $_platform;
+
 	public function __construct($platform, $authFileValue) {
 		$this->_platform      = $platform;
 		$this->_authFileValue = $authFileValue;

--- a/modules/core/test/phpunit/UserRecoverPasswordConfirmControllerTest.class
+++ b/modules/core/test/phpunit/UserRecoverPasswordConfirmControllerTest.class
@@ -25,6 +25,9 @@
  * @version $Revision: 17580 $
  */
 class UserRecoverPasswordConfirmControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_hashedPassword;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.UserRecoverPasswordConfirm');
 	}

--- a/modules/core/test/phpunit/UserRecoverPasswordControllerTest.class
+++ b/modules/core/test/phpunit/UserRecoverPasswordControllerTest.class
@@ -27,6 +27,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/helpers/UserRecoverPasswordHel
  * @version $Revision: 17580 $
  */
 class UserRecoverPasswordControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_authData;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'core.UserRecoverPassword');
 	}
@@ -719,6 +722,10 @@ class UserRecoverPasswordControllerTest extends GalleryControllerTestCase {
  * Mock ValidationPlugin
  */
 class UserRecoverPasswordControllerTestPlugin extends GalleryValidationPlugin {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_errors;
+	public $_continue;
+
 	public function setContinue($continue) {
 		$this->_continue = $continue;
 	}
@@ -737,6 +744,9 @@ class UserRecoverPasswordControllerTestPlugin extends GalleryValidationPlugin {
  * @subpackage PHPUnit
  */
 class RecoverDummyPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_platform;
+
 	public function __construct($platform) {
 		$this->_platform = $platform;
 	}
@@ -826,6 +836,9 @@ class RecoverDummyPlatform {
 }
 
 class RecoverPasswordControllerPhpVm {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_md5;
+
 	public function setMd5($string) {
 		$this->_md5 = $string;
 	}

--- a/modules/core/test/phpunit/UtilitiesTest.class
+++ b/modules/core/test/phpunit/UtilitiesTest.class
@@ -25,6 +25,12 @@
  * @version $Revision: 17580 $
  */
 class UtilitiesTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_saveCookie;
+	public $_saveServerHttpCookie;
+	public $_mkdir;
+	public $_responseHeaders;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -2546,6 +2552,9 @@ class UtilitiesTest extends GalleryTestCase {
 }
 
 class UtilitiesTestPlatform {
+	/* deprecatced dynamic properties in php 8.2 */
+	public $_testCase;
+
 	public function __construct(&$testCase) {
 		$this->_testCase =& $testCase;
 	}

--- a/modules/core/test/phpunit/ViewTest.class
+++ b/modules/core/test/phpunit/ViewTest.class
@@ -1176,6 +1176,12 @@ class ViewTestThemeId2Theme {
 }
 
 class ViewTestEventListener {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_themeId;
+	public $_params;
+	public $_testCase;
+	public $_itemId;
+
 	public function __construct($testCase, $themeId, $params, $itemId) {
 		$this->_themeId  = $themeId;
 		$this->_params   = $params;

--- a/modules/core/test/phpunit/WebTest.class
+++ b/modules/core/test/phpunit/WebTest.class
@@ -27,6 +27,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryTheme.class');
  * @version $Revision: 20940 $
  */
 class WebTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_outputFile;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -569,6 +572,11 @@ class WebTest extends GalleryTestCase {
  * Mock platform
  */
 class WebTestPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_fileBuffer;
+	public $_testCase;
+	public $_readBuffer;
+
 	public function __construct(&$testCase) {
 		$this->_testCase   =& $testCase;
 		$this->_readBuffer = array();

--- a/modules/dynamicalbum/UpdatesAlbum.inc
+++ b/modules/dynamicalbum/UpdatesAlbum.inc
@@ -27,6 +27,13 @@
  */
 class UpdatesAlbumView extends GalleryView {
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $_view;
+    var $_title;
+    var $_itemType;
+    var $_viewDescription;
+    var $_param;
+
     function __construct() {
 	global $gallery;
 	$this->_view = 'dynamicalbum.UpdatesAlbum';

--- a/modules/dynamicalbum/test/phpunit/DynamicAlbumSiteAdminControllerTest.class
+++ b/modules/dynamicalbum/test/phpunit/DynamicAlbumSiteAdminControllerTest.class
@@ -27,6 +27,9 @@
  * @version $Revision: 17580 $
  */
 class DynamicAlbumSiteAdminControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_defaultThemeId;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'dynamicalbum.DynamicAlbumSiteAdmin');
 	}

--- a/modules/dynamicalbum/test/phpunit/DynamicAlbumTest.class
+++ b/modules/dynamicalbum/test/phpunit/DynamicAlbumTest.class
@@ -27,6 +27,12 @@
  * @version $Revision: 17580 $
  */
 class DynamicAlbumTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_updatesView;
+	public $_popularView;
+	public $_randomView;
+	public $_class;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/exif/test/phpunit/ExifExtractorTest.class
+++ b/modules/exif/test/phpunit/ExifExtractorTest.class
@@ -28,6 +28,10 @@
  * @version $Revision: 17580 $
  */
 class ExifExtractorTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_photoIds;
+	public $_exif;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/exif/test/phpunit/ExifHelperTest.class
+++ b/modules/exif/test/phpunit/ExifHelperTest.class
@@ -49,6 +49,9 @@ GalleryCoreApi::requireOnce('modules/exif/classes/ExifHelper.class');
 class ExifHelperTest extends GalleryTestCase {
 	public $_save = array();
 
+	/* deprecated dynamic properties in php 8.2 */
+	public $_saveFormat;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/ffmpeg/module.inc
+++ b/modules/ffmpeg/module.inc
@@ -64,16 +64,16 @@ class FfmpegModule extends GalleryModule {
 	}
 
 	$slash = $platform->getDirectorySeparator();
-	$imageDir = $gallery->getConfig('data.gallery.plugins_data') . "modules${slash}ffmpeg";
+	$imageDir = $gallery->getConfig('data.gallery.plugins_data') . "modules{$slash}ffmpeg";
 	list ($success) = GalleryUtilities::guaranteeDirExists($imageDir);
 	if (!$success) {
 	    return GalleryCoreApi::error(ERROR_PLATFORM_FAILURE, __FILE__, __LINE__,
 					"Unable to create directory: $imageDir");
 	}
 
-	$imageFile = "$imageDir${slash}filmreel.png";
+	$imageFile = "$imageDir{$slash}filmreel.png";
 	if (!$platform->is_file($imageFile) &&
-	    !$platform->copy(dirname(__FILE__) . "${slash}images${slash}filmreel.png",
+	    !$platform->copy(dirname(__FILE__) . "{$slash}images{$slash}filmreel.png",
 			     $imageFile)) {
 	    return GalleryCoreApi::error(ERROR_PLATFORM_FAILURE, __FILE__, __LINE__,
 					"Unable to copy filmreel.png to $imageDir");

--- a/modules/ffmpeg/test/phpunit/AdminFfmpegControllerTest.class
+++ b/modules/ffmpeg/test/phpunit/AdminFfmpegControllerTest.class
@@ -26,6 +26,11 @@
  * @version $Revision: 17614 $
  */
 class AdminFfmpegControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public array $_thumbnailOps;
+	public $_movie;
+	public $_thumbnail;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'ffmpeg.AdminFfmpeg');
 	}

--- a/modules/ffmpeg/test/phpunit/FfmpegToolkitTest.class
+++ b/modules/ffmpeg/test/phpunit/FfmpegToolkitTest.class
@@ -29,6 +29,9 @@ GalleryCoreApi::requireOnce('modules/ffmpeg/classes/FfmpegToolkit.class');
  * @version $Revision: 17614 $
  */
 class FfmpegToolkitTest extends GalleryTestCase {
+	/* deprecated dynamic properties php 8.2 */
+	public $_chmodWasCalled;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -649,6 +652,10 @@ class FfmpegToolkitTest extends GalleryTestCase {
  * @subpackage PHPUnit
  */
 class FfmpegToolkitTestPlatform {
+	/* deprecated dynamic properties in ph 8.2 */
+	public $_test;
+	public $_ffmpegPath;
+
 	public function init(&$test) {
 		$this->_test                   =& $test;
 		list($ret, $this->_ffmpegPath) = GalleryCoreApi::getPluginParameter(

--- a/modules/gd/test/phpunit/GdToolkitTest.class
+++ b/modules/gd/test/phpunit/GdToolkitTest.class
@@ -36,6 +36,9 @@ class GdToolkitTest extends GalleryTestCase {
 
 	public $_oldBase;
 
+	/* deprecated dynamic properties in php 8.2 */
+	public $_gdFunctionality;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 

--- a/modules/gd/test/phpunit/TestGdFunctionality.class
+++ b/modules/gd/test/phpunit/TestGdFunctionality.class
@@ -38,6 +38,9 @@ class TestGdFunctionality {
 	public $_resources;
 	public $_outputFiles;
 
+	/* deprecated dynamic properties in php 8.2 */
+	public $_counter;
+
 	public function __construct() {
 	}
 

--- a/modules/icons/test/phpunit/IconsTest.class
+++ b/modules/icons/test/phpunit/IconsTest.class
@@ -29,6 +29,10 @@ GalleryCoreApi::requireOnce('modules/icons/classes/IconsImpl.class');
  * @version $Revision: 17580 $
  */
 class IconsTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_icons;
+	public $_saveRtl;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/imagemagick/classes/ImageMagickToolkitHelper.class
+++ b/modules/imagemagick/classes/ImageMagickToolkitHelper.class
@@ -233,7 +233,7 @@ class ImageMagickToolkitHelper {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
 	$slash = $platform->getDirectorySeparator();
-	$dataPath = dirname(dirname(__FILE__)) . "${slash}data${slash}";
+	$dataPath = dirname(dirname(__FILE__)) . "{$slash}data{$slash}";
 
 	if (empty($imageMagickPath)) {
 	    list ($ret, $imageMagickPath) =
@@ -339,7 +339,7 @@ class ImageMagickToolkitHelper {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
 	$slash = $platform->getDirectorySeparator();
-	$dataPath = dirname(dirname(__FILE__)) . "${slash}data${slash}";
+	$dataPath = dirname(dirname(__FILE__)) . "{$slash}data{$slash}";
 
 	/*
 	 * If the path is not restricted by open_basedir, then verify that it's legal.
@@ -651,7 +651,7 @@ class ImageMagickToolkitHelper {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
 	$slash = $platform->getDirectorySeparator();
-	$dataPath = dirname(dirname(__FILE__)) . "${slash}data${slash}";
+	$dataPath = dirname(dirname(__FILE__)) . "{$slash}data{$slash}";
 
 	list ($ret, $convertCmd) =
 	    ImageMagickToolkitHelper::getCommand('convert', $imageMagickPath);
@@ -693,7 +693,7 @@ class ImageMagickToolkitHelper {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
 	$slash = $platform->getDirectorySeparator();
-	$dataPath = dirname(dirname(__FILE__)) . "${slash}data${slash}";
+	$dataPath = dirname(dirname(__FILE__)) . "{$slash}data{$slash}";
 
 	list ($ret, $convertCmd) =
 	    ImageMagickToolkitHelper::getCommand('convert', $imageMagickPath);

--- a/modules/imagemagick/test/phpunit/AdminImageMagickControllerTest.class
+++ b/modules/imagemagick/test/phpunit/AdminImageMagickControllerTest.class
@@ -25,6 +25,11 @@
  * @version $Revision: 17580 $
  */
 class AdminImageMagickControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_cmykSupport;
+	public $_ranIdentify;
+	public $_slash;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'imagemagick.AdminImageMagick');
 	}
@@ -149,7 +154,7 @@ class AdminImageMagickControllerTest extends GalleryControllerTestCase {
 
 		// Use valid inputs
 		GalleryUtilities::putRequestVariable('form[action][save]', 1);
-		GalleryUtilities::putRequestVariable('form[path]', "${slash}validPathBadBinaries${slash}");
+		GalleryUtilities::putRequestVariable('form[path]', "{$slash}validPathBadBinaries{$slash}");
 		GalleryUtilities::putRequestVariable('form[jpegQuality]', '12');
 		GalleryUtilities::putRequestVariable('form[cmykSupport]', $this->_cmykSupport);
 
@@ -174,7 +179,7 @@ class AdminImageMagickControllerTest extends GalleryControllerTestCase {
 
 		// Use valid inputs
 		GalleryUtilities::putRequestVariable('form[action][save]', 1);
-		GalleryUtilities::putRequestVariable('form[path]', "${slash}invalidPath${slash}");
+		GalleryUtilities::putRequestVariable('form[path]', "{$slash}invalidPath{$slash}");
 		GalleryUtilities::putRequestVariable('form[jpegQuality]', '12');
 		GalleryUtilities::putRequestVariable('form[cmykSupport]', $this->_cmykSupport);
 
@@ -224,7 +229,7 @@ class AdminImageMagickControllerTest extends GalleryControllerTestCase {
 
 		// Use valid inputs
 		GalleryUtilities::putRequestVariable('form[action][save]', 1);
-		GalleryUtilities::putRequestVariable('form[path]', "${slash}vulnerablePath${slash}");
+		GalleryUtilities::putRequestVariable('form[path]', "{$slash}vulnerablePath{$slash}");
 		GalleryUtilities::putRequestVariable('form[jpegQuality]', '80');
 		GalleryUtilities::putRequestVariable('form[cmykSupport]', $this->_cmykSupport);
 
@@ -302,6 +307,10 @@ class AdminImageMagickControllerTest extends GalleryControllerTestCase {
  * @subpackage PHPUnit
  */
 class AdminImageMagickControllerTestPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_unitTest;
+	public $_platform;
+
 	public function __construct($originalPlatform, &$unitTest) {
 		$this->_platform = $originalPlatform;
 		$this->_unitTest =& $unitTest;
@@ -311,16 +320,16 @@ class AdminImageMagickControllerTestPlatform {
 		$slash = $this->getDirectorySeparator();
 
 		switch ($path) {
-			case "${slash}validPath":
-			case "${slash}validPath${slash}":
-			case "${slash}validPath${slash}identify":
-			case "${slash}validPath${slash}convert":
-			case "${slash}vulnerablePath":
-			case "${slash}vulnerablePath${slash}":
-			case "${slash}vulnerablePath${slash}identify":
-			case "${slash}vulnerablePath${slash}convert":
-			case "${slash}validPathBadBinaries":
-			case "${slash}validPathBadBinaries${slash}":
+			case "{$slash}validPath":
+			case "{$slash}validPath{$slash}":
+			case "{$slash}validPath{$slash}identify":
+			case "{$slash}validPath{$slash}convert":
+			case "{$slash}vulnerablePath":
+			case "{$slash}vulnerablePath{$slash}":
+			case "{$slash}vulnerablePath{$slash}identify":
+			case "{$slash}vulnerablePath{$slash}convert":
+			case "{$slash}validPathBadBinaries":
+			case "{$slash}validPathBadBinaries{$slash}":
 				return true;
 		}
 
@@ -331,9 +340,9 @@ class AdminImageMagickControllerTestPlatform {
 		$slash = $this->getDirectorySeparator();
 
 		switch ($dir) {
-			case "${slash}validPath${slash}":
-			case "${slash}vulnerablePath${slash}":
-			case "${slash}validPathBadBinaries${slash}":
+			case "{$slash}validPath{$slash}":
+			case "{$slash}vulnerablePath{$slash}":
+			case "{$slash}validPathBadBinaries{$slash}":
 				return true;
 		}
 
@@ -364,7 +373,7 @@ class AdminImageMagickControllerTestPlatform {
 		$slash = $this->getDirectorySeparator();
 
 		switch ($args[0][0]) {
-			case "${slash}validPath${slash}identify":
+			case "{$slash}validPath{$slash}identify":
 				$this->_unitTest->_ranIdentify++;
 
 				return array(
@@ -372,7 +381,7 @@ class AdminImageMagickControllerTestPlatform {
 					empty($args[0][1]) ? array('Version: ImageMagick 6.3.3-5') : array('test.gif GIF 50x50+0+0 PseudoClass 8c 8-bit 232.0 0.000u 0:01'),
 				);
 
-			case "${slash}vulnerablePath${slash}identify":
+			case "{$slash}vulnerablePath{$slash}identify":
 				$this->_unitTest->_ranIdentify++;
 
 				return array(
@@ -380,12 +389,12 @@ class AdminImageMagickControllerTestPlatform {
 					empty($args[0][1]) ? array('Version: ImageMagick 6.1.3') : array('test.gif GIF 50x50+0+0 PseudoClass 8c 8-bit 232.0 0.000u 0:01'),
 				);
 
-			case "${slash}validPath${slash}convert":
-			case "${slash}vulnerablePath${slash}convert":
+			case "{$slash}validPath{$slash}convert":
+			case "{$slash}vulnerablePath{$slash}convert":
 				return array(1, array());
 
-			case "${slash}validPath${slash}composite":
-			case "${slash}vulnerablePath${slash}composite":
+			case "{$slash}validPath{$slash}composite":
+			case "{$slash}vulnerablePath{$slash}composite":
 				return array(1, array());
 
 			default:

--- a/modules/imagemagick/test/phpunit/ImageMagickToolkitTest.class
+++ b/modules/imagemagick/test/phpunit/ImageMagickToolkitTest.class
@@ -33,6 +33,9 @@ class ImageMagickToolkitTest extends GalleryTestCase
 	// The current environment array item we are processing
 	public $_currentEnvironment = array();
 
+	/* deprecated dynamic properties in php 8.2 */
+	public $_chmodWasCalled;
+
 	/*
 	 * Information about files in our pseudo-platform.
 	 * Better would be to store the files information in the Platform, but
@@ -1415,6 +1418,12 @@ class ImageMagickToolkitTestPlatform
 {
 	public $_environment = array();
 	public $_files;
+
+	/* deprecated dynamic properties in php 8.2 */
+	public $_counter;
+	public $_copyOk;
+	public $_platform;
+	public $_test;
 
 	public function __construct($originalPlatform, &$files, &$test)
 	{

--- a/modules/itemadd/ItemAddFromServer.inc
+++ b/modules/itemadd/ItemAddFromServer.inc
@@ -27,6 +27,21 @@
  */
 class ItemAddFromServer extends ItemAddPlugin {
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $_platform;
+    var $_dirSep;
+    var $_templateAdapter;
+    var $_storage;
+    var $_addController;
+    var $_addingItemsMessage;
+    var $_fileCountMessage;
+    var $_totalItems;
+    var $_lastPostProcessed;
+    var $_addedItems;
+    var $_progressBatch;
+    var $_processBatch;
+    var $_localServerDirList;
+
     /**
      * @see ItemAddPlugin::isAppropriate
      */

--- a/modules/itemadd/test/phpunit/ItemAddFromServerTest.class
+++ b/modules/itemadd/test/phpunit/ItemAddFromServerTest.class
@@ -26,6 +26,14 @@
  * @version $Revision: 18162 $
  */
 class ItemAddFromServerTest extends ItemAddPluginTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_addController;
+	public $_rootAlbum;
+	public $_lockId;
+	public $_symlinkAllowedPlatform;
+	public $_symlinkDisallowedPlatform;
+	public $_baseDir;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'itemadd', 'ItemAddFromServer');
 	}
@@ -716,6 +724,13 @@ class ItemAddFromServerTest extends ItemAddPluginTestCase {
  * Test platform
  */
 class ItemAddFromServerTestPlatform extends GalleryPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_delegate;
+	public $_dirSep;
+	public $_symlinkSupported;
+	public $_baseDir;
+	public $_baseDirRecursive;
+
 	public function __construct($delegate, $symlinkSupported) {
 		$this->_delegate         = $delegate;
 		$dirSep                  = $this->_dirSep                  = $delegate->getDirectorySeparator();

--- a/modules/itemadd/test/phpunit/ItemAddFromWebTest.class
+++ b/modules/itemadd/test/phpunit/ItemAddFromWebTest.class
@@ -37,6 +37,16 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryUnknownItem.class');
  * @version $Revision: 20940 $
  */
 class ItemAddFromWebTest extends ItemAddPluginTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_addController;
+	public $_outputFile;
+	public $_lockIds;
+	public $_session;
+	public $_saveRecentUrls;
+	public $_photo;
+	public $_movie;
+	public $_audio;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'itemadd', 'ItemAddFromWeb');
 	}
@@ -831,6 +841,10 @@ class ItemAddFromWebTest extends ItemAddPluginTestCase {
  * @subpackage PHPUnit
  */
 class ItemAddFromWebTestPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_readBuffer;
+	public $_testCase;
+
 	public function __construct(&$testCase) {
 		$this->_testCase = $testCase;
 	}

--- a/modules/itemadd/test/phpunit/ItemAddSiteAdminControllerTest.class
+++ b/modules/itemadd/test/phpunit/ItemAddSiteAdminControllerTest.class
@@ -592,6 +592,9 @@ class ItemAddSiteAdminControllerTest extends GalleryControllerTestCase {
  * @subpackage PHPUnit
  */
 class ItemAddSiteAdminControllerTestPhpVm extends GalleryPhpVm {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_iniVal;
+
 	public function __construct($iniVal) {
 		$this->_iniVal = $iniVal;
 	}

--- a/modules/jpegtran/classes/JpegtranToolkitHelper.class
+++ b/modules/jpegtran/classes/JpegtranToolkitHelper.class
@@ -94,7 +94,7 @@ class JpegtranToolkitHelper {
 	global $gallery;
 	$platform =& $gallery->getPlatform();
 	$slash = $platform->getDirectorySeparator();
-	$dataPath = dirname(dirname(__FILE__)) . "${slash}data${slash}";
+	$dataPath = dirname(dirname(__FILE__)) . "{$slash}data{$slash}";
 
 	/*
 	 * If the path is not restricted by open_basedir, then verify that it's legal.  Else just

--- a/modules/jpegtran/test/phpunit/JpegtranToolkitTest.class
+++ b/modules/jpegtran/test/phpunit/JpegtranToolkitTest.class
@@ -29,6 +29,10 @@ GalleryCoreApi::requireOnce('modules/jpegtran/classes/JpegtranToolkit.class');
  * @version $Revision: 17580 $
  */
 class JpegtranToolkitTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_chmodWasCalled;
+	public $_jpegtranPath;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -386,6 +390,13 @@ class JpegtranToolkitTest extends GalleryTestCase {
  * @subpackage PHPUnit
  */
 class JpegtranToolkitTestPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_envId;
+	public $_test;
+	public $_testFile;
+	public $_jpegtranPath;
+	public $_chdirCount;
+
 	public function __construct(&$test, $jpegtranPath) {
 		$this->_test         =& $test;
 		$this->_testFile     = dirname(dirname(__DIR__)) . '/data/test.jpg';

--- a/modules/keyalbum/test/phpunit/KeywordAlbumCallbacksTest.class
+++ b/modules/keyalbum/test/phpunit/KeywordAlbumCallbacksTest.class
@@ -29,6 +29,9 @@ GalleryCoreApi::requireOnce('modules/keyalbum/Callbacks.inc');
  * @version $Revision: 17580 $
  */
 class KeywordAlbumCallbacksTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_originalGuestUserId;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -766,6 +769,10 @@ class KeywordAlbumCallbacksTest extends GalleryTestCase {
  * Mock storage for callbacks tests.
  */
 class KeywordAlbumCallbacksTestStorage {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_storage;
+	public $_queries;
+
 	public function __construct($storage, $queries) {
 		// Avoid weird reference thing in php4 that makes _extras->_gs point to mock storage
 		$storage->_extras = null;

--- a/modules/keyalbum/test/phpunit/KeywordAlbumSiteAdminControllerTest.class
+++ b/modules/keyalbum/test/phpunit/KeywordAlbumSiteAdminControllerTest.class
@@ -27,6 +27,9 @@
  * @version $Revision: 17580 $
  */
 class KeywordAlbumSiteAdminControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_defaultThemeId;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'keyalbum.KeywordAlbumSiteAdmin');
 	}

--- a/modules/linkitem/module.inc
+++ b/modules/linkitem/module.inc
@@ -53,7 +53,7 @@ class LinkItemModule extends GalleryModule /* and GalleryEventListener */ {
 					 "Unable to create directory: $imageDir");
 	}
 
-	$imageFile = "$imageDir${slash}arrow.png";
+	$imageFile = "$imageDir{$slash}arrow.png";
 	if (!$platform->is_file($imageFile) &&
 	    !$platform->copy(dirname(__FILE__) . "{$slash}images{$slash}arrow.png", $imageFile)) {
 	    return GalleryCoreApi::error(ERROR_PLATFORM_FAILURE, __FILE__, __LINE__,

--- a/modules/linkitem/module.inc
+++ b/modules/linkitem/module.inc
@@ -46,7 +46,7 @@ class LinkItemModule extends GalleryModule /* and GalleryEventListener */ {
 	$platform =& $gallery->getPlatform();
 	$slash = $platform->getDirectorySeparator();
 
-	$imageDir = $gallery->getConfig('data.gallery.plugins_data') . "modules${slash}linkitem";
+	$imageDir = $gallery->getConfig('data.gallery.plugins_data') . "modules{$slash}linkitem";
 	list ($success) = GalleryUtilities::guaranteeDirExists($imageDir);
 	if (!$success) {
 	    return GalleryCoreApi::error(ERROR_PLATFORM_FAILURE, __FILE__, __LINE__,
@@ -55,7 +55,7 @@ class LinkItemModule extends GalleryModule /* and GalleryEventListener */ {
 
 	$imageFile = "$imageDir${slash}arrow.png";
 	if (!$platform->is_file($imageFile) &&
-	    !$platform->copy(dirname(__FILE__) . "${slash}images${slash}arrow.png", $imageFile)) {
+	    !$platform->copy(dirname(__FILE__) . "{$slash}images{$slash}arrow.png", $imageFile)) {
 	    return GalleryCoreApi::error(ERROR_PLATFORM_FAILURE, __FILE__, __LINE__,
 					 "Unable to copy arrow.png to $imageDir");
 	}

--- a/modules/linkitem/test/phpunit/ItemAddLinkItemTest.class
+++ b/modules/linkitem/test/phpunit/ItemAddLinkItemTest.class
@@ -26,6 +26,10 @@
  * @version $Revision: 17580 $
  */
 class ItemAddLinkItemTest extends ItemAddPluginTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_addController;
+	public $_lockId;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'linkitem', 'ItemAddLinkItem');
 	}

--- a/modules/linkitem/test/phpunit/LinkItemOptionTest.class
+++ b/modules/linkitem/test/phpunit/LinkItemOptionTest.class
@@ -28,6 +28,9 @@ GalleryCoreApi::requireOnce('lib/tools/phpunit/ItemEditOptionTestCase.class');
  * @version $Revision: 17580 $
  */
 class LinkItemOptionTest extends ItemEditOptionTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_link;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'linkitem', 'LinkItemOption');
 	}

--- a/modules/linkitem/test/phpunit/LinkItemTest.class
+++ b/modules/linkitem/test/phpunit/LinkItemTest.class
@@ -26,6 +26,10 @@
  * @version $Revision: 17580 $
  */
 class LinkItemTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_lockId;
+	public $_link;
+
 	public function setUp($x1 = null) {
 		$ret = parent::setUp();
 

--- a/modules/netpbm/test/phpunit/AdminNetPbmControllerTest.class
+++ b/modules/netpbm/test/phpunit/AdminNetPbmControllerTest.class
@@ -257,6 +257,9 @@ class AdminNetPbmControllerTest extends GalleryControllerTestCase {
  * @subpackage PHPUnit
  */
 class AdminNetPbmControllerTestPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_platform;
+
 	public function __construct($originalPlatform) {
 		$this->_platform = $originalPlatform;
 	}

--- a/modules/netpbm/test/phpunit/NetPbmToolkitTest.class
+++ b/modules/netpbm/test/phpunit/NetPbmToolkitTest.class
@@ -31,6 +31,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryPlatform/WinNtPlatform.
  * @version $Revision: 17580 $
  */
 class NetPbmToolkitTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_chmodWasCalled;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -1085,6 +1088,13 @@ class NetPbmToolkitTest extends GalleryTestCase {
  * @subpackage PHPUnit
  */
 class NetPbmToolkitTestPlatform extends WinNtPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_counter;
+	public $_platform;
+	public $_test;
+	public $_netPbmPath;
+	public $_jheadPath;
+
 	public function __construct($platform, &$test) {
 		$this->_platform = $platform;
 		$this->_test     =& $test;

--- a/modules/newitems/test/phpunit/NewItemsSiteAdminControllerTest.class
+++ b/modules/newitems/test/phpunit/NewItemsSiteAdminControllerTest.class
@@ -29,6 +29,9 @@ GalleryCoreApi::requireOnce('modules/newitems/classes/NewItemsHelper.class');
  * @version $Revision: 17580 $
  */
 class NewItemsSiteAdminControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_newItemSortIds;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'newitems.NewItemsSiteAdmin');
 	}

--- a/modules/rating/test/phpunit/RatingCallbacksTest.class
+++ b/modules/rating/test/phpunit/RatingCallbacksTest.class
@@ -29,6 +29,9 @@ GalleryCoreApi::requireOnce('modules/rating/Callbacks.inc');
  * @version $Revision: 17580 $
  */
 class RatingCallbacksTest extends GalleryTestCase {
+	/* deprecated dynamic properties in ph 8.2 */
+	public $_authToken;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/rating/test/phpunit/RatingHelperTest.class
+++ b/modules/rating/test/phpunit/RatingHelperTest.class
@@ -30,6 +30,9 @@ GalleryCoreApi::requireOnce('modules/rating/classes/RatingHelper.class');
  * @version $Revision: 17580 $
  */
 class RatingHelperTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_users;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/rating/test/phpunit/RatingOptionTest.class
+++ b/modules/rating/test/phpunit/RatingOptionTest.class
@@ -26,6 +26,9 @@
  * @version $Revision: 17580 $
  */
 class RatingOptionTest extends ItemEditOptionTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_childAlbum;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'rating', 'RatingItemEdit');
 	}

--- a/modules/rearrange/test/phpunit/RearrangeItemsControllerTest.class
+++ b/modules/rearrange/test/phpunit/RearrangeItemsControllerTest.class
@@ -26,6 +26,9 @@
  * @version $Revision: 17580 $
  */
 class RearrangeItemsControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_childIds;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'rearrange.RearrangeItems');
 	}

--- a/modules/register/UserSelfRegistration.inc
+++ b/modules/register/UserSelfRegistration.inc
@@ -27,6 +27,9 @@
  */
 class UserSelfRegistrationController extends GalleryController {
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $_pluginInstances;
+
     /**
      * @see GalleryController::handleRequest
      */

--- a/modules/register/test/phpunit/AdminSelfRegistrationControllerTest.class
+++ b/modules/register/test/phpunit/AdminSelfRegistrationControllerTest.class
@@ -28,6 +28,9 @@
 class AdminSelfRegistrationControllerTest extends GalleryControllerTestCase {
 	public $paramNames;
 
+	/* deprecated dynamic properties in php 8.2 */
+	public $_pendingUser;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'register.AdminSelfRegistration');
 	}

--- a/modules/register/test/phpunit/UserSelfRegistrationControllerTest.class
+++ b/modules/register/test/phpunit/UserSelfRegistrationControllerTest.class
@@ -756,7 +756,8 @@ class RegisterDummyPlatform {
 /**
  * Mock ValidationPlugin
  */
-class UserSelfRegistrationControllerTestPlugin extends GalleryValidationPlugin {	/* deprecated dynamic properties in php 8.2 */
+class UserSelfRegistrationControllerTestPlugin extends GalleryValidationPlugin {
+	/* deprecated dynamic properties in php 8.2 */
 	public $_emailBody;
 	public $_errors;
 	public $_continue;

--- a/modules/register/test/phpunit/UserSelfRegistrationControllerTest.class
+++ b/modules/register/test/phpunit/UserSelfRegistrationControllerTest.class
@@ -29,6 +29,10 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryValidationPlugin.class'
  * @version $Revision: 18057 $
  */
 class UserSelfRegistrationControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_emailBody;
+	public $_emailSubject;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'register.UserSelfRegistration');
 	}
@@ -659,6 +663,10 @@ class UserSelfRegistrationControllerTest extends GalleryControllerTestCase {
 }
 
 class RegisterDummyPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_test;
+	public $_platform;
+
 	public function __construct($platform, &$test) {
 		$this->_platform = $platform;
 		$this->_test     =& $test;
@@ -748,7 +756,11 @@ class RegisterDummyPlatform {
 /**
  * Mock ValidationPlugin
  */
-class UserSelfRegistrationControllerTestPlugin extends GalleryValidationPlugin {
+class UserSelfRegistrationControllerTestPlugin extends GalleryValidationPlugin {	/* deprecated dynamic properties in php 8.2 */
+	public $_emailBody;
+	public $_errors;
+	public $_continue;
+
 	public function setContinue($continue) {
 		$this->_continue = $continue;
 	}

--- a/modules/rewrite/classes/RewriteUrlGenerator.class
+++ b/modules/rewrite/classes/RewriteUrlGenerator.class
@@ -43,6 +43,9 @@ class RewriteUrlGenerator extends GalleryUrlGenerator {
      */
     var $_shortUrls = array();
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $_language;
+
     /**
      * Return first short URL to match URL params.
      * @param array $params URL params

--- a/modules/rewrite/classes/parsers/isapirewrite/IsapiRewriteUrlGenerator.class
+++ b/modules/rewrite/classes/parsers/isapirewrite/IsapiRewriteUrlGenerator.class
@@ -29,6 +29,8 @@ GalleryCoreApi::requireOnce('modules/rewrite/classes/RewriteUrlGenerator.class')
  * @version $Revision: 17580 $
  */
 class IsapiRewriteUrlGenerator extends RewriteUrlGenerator {
+    /* deprecated dynamic properties in php 8.2 */
+    var $_rootItemId;
 
     /**
      * @see GalleryUrlGenerator::init

--- a/modules/rewrite/classes/parsers/pathinfo/PathInfoUrlGenerator.class
+++ b/modules/rewrite/classes/parsers/pathinfo/PathInfoUrlGenerator.class
@@ -46,6 +46,9 @@ class PathInfoUrlGenerator extends RewriteUrlGenerator {
      */
     var $_piFile;
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $_baseUrl;
+
     /**
      * @see GalleryUrlGenerator::init
      */

--- a/modules/rewrite/test/phpunit/AdminRewriteControllerTest.class
+++ b/modules/rewrite/test/phpunit/AdminRewriteControllerTest.class
@@ -961,6 +961,9 @@ class AdminRewriteMockModule extends GalleryModule {
  * @subpackage PHPUnit
  */
 class AdminRewriteMockPlatform extends GalleryPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_list;
+
 	public function file_exists($file) {
 		if (strpos($file, 'modules/adminrewritemock/module.inc') !== false) {
 			return true;

--- a/modules/rewrite/test/phpunit/IsapiRewriteHelperTest.class
+++ b/modules/rewrite/test/phpunit/IsapiRewriteHelperTest.class
@@ -31,6 +31,9 @@ GalleryCoreApi::requireOnce(
 	'modules/rewrite/classes/parsers/isapirewrite/IsapiRewriteHelper.class'
 );
 class IsapiRewriteHelperTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_fileContent;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -218,6 +221,10 @@ class IsapiRewriteHelperMockPlatform extends GalleryPlatform {
 	public $_isReadable      = true;
 	public $_fileExists      = true;
 	public $_previousContent = array();
+
+	/* deprecated dynamic properties in php 8.2 */
+	public $_readBuffer;
+	public $_test;
 
 	public function init(&$test) {
 		$this->_test =& $test;

--- a/modules/rewrite/test/phpunit/IsapiRewriteParserTest.class
+++ b/modules/rewrite/test/phpunit/IsapiRewriteParserTest.class
@@ -32,6 +32,11 @@ GalleryCoreApi::requireOnce('modules/rewrite/test/phpunit/RewriteParserTestCase.
  * @version $Revision: 17580 $
  */
 class IsapiRewriteParserTest extends RewriteParserTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_fileContent;
+	public $_parser;
+	public $_testPassString;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, null);
 	}

--- a/modules/rewrite/test/phpunit/IsapiRewriteUrlGeneratorTest.class
+++ b/modules/rewrite/test/phpunit/IsapiRewriteUrlGeneratorTest.class
@@ -32,6 +32,16 @@ GalleryCoreApi::requireOnce('modules/rewrite/test/phpunit/RewriteUrlGeneratorTes
  * @version $Revision: 17580 $
  */
 class IsapiRewriteUrlGeneratorTest extends RewriteUrlGeneratorTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_testAlbum;
+	public $_testItem;
+	public $_testAlbumPath;
+	public $_testItemPath;
+	public $_urlEncodePath;
+	public $_origEmbed;
+	public $_urlGeneratorName;
+	public $_urlGenerator;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, null);
 	}

--- a/modules/rewrite/test/phpunit/ModRewriteHelperTest.class
+++ b/modules/rewrite/test/phpunit/ModRewriteHelperTest.class
@@ -31,6 +31,10 @@ GalleryCoreApi::requireOnce(
 	'modules/rewrite/classes/parsers/modrewrite/ModRewriteHelper.class'
 );
 class ModRewriteHelperTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_fileContent;
+	public $_embeddedFileContent;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -368,6 +372,10 @@ class ModRewriteHelperMockPlatform extends GalleryPlatform {
 	public $_fileExistsEmbed         = true;
 	public $_embeddedPreviousContent = array();
 	public $_previousContent         = array();
+
+	/* deprecated dynamic properties in php 8.2 */
+	public $_readBuffer;
+	public $_test;
 
 	public function init(&$test) {
 		$this->_test =& $test;

--- a/modules/rewrite/test/phpunit/ModRewriteParserTest.class
+++ b/modules/rewrite/test/phpunit/ModRewriteParserTest.class
@@ -30,6 +30,12 @@ GalleryCoreApi::requireOnce('modules/rewrite/classes/RewriteHelper.class');
 GalleryCoreApi::requireOnce('modules/rewrite/classes/parsers/modrewrite/parser.inc');
 GalleryCoreApi::requireOnce('modules/rewrite/test/phpunit/RewriteParserTestCase.class');
 class ModRewriteParserTest extends RewriteParserTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_fileContent;
+	public $_embeddedFileContent;
+	public $_parser;
+	public $_testPassString;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, null);
 	}

--- a/modules/rewrite/test/phpunit/ModRewriteUrlGeneratorTest.class
+++ b/modules/rewrite/test/phpunit/ModRewriteUrlGeneratorTest.class
@@ -32,6 +32,17 @@ GalleryCoreApi::requireOnce('modules/rewrite/test/phpunit/RewriteUrlGeneratorTes
  * @version $Revision: 17580 $
  */
 class ModRewriteUrlGeneratorTest extends RewriteUrlGeneratorTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_expectedUrl;
+	public $_testAlbum;
+	public $_testItem;
+	public $_testAlbumPath;
+	public $_testItemPath;
+	public $_urlEncodePath;
+	public $_origEmbed;
+	public $_urlGeneratorName;
+	public $_urlGenerator;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, null);
 	}

--- a/modules/rewrite/test/phpunit/PathInfoParserTest.class
+++ b/modules/rewrite/test/phpunit/PathInfoParserTest.class
@@ -30,6 +30,10 @@ GalleryCoreApi::requireOnce('modules/rewrite/classes/RewriteHelper.class');
 GalleryCoreApi::requireOnce('modules/rewrite/classes/parsers/pathinfo/parser.inc');
 GalleryCoreApi::requireOnce('modules/rewrite/test/phpunit/RewriteParserTestCase.class');
 class PathInfoParserTest extends RewriteParserTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_parser;
+	public $_testPassString;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, null);
 	}

--- a/modules/rewrite/test/phpunit/PathInfoUrlGeneratorTest.class
+++ b/modules/rewrite/test/phpunit/PathInfoUrlGeneratorTest.class
@@ -29,6 +29,17 @@ GalleryCoreApi::requireOnce('modules/rewrite/test/phpunit/RewriteUrlGeneratorTes
  * @version $Revision: 17580 $
  */
 class PathInfoUrlGeneratorTest extends RewriteUrlGeneratorTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_expectedUrl;
+	public $_testAlbum;
+	public $_testItem;
+	public $_testAlbumPath;
+	public $_testItemPath;
+	public $_urlEncodePath;
+	public $_origEmbed;
+	public $_urlGeneratorName;
+	public $_urlGenerator;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, null);
 	}

--- a/modules/rewrite/test/phpunit/RewriteApiTest.class
+++ b/modules/rewrite/test/phpunit/RewriteApiTest.class
@@ -29,6 +29,9 @@ GalleryCoreApi::requireOnce('modules/rewrite/classes/RewriteHelper.class');
  * @version $Revision: 17580 $
  */
 class RewriteApiTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_rewriteApi;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/rewrite/test/phpunit/RewriteHelperTest.class
+++ b/modules/rewrite/test/phpunit/RewriteHelperTest.class
@@ -28,6 +28,9 @@ GalleryCoreApi::requireOnce('modules/rewrite/classes/RewriteHelper.class');
  * @version $Revision: 20886 $
  */
 class RewriteHelperTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_defaultOptions;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -1120,6 +1123,9 @@ class RewriteHelperMockModule extends GalleryModule {
 }
 
 class RewriteHelperMockPlatform extends GalleryPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_list;
+
 	public function file_exists($file) {
 		if (strpos($file, 'modules/rewritehelpermock/module.inc') !== false) {
 			return true;

--- a/modules/rewrite/test/phpunit/RewriteModuleTest.class
+++ b/modules/rewrite/test/phpunit/RewriteModuleTest.class
@@ -492,6 +492,9 @@ class RewriteModuleMockParser extends RewriteParser {
  * Test platform for this test
  */
 class RewriteModuleMockPlatform extends GalleryPlatform {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_list;
+
 	public function file_exists($file) {
 		if (strpos($file, 'modules/rewritemodulemock/module.inc') !== false) {
 			return true;

--- a/modules/rewrite/test/phpunit/RewriteParserTestCase.class
+++ b/modules/rewrite/test/phpunit/RewriteParserTestCase.class
@@ -529,6 +529,10 @@ class RewriteParserMockPlatform extends GalleryPlatform {
 	public $_embeddedPreviousContent = array();
 	public $_previousContent         = array();
 
+	/* deprecated dynamic properties in php 8.2 */
+	public $_test;
+	public $_list;
+
 	public function init(&$test) {
 		$this->_test =& $test;
 	}

--- a/modules/sitemap/test/phpunit/SitemapViewTest.class
+++ b/modules/sitemap/test/phpunit/SitemapViewTest.class
@@ -29,6 +29,10 @@ GalleryCoreApi::requireOnce('modules/sitemap/Sitemap.inc');
  * @version $Revision: 20940 $
  */
 class SitemapViewTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_start_of_2005;
+	public $_start_of_2006;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}
@@ -184,6 +188,9 @@ class SitemapViewTestUrlGenerator {
 GalleryCoreApi::requireOnce('modules/core/classes/GalleryPhpVm.class');
 
 class SitemapViewTestVm extends GalleryPhpVm {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_time;
+
 	public function header($string, $replace = NULL) {
 		echo "Header: $string\n";
 	}
@@ -198,6 +205,9 @@ class SitemapViewTestVm extends GalleryPhpVm {
 }
 
 class SitemapViewTestStorage {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_storage;
+
 	public function __construct($storage) {
 		$this->_storage = $storage;
 	}

--- a/modules/slideshow/AdminSlideshow.inc
+++ b/modules/slideshow/AdminSlideshow.inc
@@ -29,6 +29,9 @@ GalleryCoreApi::requireOnce('modules/slideshow/classes/PicLensHelper.class');
  */
 class AdminSlideshowController extends GalleryController {
 
+    /* deprecated dynamic properties in php 8.2 */
+    var $_picLensHelper;
+
     /**
      * Provide an instance of PicLensHelper for the controller to use instead of
      * the default.  This allows tests to inject this dependency.

--- a/modules/slideshow/DownloadPicLens.inc
+++ b/modules/slideshow/DownloadPicLens.inc
@@ -60,12 +60,12 @@ class DownloadPicLensView extends GalleryView {
 	$codeDir = $gallery->getConfig('data.gallery.plugins_data') . 'modules/slideshow/';
 	switch ($file) {
 	case 'js':
-	    return $this->_sendFile(array('path' => "${codeDir}piclens.js",
+	    return $this->_sendFile(array('path' => "{$codeDir}piclens.js",
 					  'mimeType' => 'application/x-javascript',
 					  'pseudoFileName' => 'piclens.js'));
 
 	case 'swf':
-	    return $this->_sendFile(array('path' => "${codeDir}PicLensLite.swf",
+	    return $this->_sendFile(array('path' => "{$codeDir}PicLensLite.swf",
 					  'mimeType' => 'application/x-shockwave-flash',
 					  'pseudoFileName' => 'PicLensLite.swf'));
 

--- a/modules/slideshow/classes/PicLensHelper.class
+++ b/modules/slideshow/classes/PicLensHelper.class
@@ -48,8 +48,8 @@ class PicLensHelper {
 	}
 
 	$codeDir = $gallery->getConfig('data.gallery.plugins_data') . 'modules/slideshow/';
-	$jsPath = "${codeDir}piclens.js";
-	$swfPath = "${codeDir}PicLensLite.swf";
+	$jsPath = "{$codeDir}piclens.js";
+	$swfPath = "{$codeDir}PicLensLite.swf";
 	list($success1) = GalleryCoreApi::fetchWebFile($info['jsUrl'], "$jsPath.new");
 	list($success2) = GalleryCoreApi::fetchWebFile($info['swfUrl'], "$swfPath.new");
 	if ($success1 && $success2) {

--- a/modules/thumbnail/test/phpunit/CustomThumbnailOptionTest.class
+++ b/modules/thumbnail/test/phpunit/CustomThumbnailOptionTest.class
@@ -30,6 +30,9 @@ GalleryCoreApi::requireOnce('modules/core/classes/GalleryToolkit.class');
  * @version $Revision: 17580 $
  */
 class CustomThumbnailOptionTest extends ItemEditOptionTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_image;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'thumbnail', 'CustomThumbnailOption');
 	}

--- a/modules/thumbnail/test/phpunit/ThumbnailImageTest.class
+++ b/modules/thumbnail/test/phpunit/ThumbnailImageTest.class
@@ -29,6 +29,10 @@ GalleryCoreApi::requireOnce('modules/thumbnail/classes/ThumbnailHelper.class');
  * @version $Revision: 17580 $
  */
 class ThumbnailImageTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_customThumbnail;
+	public $_mimeTypeThumbnail;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/thumbnail/test/phpunit/ThumbnailToolkitTest.class
+++ b/modules/thumbnail/test/phpunit/ThumbnailToolkitTest.class
@@ -28,6 +28,9 @@ GalleryCoreApi::requireOnce('modules/thumbnail/classes/ThumbnailHelper.class');
  * @version $Revision: 17580 $
  */
 class ThumbnailToolkitTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_itemId;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/thumbpage/test/phpunit/ThumbOffsetItemEditPluginTest.class
+++ b/modules/thumbpage/test/phpunit/ThumbOffsetItemEditPluginTest.class
@@ -26,6 +26,9 @@
  * @version $Revision: 17580 $
  */
 class ThumbOffsetItemEditPluginTest extends ItemEditPluginTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_thumbnail;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'thumbpage', 'ItemEditThumbOffset');
 	}

--- a/modules/thumbpage/test/phpunit/ThumbPageItemEditPluginTest.class
+++ b/modules/thumbpage/test/phpunit/ThumbPageItemEditPluginTest.class
@@ -26,6 +26,9 @@
  * @version $Revision: 17580 $
  */
 class ThumbPageItemEditPluginTest extends ItemEditPluginTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_thumbnail;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'thumbpage', 'ItemEditThumbPage');
 	}

--- a/modules/useralbum/test/phpunit/UserAlbumControllerTest.class
+++ b/modules/useralbum/test/phpunit/UserAlbumControllerTest.class
@@ -27,6 +27,11 @@
  * @version $Revision: 17631 $
  */
 class UserAlbumControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_userWithAlbum;
+	public $_userAlbumId;
+	public $_userWithoutAlbum;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'useralbum.UserAlbum');
 	}

--- a/modules/useralbum/test/phpunit/UserAlbumTest.class
+++ b/modules/useralbum/test/phpunit/UserAlbumTest.class
@@ -27,6 +27,9 @@
  * @version $Revision: 18064 $
  */
 class UserAlbumTest extends GalleryTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_allUserGroupId;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName);
 	}

--- a/modules/watermark/test/phpunit/ItemEditWatermarkPluginTest.class
+++ b/modules/watermark/test/phpunit/ItemEditWatermarkPluginTest.class
@@ -28,6 +28,16 @@ GalleryCoreApi::requireOnce('modules/watermark/classes/WatermarkImage.class');
  * @version $Revision: 17580 $
  */
 class ItemEditWatermarkPluginTest extends ItemEditPluginTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_watermark;
+	public $_subalbum;
+	public $_preferreds;
+	public $_resizes;
+	public $_thumbnails;
+	public $_resize;
+	public $_thumbnail;
+	public $_templateAdapter;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'watermark', 'ItemEditWatermark');
 	}

--- a/modules/watermark/test/phpunit/UserWatermarkEditControllerTest.class
+++ b/modules/watermark/test/phpunit/UserWatermarkEditControllerTest.class
@@ -28,6 +28,9 @@ GalleryCoreApi::requireOnce('modules/watermark/classes/WatermarkImage.class');
  * @version $Revision: 17580 $
  */
 class UserWatermarkEditControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_idToDelete;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'watermark.UserWatermarkEdit');
 	}

--- a/modules/watermark/test/phpunit/UserWatermarksControllerTest.class
+++ b/modules/watermark/test/phpunit/UserWatermarksControllerTest.class
@@ -30,6 +30,9 @@ GalleryCoreApi::requireOnce('modules/watermark/classes/WatermarkImage.class');
  * @version $Revision: 17580 $
  */
 class UserWatermarksControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_idToDelete;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'watermark.UserWatermarks');
 	}

--- a/modules/watermark/test/phpunit/WatermarkOptionTest.class
+++ b/modules/watermark/test/phpunit/WatermarkOptionTest.class
@@ -30,6 +30,12 @@ GalleryCoreApi::requireOnce('modules/watermark/classes/WatermarkImage.class');
  * @version $Revision: 17580 $
  */
 class WatermarkOptionTest extends ItemAddOptionTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_images;
+	public $_thumbnails;
+	public $_resizes;
+	public $_itemThumbnails;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'watermark', 'WatermarkOption');
 	}

--- a/modules/watermark/test/phpunit/WatermarkSiteAdminControllerTest.class
+++ b/modules/watermark/test/phpunit/WatermarkSiteAdminControllerTest.class
@@ -30,6 +30,12 @@ GalleryCoreApi::requireOnce('modules/watermark/classes/WatermarkHelper.class');
  * @version $Revision: 20886 $
  */
 class WatermarkSiteAdminControllerTest extends GalleryControllerTestCase {
+	/* deprecated dynamic properties in php 8.2 */
+	public $_randomName;
+	public $_expectedName;
+	public $_beforeWatermarks;
+	public $_afterWatermarks;
+
 	public function __construct($methodName) {
 		parent::__construct($methodName, 'watermark.WatermarkSiteAdmin');
 	}


### PR DESCRIPTION
This patch fixes all found PHP deprecation warnings in PHP 8.2 when running the Gallery2 unit tests. It also include fixes to a few other bugs that I stumbled across while fixing the deprecation warnings.