### PR TITLE
Properly fix the unittest breakage caused by commit ebe9a8d

### DIFF
--- a/modules/core/UserRecoverPassword.inc
+++ b/modules/core/UserRecoverPassword.inc
@@ -238,7 +238,7 @@ class UserRecoverPasswordController extends GalleryController {
 	GalleryCoreApi::requireOnce('lib/joomla/crypt.php');
         $j = new JCrypt();
 
-        return bin2hex($j->genRandomBytes(32));
+        return $phpVm->bin2hex($j->genRandomBytes(32));
     }
 }
 

--- a/modules/core/classes/GalleryPhpVm.class
+++ b/modules/core/classes/GalleryPhpVm.class
@@ -96,6 +96,16 @@ class GalleryPhpVm {
     }
 
     /**
+     * Return the hex value from bin2hex() of the given string
+     *
+     * @param string $string string to be converted to hex
+     * @return string converted hex string value
+     */
+    function bin2hex($string) {
+	return bin2hex($string);
+    }
+
+    /**
      * Calculates the crc32 polynomial of a string
      *
      * @param string $string the value to be checksummed

--- a/modules/core/test/phpunit/UserRecoverPasswordControllerTest.class
+++ b/modules/core/test/phpunit/UserRecoverPasswordControllerTest.class
@@ -107,7 +107,7 @@ class UserRecoverPasswordControllerTest extends GalleryControllerTestCase {
 			'GalleryRecoverPasswordMap',
 			array(
 				'userName'       => $userName,
-				'authString'     => $controllerPhpVm->md5($this->_authData),
+				'authString'     => $controllerPhpVm->bin2hex($this->_authData),
 				'requestExpires' => time() + (3 * 24 * 60 * 60) + (15 * 60),
 			)
 		);
@@ -191,7 +191,7 @@ class UserRecoverPasswordControllerTest extends GalleryControllerTestCase {
 			'GalleryRecoverPasswordMap',
 			array(
 				'userName'       => $this->_user->getUserName(),
-				'authString'     => bin2hex('12345'),
+				'authString'     => md5('12345'),
 				'requestExpires' => time() + (7 * 24 * 60 * 60) + (15 * 60),
 			)
 		);
@@ -234,7 +234,7 @@ class UserRecoverPasswordControllerTest extends GalleryControllerTestCase {
 			return $ret;
 		}
 
-		$this->assertEquals(bin2hex('12345'), $newAuthString, 'Auth String Incorrect');
+		$this->assertEquals(md5('12345'), $newAuthString, 'Auth String Incorrect');
 
 		// Verify we did not send an email
 		$session =& $gallery->getSession();
@@ -254,7 +254,7 @@ class UserRecoverPasswordControllerTest extends GalleryControllerTestCase {
 			'GalleryRecoverPasswordMap',
 			array(
 				'userName'       => $this->_user->getUserName(),
-				'authString'     => bin2hex('12345'),
+				'authString'     => md5('12345'),
 				'requestExpires' => time() - (22 * 60),
 			)
 		);
@@ -841,6 +841,10 @@ class RecoverPasswordControllerPhpVm {
 
 	public function setMd5($string) {
 		$this->_md5 = $string;
+	}
+
+	public function md5($string) {
+		return $this->_md5;
 	}
 
 	public function bin2hex($string) {


### PR DESCRIPTION
This patch reverts the previous broken patch and adds a proper fix to the unittest breakage caused by commit ebe9a8d
