### PR TITLE
Add MariaDB to README.html

### DIFF
--- a/README.html
+++ b/README.html
@@ -289,7 +289,8 @@
       </li>
       <li>
 	One of the following databases: <a href="http://mysql.com/" target="_blank">MySQL</a>
-	3.x, 4.x or 5.x, <a href="http://www.postgresql.org/" target="_blank">PostgreSQL</a>
+	3.x, 4.x or 5.x, <a href="https://mariadb.org/" target="_blank">MariaDB</a> 10.6+,
+	<a href="http://www.postgresql.org/" target="_blank">PostgreSQL</a>
 	7.x or 8.x, <a href="http://www.oracle.com/" target="_blank">Oracle</a> 9i or 10g,
 	<a href="http://www.ibm.com/software/data/db2/" target="_blank">IBM DB2</a> 9.x,
 	<a href="http://www.microsoft.com/sql/" target="_blank">Microsoft SQL Server</a> 2005


### PR DESCRIPTION
MariaDB is also supported and used by docker-compose, but isn't mentioned in the README.html.

I tested it on my Gentoo Linux with MariaDB 10.6.14.