### PR TITLE
Adapt to changed behaviour in PostgreSQL type cast

### DIFF
--- a/modules/core/classes/GalleryStorage/PostgreSqlStorage.class
+++ b/modules/core/classes/GalleryStorage/PostgreSqlStorage.class
@@ -138,7 +138,11 @@ class PostgreSqlStorage extends GalleryStorage {
      * @see GalleryStorage::convertBitsToInt
      */
     function convertBitsToInt($bitsVal) {
-	return bindec($bitsVal);
+        if (is_null($bitsVal)) {
+            return 0;
+        } else {
+	    return bindec($bitsVal);
+        }
     }
 
     /**
@@ -203,11 +207,10 @@ class PostgreSqlStorage extends GalleryStorage {
 	     * 2 - number of rows
 	     */
 	    $markers = GalleryUtilities::makeMarkers(sizeof($args[1]));
-	    $rowList = rtrim(str_repeat('SELECT ' . $markers . ' UNION ALL ', $args[2]),
-			     'UNION ALL ');
+	    $rowList = rtrim(str_repeat('(' . $markers . '), ', $args[2]), ', ');
 	    $sql = 'INSERT INTO ' . $args[0] . ' (';
 	    $sql .= join(', ', $args[1]);
-	    $sql .= ') ' . $rowList;
+	    $sql .= ') VALUES ' . $rowList;
 	    break;
 
 	case 'AVG':
@@ -228,7 +231,7 @@ class PostgreSqlStorage extends GalleryStorage {
      */
     function getVersion() {
 	if (function_exists('pg_version')) {
-	    return implode(' ', pg_version());
+	    return implode(' ', pg_version($this->_db->_connectionID));
 	}
 	return null;
     }

--- a/modules/rewrite/classes/parsers/isapirewrite/IsapiRewriteUrlGenerator.class
+++ b/modules/rewrite/classes/parsers/isapirewrite/IsapiRewriteUrlGenerator.class
@@ -29,8 +29,6 @@ GalleryCoreApi::requireOnce('modules/rewrite/classes/RewriteUrlGenerator.class')
  * @version $Revision: 17580 $
  */
 class IsapiRewriteUrlGenerator extends RewriteUrlGenerator {
-    /* deprecated dynamic properties in php 8.2 */
-    var $_rootItemId;
 
     /**
      * @see GalleryUrlGenerator::init


### PR DESCRIPTION
This patch fixes a change in how PostgreSQL handles implicit type casts. The patch also backs out the unnecessary change in the previous pull request.