### PR TITLE
Commit ebe9a8d breaks unittest UserRecoverPasswordControllerTest.class

### DIFF
--- a/modules/core/test/phpunit/UserRecoverPasswordControllerTest.class
+++ b/modules/core/test/phpunit/UserRecoverPasswordControllerTest.class
@@ -191,7 +191,7 @@ class UserRecoverPasswordControllerTest extends GalleryControllerTestCase {
 			'GalleryRecoverPasswordMap',
 			array(
 				'userName'       => $this->_user->getUserName(),
-				'authString'     => md5('12345'),
+				'authString'     => bin2hex('12345'),
 				'requestExpires' => time() + (7 * 24 * 60 * 60) + (15 * 60),
 			)
 		);
@@ -234,7 +234,7 @@ class UserRecoverPasswordControllerTest extends GalleryControllerTestCase {
 			return $ret;
 		}
 
-		$this->assertEquals(md5('12345'), $newAuthString, 'Auth String Incorrect');
+		$this->assertEquals(bin2hex('12345'), $newAuthString, 'Auth String Incorrect');
 
 		// Verify we did not send an email
 		$session =& $gallery->getSession();
@@ -254,7 +254,7 @@ class UserRecoverPasswordControllerTest extends GalleryControllerTestCase {
 			'GalleryRecoverPasswordMap',
 			array(
 				'userName'       => $this->_user->getUserName(),
-				'authString'     => md5('12345'),
+				'authString'     => bin2hex('12345'),
 				'requestExpires' => time() - (22 * 60),
 			)
 		);
@@ -843,7 +843,7 @@ class RecoverPasswordControllerPhpVm {
 		$this->_md5 = $string;
 	}
 
-	public function md5($string) {
+	public function bin2hex($string) {
 		return $this->_md5;
 	}
 


### PR DESCRIPTION
The change in modules/core/UserRecoverPassword.inc breaks the unittest 'UserRecoverPasswordControllerTest.testRecoverPassword'.

Failure Details

    UserRecoverPasswordControllerTest.testRecoverPassword
        Recover Password md5 mismatch 
        Mismatch At: at char 0 (0x0 != 0x97)] abcdefghijklmnopqrstuvwxyz123456 !== 20c10c653fd439d0a452d442d92e6690
        EXPECTED: abcdefghijklmnopqrstuvwxyz123456
        ACTUAL: 20c10c653fd439d0a452d442d92e6690