### PR TITLE
Revert "Commit ebe9a8d breaks unittest UserRecoverPasswordControllerTest.class"

### DIFF
--- a/modules/core/test/phpunit/UserRecoverPasswordControllerTest.class
+++ b/modules/core/test/phpunit/UserRecoverPasswordControllerTest.class
@@ -191,7 +191,7 @@ class UserRecoverPasswordControllerTest extends GalleryControllerTestCase {
 			'GalleryRecoverPasswordMap',
 			array(
 				'userName'       => $this->_user->getUserName(),
-				'authString'     => bin2hex('12345'),
+				'authString'     => md5('12345'),
 				'requestExpires' => time() + (7 * 24 * 60 * 60) + (15 * 60),
 			)
 		);
@@ -234,7 +234,7 @@ class UserRecoverPasswordControllerTest extends GalleryControllerTestCase {
 			return $ret;
 		}
 
-		$this->assertEquals(bin2hex('12345'), $newAuthString, 'Auth String Incorrect');
+		$this->assertEquals(md5('12345'), $newAuthString, 'Auth String Incorrect');
 
 		// Verify we did not send an email
 		$session =& $gallery->getSession();
@@ -254,7 +254,7 @@ class UserRecoverPasswordControllerTest extends GalleryControllerTestCase {
 			'GalleryRecoverPasswordMap',
 			array(
 				'userName'       => $this->_user->getUserName(),
-				'authString'     => bin2hex('12345'),
+				'authString'     => md5('12345'),
 				'requestExpires' => time() - (22 * 60),
 			)
 		);
@@ -843,7 +843,7 @@ class RecoverPasswordControllerPhpVm {
 		$this->_md5 = $string;
 	}
 
-	public function bin2hex($string) {
+	public function md5($string) {
 		return $this->_md5;
 	}
 


### PR DESCRIPTION
This patch actually makes it worse since it breaks the unittest completely instead of just causing an error.

The problem is that before commit ebe9a8d the authdata strings used in the unittest for comparison wasn't hashed. After the commit one of the strings is hashed and the comparison fails.